### PR TITLE
[SELC-3157] feat: SaveToken step for onboarding async

### DIFF
--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -21,6 +21,11 @@ locals {
     resource_group_name = "${local.prefix}-${var.env_short}-functions-rg",
     insights_key = "${local.prefix}-${var.env_short}-appinsights"
   }
+
+  mongo_db = {
+    mongodb_rg_name = "${local.prefix}-${var.env_short}-cosmosdb-mongodb-rg",
+    cosmosdb_account_mongodb_name = "${local.prefix}-${var.env_short}-cosmosdb-mongodb-account"
+  }
 }
 
 variable "env" {
@@ -73,4 +78,10 @@ variable "environment_roles" {
     subscription = list(string)
   })
   description = "GitHub Continous Integration roles"
+}
+
+variable "cosmosdb_mongodb_throughput" {
+  type        = number
+  description = "The throughput of the MongoDB database (RU/s). Must be set in increments of 100. The minimum value is 400. This must be set upon database creation otherwise it cannot be updated without a manual terraform destroy-apply."
+  default     = 1000
 }

--- a/.identity/mongodb.tf
+++ b/.identity/mongodb.tf
@@ -1,0 +1,52 @@
+# Onboarding
+
+resource "azurerm_cosmosdb_mongo_database" "selc_onboarding" {
+  name                = "selcOnboarding"
+  resource_group_name = local.mongo_db.mongodb_rg_name
+  account_name        = local.mongo_db.cosmosdb_account_mongodb_name
+
+  throughput = var.cosmosdb_mongodb_throughput
+}
+
+resource "azurerm_management_lock" "mongodb_selc_onboarding" {
+  name       = "mongodb-selc-onboarding-lock"
+  scope      = azurerm_cosmosdb_mongo_database.selc_onboarding.id
+  lock_level = "CanNotDelete"
+  notes      = "This items can't be deleted in this subscription!"
+}
+
+module "mongdb_collection_onboardings" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_mongodb_collection?ref=v7.3.0"
+
+  name                = "onboardings"
+  resource_group_name = local.mongo_db.mongodb_rg_name
+
+  cosmosdb_mongo_account_name  = local.mongo_db.cosmosdb_account_mongodb_name
+  cosmosdb_mongo_database_name = azurerm_cosmosdb_mongo_database.selc_onboarding.name
+
+  indexes = [{
+    keys   = ["_id"]
+    unique = true
+    }
+  ]
+
+  lock_enable = true
+}
+
+module "mongdb_collection_tokens" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//cosmosdb_mongodb_collection?ref=v7.3.0"
+
+  name                = "tokens"
+  resource_group_name = local.mongo_db.mongodb_rg_name
+
+  cosmosdb_mongo_account_name  = local.mongo_db.cosmosdb_account_mongodb_name
+  cosmosdb_mongo_database_name = azurerm_cosmosdb_mongo_database.selc_onboarding.name
+
+  indexes = [{
+    keys   = ["_id"]
+    unique = true
+    }
+  ]
+
+  lock_enable = true
+}

--- a/onboarding-functions/README.md
+++ b/onboarding-functions/README.md
@@ -7,32 +7,37 @@ These functions handle all asynchronous activities related to preparing and comp
 
 It is triggered by http request at GET or POST `/api/StartOnboardingOrchestration?onboardingId={onboardingId}` where onboardingId is a reference to onboarding which you want to process.
 
-## Configuration Properties
+## Running locally
+### Configuration Properties
 
 Before running you must set these properties as environment variables.
 
 
-| **Property**                                       | **Environment Variable**     | **Default** | **Required** |
-|----------------------------------------------------|------------------------------|-------------|:------------:|
-| quarkus.mongodb.connection-string<br/>             | MONGODB_CONNECTION_URI       |             |     yes      |
-| quarkus.azure-functions.app-name<br/>              | AZURE_APP_NAME               |             |      no      |
-| quarkus.azure-functions.subscription-id<br/>       | AZURE_SUBSCRIPTION_ID        |             |      no      |
-| quarkus.azure-functions.resource-group<br/>        | AZURE_RESOURCE_GROUP         |             |      no      |
-| quarkus.azure-functions.app-insights-key<br/>      | AZURE_APP_INSIGHTS_KEY       |             |      no      |
-| quarkus.azure-functions.app-service-plan-name<br/> | AZURE_APP_SERVICE_PLAN_NAME  |             |      no      |
+| **Property**                                                           | **Environment Variable**   | **Default** | **Required** |
+|------------------------------------------------------------------------|----------------------------|-------------|:------------:|
+| quarkus.mongodb.connection-string<br/>                                 | MONGODB_CONNECTION_URI     |             |     yes      |
+| quarkus.openapi-generator.user_registry_json.auth.api_key.api-key<br/> | USER_REGISTRY_API_KEY      |             |     yes      |
+| quarkus.rest-client."*.user_registry_json.api.UserApi".url<br/>        | USER_REGISTRY_URL          |             |     yes      |
 
-## Packaging
+### Storage emulator: Azurite
+
+Use the Azurite emulator for local Azure Storage development. Once installed, you must create `selc-d-contracts-blob` and `selc-product` container.
+
+([guide](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio))
+
+### Packaging
 
 The application can be packaged using:
 ```shell script
 ./mvnw package
 ```
+
 It produces the `onboarding-functions-1.0.0-SNAPSHOT.jar` file in the `target/` directory.
 
-## Start application
+### Start application
 
 ```shell script
-./mvnw quarkus:run
+./mvnw package quarkus:run
 ```
 
 If you want enable debugging you must add -DenableDebug
@@ -41,6 +46,22 @@ If you want enable debugging you must add -DenableDebug
 ./mvnw quarkus:run -DenableDebug
 ```
 You can follow this guide for debugging application in IntelliJ https://www.jetbrains.com/help/idea/tutorial-remote-debug.html
+
+## Deploy
+
+### Configuration Properties
+
+Before deploy you must set these properties as environment variables.
+
+
+| **Property**                                       | **Environment Variable**     | **Default** | **Required** |
+|----------------------------------------------------|------------------------------|-------------|:------------:|
+| quarkus.azure-functions.app-name<br/>              | AZURE_APP_NAME               |             |      no      |
+| quarkus.azure-functions.subscription-id<br/>       | AZURE_SUBSCRIPTION_ID        |             |      no      |
+| quarkus.azure-functions.resource-group<br/>        | AZURE_RESOURCE_GROUP         |             |      no      |
+| quarkus.azure-functions.app-insights-key<br/>      | AZURE_APP_INSIGHTS_KEY       |             |      no      |
+| quarkus.azure-functions.app-service-plan-name<br/> | AZURE_APP_SERVICE_PLAN_NAME  |             |      no      |
+
 
 ## Related Guides
 

--- a/onboarding-functions/pom.xml
+++ b/onboarding-functions/pom.xml
@@ -138,16 +138,22 @@
       <version>1.0.10</version>
     </dependency>
     <dependency>
+      <groupId>org.digidoc4j.dss</groupId>
+      <artifactId>dss-document</artifactId>
+      <version>5.11.1.d4j.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.openapi.generator</groupId>
       <artifactId>quarkus-openapi-generator</artifactId>
       <version>2.2.10</version>
     </dependency>
+
+    <!-- test -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5-mockito</artifactId>
@@ -163,8 +169,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>

--- a/onboarding-functions/pom.xml
+++ b/onboarding-functions/pom.xml
@@ -91,8 +91,8 @@
       <artifactId>quarkus-rest-client-jackson</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-multipart-provider</artifactId>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.openhtmltopdf/openhtmltopdf-core -->

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/OnboardingFunctions.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/OnboardingFunctions.java
@@ -19,6 +19,7 @@ import com.microsoft.durabletask.azurefunctions.DurableClientContext;
 import com.microsoft.durabletask.azurefunctions.DurableClientInput;
 import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
 import it.pagopa.selfcare.entity.Onboarding;
+import it.pagopa.selfcare.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.service.OnboardingService;
 import jakarta.inject.Inject;
 
@@ -78,7 +79,8 @@ public class OnboardingFunctions {
     }
 
     private String getOnboardingString(String onboardingId) {
-        Onboarding onboarding = service.getOnboarding(onboardingId);
+        Onboarding onboarding = service.getOnboarding(onboardingId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format("Onboarding with id %s not found!", onboardingId)));
 
         String onboardingString = null;
         try {

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/OnboardingFunctions.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/OnboardingFunctions.java
@@ -132,6 +132,11 @@ public class OnboardingFunctions {
     @FunctionName("SaveToken")
     public String SaveToken(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
         context.getLogger().info("SaveToken: " + onboardingString);
+        try {
+            service.saveToken(objectMapper.readValue(onboardingString, Onboarding.class));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
         return onboardingString;
     }
 

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
@@ -2,16 +2,18 @@ package it.pagopa.selfcare.entity;
 
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 
 @MongoEntity(collection="onboardings")
 public class Onboarding {
 
-    public ObjectId id;
+    private ObjectId id;
 
     private String productId;
     private Institution institution;
@@ -19,6 +21,11 @@ public class Onboarding {
     private String pricingPlan;
     private Billing billing;
     private Boolean signContract;
+
+
+    private OffsetDateTime expiringDate;
+
+    private OnboardingStatus status;
 
     public ObjectId getId() {
         return id;
@@ -74,5 +81,21 @@ public class Onboarding {
 
     public void setSignContract(Boolean signContract) {
         this.signContract = signContract;
+    }
+
+    public OffsetDateTime getExpiringDate() {
+        return expiringDate;
+    }
+
+    public void setExpiringDate(OffsetDateTime expiringDate) {
+        this.expiringDate = expiringDate;
+    }
+
+    public OnboardingStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OnboardingStatus status) {
+        this.status = status;
     }
 }

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
@@ -3,6 +3,8 @@ package it.pagopa.selfcare.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.codecs.pojo.annotations.BsonIgnore;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
@@ -11,9 +13,11 @@ import java.util.List;
 
 
 @MongoEntity(collection="onboardings")
-public class Onboarding {
+public class Onboarding  {
 
     private ObjectId id;
+
+    private String onboardingId;
 
     private String productId;
     private Institution institution;
@@ -23,7 +27,7 @@ public class Onboarding {
     private Boolean signContract;
 
 
-    private OffsetDateTime expiringDate;
+    private LocalDateTime expiringDate;
 
     private OnboardingStatus status;
 
@@ -83,11 +87,11 @@ public class Onboarding {
         this.signContract = signContract;
     }
 
-    public OffsetDateTime getExpiringDate() {
+    public LocalDateTime getExpiringDate() {
         return expiringDate;
     }
 
-    public void setExpiringDate(OffsetDateTime expiringDate) {
+    public void setExpiringDate(LocalDateTime expiringDate) {
         this.expiringDate = expiringDate;
     }
 
@@ -97,5 +101,13 @@ public class Onboarding {
 
     public void setStatus(OnboardingStatus status) {
         this.status = status;
+    }
+
+    public String getOnboardingId() {
+        return onboardingId;
+    }
+
+    public void setOnboardingId(String onboardingId) {
+        this.onboardingId = onboardingId;
     }
 }

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Token.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Token.java
@@ -1,0 +1,115 @@
+package it.pagopa.selfcare.entity;
+
+import io.quarkus.mongodb.panache.common.MongoEntity;
+import it.pagopa.selfcare.onboarding.common.TokenType;
+import org.bson.types.ObjectId;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+
+@MongoEntity(collection="tokens")
+public class Token {
+
+    private ObjectId id;
+    private TokenType type;
+    private String productId;
+    private String checksum;
+    private String contractVersion;
+    private String contractTemplate;
+    private String contractSigned;
+    //@Indexed
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+    private OffsetDateTime deletedAt;
+    private OffsetDateTime activatedAt;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public TokenType getType() {
+        return type;
+    }
+
+    public void setType(TokenType type) {
+        this.type = type;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getChecksum() {
+        return checksum;
+    }
+
+    public void setChecksum(String checksum) {
+        this.checksum = checksum;
+    }
+
+    public String getContractVersion() {
+        return contractVersion;
+    }
+
+    public void setContractVersion(String contractVersion) {
+        this.contractVersion = contractVersion;
+    }
+
+    public String getContractTemplate() {
+        return contractTemplate;
+    }
+
+    public void setContractTemplate(String contractTemplate) {
+        this.contractTemplate = contractTemplate;
+    }
+
+    public String getContractSigned() {
+        return contractSigned;
+    }
+
+    public void setContractSigned(String contractSigned) {
+        this.contractSigned = contractSigned;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public OffsetDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(OffsetDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public OffsetDateTime getActivatedAt() {
+        return activatedAt;
+    }
+
+    public void setActivatedAt(OffsetDateTime activatedAt) {
+        this.activatedAt = activatedAt;
+    }
+}
+

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Token.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/entity/Token.java
@@ -4,6 +4,7 @@ import io.quarkus.mongodb.panache.common.MongoEntity;
 import it.pagopa.selfcare.onboarding.common.TokenType;
 import org.bson.types.ObjectId;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -19,10 +20,10 @@ public class Token {
     private String contractTemplate;
     private String contractSigned;
     //@Indexed
-    private OffsetDateTime createdAt;
-    private OffsetDateTime updatedAt;
-    private OffsetDateTime deletedAt;
-    private OffsetDateTime activatedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+    private LocalDateTime activatedAt;
 
     public ObjectId getId() {
         return id;
@@ -80,35 +81,35 @@ public class Token {
         this.contractSigned = contractSigned;
     }
 
-    public OffsetDateTime getCreatedAt() {
+    public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(OffsetDateTime createdAt) {
+    public void setCreatedAt(LocalDateTime createdAt) {
         this.createdAt = createdAt;
     }
 
-    public OffsetDateTime getUpdatedAt() {
+    public LocalDateTime getUpdatedAt() {
         return updatedAt;
     }
 
-    public void setUpdatedAt(OffsetDateTime updatedAt) {
+    public void setUpdatedAt(LocalDateTime updatedAt) {
         this.updatedAt = updatedAt;
     }
 
-    public OffsetDateTime getDeletedAt() {
+    public LocalDateTime getDeletedAt() {
         return deletedAt;
     }
 
-    public void setDeletedAt(OffsetDateTime deletedAt) {
+    public void setDeletedAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }
 
-    public OffsetDateTime getActivatedAt() {
+    public LocalDateTime getActivatedAt() {
         return activatedAt;
     }
 
-    public void setActivatedAt(OffsetDateTime activatedAt) {
+    public void setActivatedAt(LocalDateTime activatedAt) {
         this.activatedAt = activatedAt;
     }
 }

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/exception/ResourceNotFoundException.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/exception/ResourceNotFoundException.java
@@ -8,6 +8,10 @@ public class ResourceNotFoundException extends RuntimeException {
         super(message);
         this.code = code;
     }
+    public ResourceNotFoundException(String message) {
+        super(message);
+        this.code = "0000";
+    }
 
     public String getCode() {
         return code;

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/repository/OnboardingRepository.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/repository/OnboardingRepository.java
@@ -1,21 +1,8 @@
 package it.pagopa.selfcare.repository;
 
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.BsonField;
-import com.mongodb.client.model.Filters;
 import io.quarkus.mongodb.panache.PanacheMongoRepository;
-import io.quarkus.mongodb.reactive.ReactiveMongoClient;
-import io.quarkus.mongodb.reactive.ReactiveMongoCollection;
-import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.entity.Onboarding;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import java.time.LocalDateTime;
-import java.util.Objects;
-import java.util.Optional;
 
 @ApplicationScoped
 public class OnboardingRepository implements PanacheMongoRepository<Onboarding> {

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/repository/TokenRepository.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/repository/TokenRepository.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.repository;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import it.pagopa.selfcare.entity.Token;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TokenRepository implements PanacheMongoRepository<Token> {
+}

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractService.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractService.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface ContractService {
     File createContractPDF(String contractTemplatePath, Onboarding onboarding, UserResource validManager, List<UserResource> users, List<String> geographicTaxonomies);
+
+    File retrieveContractNotSigned(String onboardingId);
 }

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractServiceDefault.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractServiceDefault.java
@@ -79,8 +79,8 @@ public class ContractServiceDefault implements ContractService {
             getPDFAsFile(files, contractTemplateText, data);
 
             //return signContract(institution, request, files.toFile());
-            final String filename = String.format("%s.pdf", onboarding.getId());
-            final String path = String.format("%s7%s", azureStorageConfig.contractPath(), onboarding.getId().toHexString());
+            final String filename = String.format("%s.pdf", onboarding.getOnboardingId());
+            final String path = String.format("%s%s", azureStorageConfig.contractPath(), onboarding.getOnboardingId());
             azureBlobClient.uploadFile(path, filename, Files.readAllBytes(files));
 
             return files.toFile();
@@ -126,7 +126,7 @@ public class ContractServiceDefault implements ContractService {
     @Override
     public File retrieveContractNotSigned(String onboardingId) {
         final String filename = String.format("%s.pdf", onboardingId);
-        final String path = String.format("%s/%s/%s", azureStorageConfig.contractPath(), onboardingId, filename);
+        final String path = String.format("%s%s/%s", azureStorageConfig.contractPath(), onboardingId, filename);
         return azureBlobClient.getFileAsPdf(path);
     }
 

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractServiceDefault.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/service/ContractServiceDefault.java
@@ -122,4 +122,12 @@ public class ContractServiceDefault implements ContractService {
 
         log.debug("PDF stream properly retrieved");
     }
+
+    @Override
+    public File retrieveContractNotSigned(String onboardingId) {
+        final String filename = String.format("%s.pdf", onboardingId);
+        final String path = String.format("%s/%s/%s", azureStorageConfig.contractPath(), onboardingId, filename);
+        return azureBlobClient.getFileAsPdf(path);
+    }
+
 }

--- a/onboarding-functions/src/main/java/it/pagopa/selfcare/service/OnboardingService.java
+++ b/onboarding-functions/src/main/java/it/pagopa/selfcare/service/OnboardingService.java
@@ -1,12 +1,18 @@
 package it.pagopa.selfcare.service;
 
+import eu.europa.esig.dss.enumerations.DigestAlgorithm;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.entity.Onboarding;
+import it.pagopa.selfcare.entity.Token;
 import it.pagopa.selfcare.entity.User;
 import it.pagopa.selfcare.exception.GenericOnboardingException;
+import it.pagopa.selfcare.onboarding.common.TokenType;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.repository.OnboardingRepository;
+import it.pagopa.selfcare.repository.TokenRepository;
 import it.pagopa.selfcare.utils.GenericError;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -17,6 +23,9 @@ import org.openapi.quarkus.user_registry_json.model.UserResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +48,10 @@ public class OnboardingService {
 
     @Inject
     OnboardingRepository repository;
+
+    @Inject
+    TokenRepository tokenRepository;
+
     public Onboarding getOnboarding(String onboardingId) {
         return repository.findById(new ObjectId(onboardingId));
     }
@@ -61,6 +74,29 @@ public class OnboardingService {
         //File pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContract().getPath());
 
     }
+
+    public void saveToken(Onboarding onboarding) {
+        /* create digest */
+        File contract = contractService.retrieveContractNotSigned(onboarding.getId().toHexString());
+        DSSDocument document = new FileDocument(contract);
+        String digest = document.getDigest(DigestAlgorithm.SHA256);
+
+        log.debug("createToken for onboarding {}", onboarding.getId().toHexString());
+
+        /* persist token entity */
+        Product product = productService.getProductIsValid(onboarding.getProductId());
+        Token token = new Token();
+        token.setContractTemplate(product.getContractTemplatePath());
+        token.setContractVersion(product.getContractTemplateVersion());
+        token.setCreatedAt(OffsetDateTime.now());
+        token.setUpdatedAt(OffsetDateTime.now());
+        token.setProductId(onboarding.getProductId());
+        token.setChecksum(digest);
+        token.setType(TokenType.INSTITUTION);
+
+        tokenRepository.persist(token);
+    }
+
 
     public String getValidManagerId(List<User> users) {
         log.debug("START - getOnboardingValidManager for users list size: {}", users.size());

--- a/onboarding-functions/src/main/resources/application.properties
+++ b/onboarding-functions/src/main/resources/application.properties
@@ -5,6 +5,11 @@ quarkus.azure-functions.region=${AZURE_APP_REGION:westeurope}
 quarkus.azure-functions.app-insights-key=${AZURE_APP_INSIGHTS_KEY}
 quarkus.azure-functions.app-service-plan-name=${AZURE_APP_SERVICE_PLAN_NAME}
 
+quarkus.azure-functions.app-settings.MONGODB_CONNECTION_URI=${MONGODB_CONNECTION_URI}
+quarkus.azure-functions.app-settings.USER_REGISTRY_API_KEY=${USER_REGISTRY_API_KEY}
+quarkus.azure-functions.app-settings.USER_REGISTRY_URL=${USER_REGISTRY_URL}
+quarkus.azure-functions.app-settings.BLOB_STORAGE_CONN_STRING_PRODUCT=${BLOB_STORAGE_CONN_STRING_PRODUCT}
+
 quarkus.mongodb.connection-string = ${MONGODB_CONNECTION_URI}
 quarkus.mongodb.database = selcOnboarding
 
@@ -22,7 +27,7 @@ quarkus.rest-client."org.openapi.quarkus.user_registry_json.api.UserApi".url=${U
 ## AZURE STORAGE ##
 
 onboarding-functions.blob-storage.container-contract=${STORAGE_CONTAINER_CONTRACT:selc-d-contracts-blob}
-onboarding-functions.blob-storage.container-product=${STORAGE_CONTAINER_PRODUCT:selc-product}
+onboarding-functions.blob-storage.container-product=${STORAGE_CONTAINER_PRODUCT:product}
 onboarding-functions.blob-storage.contract-path = parties/docs/
 onboarding-functions.blob-storage.product-filepath = products.json
 onboarding-functions.blob-storage.connection-string-contract = ${BLOB_STORAGE_CONN_STRING_CONTRACT:UseDevelopmentStorage=true;}

--- a/onboarding-functions/src/test/java/it/pagopa/selfcare/service/ContractServiceDefaultTest.java
+++ b/onboarding-functions/src/test/java/it/pagopa/selfcare/service/ContractServiceDefaultTest.java
@@ -42,6 +42,7 @@ public class ContractServiceDefaultTest {
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
         onboarding.setId(ObjectId.get());
+        onboarding.setOnboardingId("example");
         onboarding.setProductId("productId");
         onboarding.setUsers(List.of());
 
@@ -107,12 +108,12 @@ public class ContractServiceDefaultTest {
         File pdf = mock(File.class);
         Mockito.when(azureBlobClient.getFileAsPdf(any())).thenReturn(pdf);
 
-        contractService.retrieveContractNotSigned(onboarding.getId().toHexString());
+        contractService.retrieveContractNotSigned(onboarding.getOnboardingId());
 
         ArgumentCaptor<String> filepathActual = ArgumentCaptor.forClass(String.class);
         Mockito.verify(azureBlobClient, times(1))
                 .getFileAsPdf(filepathActual.capture());
-        assertTrue(filepathActual.getValue().contains(onboarding.getId().toHexString()));
+        assertTrue(filepathActual.getValue().contains(onboarding.getOnboardingId()));
     }
 
 }

--- a/onboarding-functions/src/test/java/it/pagopa/selfcare/service/ContractServiceDefaultTest.java
+++ b/onboarding-functions/src/test/java/it/pagopa/selfcare/service/ContractServiceDefaultTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.service;
 
 import io.quarkus.mailer.Mailer;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.Mock;
 import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
@@ -10,17 +11,23 @@ import it.pagopa.selfcare.entity.Onboarding;
 import jakarta.inject.Inject;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 @QuarkusTest
 public class ContractServiceDefaultTest {
@@ -90,6 +97,22 @@ public class ContractServiceDefaultTest {
         Mockito.when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn(contractHtml);
 
         assertNotNull(contractService.createContractPDF(contractFilepath, onboarding, manager, List.of(), List.of()));
+    }
+
+    @Test
+    void retrieveContractNotSigned() {
+
+        Onboarding onboarding = createOnboarding();
+
+        File pdf = mock(File.class);
+        Mockito.when(azureBlobClient.getFileAsPdf(any())).thenReturn(pdf);
+
+        contractService.retrieveContractNotSigned(onboarding.getId().toHexString());
+
+        ArgumentCaptor<String> filepathActual = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(azureBlobClient, times(1))
+                .getFileAsPdf(filepathActual.capture());
+        assertTrue(filepathActual.getValue().contains(onboarding.getId().toHexString()));
     }
 
 }

--- a/onboarding-functions/src/test/java/it/pagopa/selfcare/service/OnboardingServiceTest.java
+++ b/onboarding-functions/src/test/java/it/pagopa/selfcare/service/OnboardingServiceTest.java
@@ -27,11 +27,11 @@ import org.openapi.quarkus.user_registry_json.model.UserResource;
 import java.io.File;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import static it.pagopa.selfcare.service.OnboardingService.USERS_FIELD_LIST;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 
 @QuarkusTest
@@ -57,6 +57,7 @@ public class OnboardingServiceTest {
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
         onboarding.setId(ObjectId.get());
+        onboarding.setOnboardingId(onboarding.getId().toHexString());
         onboarding.setProductId("productId");
         onboarding.setUsers(List.of());
         return onboarding;
@@ -65,10 +66,11 @@ public class OnboardingServiceTest {
     @Test
     void getOnboarding() {
         Onboarding onboarding = createOnboarding();
-        Mockito.when(onboardingRepository.findById(onboarding.getId())).thenReturn(onboarding);
+        Mockito.when(onboardingRepository.findByIdOptional(any())).thenReturn(Optional.of(onboarding));
 
-        Onboarding actual = onboardingService.getOnboarding(onboarding.getId().toHexString());
-        assertEquals(onboarding.getId().toHexString(), actual.getId().toHexString());
+        Optional<Onboarding> actual = onboardingService.getOnboarding(onboarding.getOnboardingId());
+        assertTrue(actual.isPresent());
+        assertEquals(onboarding.getOnboardingId(), actual.get().getOnboardingId());
     }
 
     @Test
@@ -131,7 +133,7 @@ public class OnboardingServiceTest {
         DSSDocument document = new FileDocument(contract);
         String digestExpected = document.getDigest(DigestAlgorithm.SHA256);
 
-        Mockito.when(contractService.retrieveContractNotSigned(onboarding.getId().toHexString()))
+        Mockito.when(contractService.retrieveContractNotSigned(onboarding.getOnboardingId()))
                         .thenReturn(contract);
         Product productExpected = createDummyProduct();
         Mockito.when(productService.getProductIsValid(onboarding.getProductId()))

--- a/onboarding-ms/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
+++ b/onboarding-ms/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
@@ -2,10 +2,12 @@ package it.pagopa.selfcare.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntityBase;
 import it.pagopa.selfcare.controller.request.ContractRequest;
 import it.pagopa.selfcare.controller.request.OnboardingImportContract;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
@@ -30,5 +32,5 @@ public class Onboarding extends ReactivePanacheMongoEntity  {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private OffsetDateTime expiringDate;
+    private LocalDateTime expiringDate;
 }

--- a/onboarding-ms/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
+++ b/onboarding-ms/src/main/java/it/pagopa/selfcare/entity/Onboarding.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
@@ -29,4 +30,5 @@ public class Onboarding extends ReactivePanacheMongoEntity  {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+    private OffsetDateTime expiringDate;
 }

--- a/onboarding-ms/src/main/java/it/pagopa/selfcare/service/OnboardingServiceDefault.java
+++ b/onboarding-ms/src/main/java/it/pagopa/selfcare/service/OnboardingServiceDefault.java
@@ -95,7 +95,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     public Uni<OnboardingResponse> fillUsersAndOnboarding(Onboarding onboarding, List<UserRequest> userRequests) {
-        onboarding.setExpiringDate( OffsetDateTime.now().plus(onboardingExpireDate, ChronoUnit.DAYS));
+        onboarding.setExpiringDate( OffsetDateTime.now().plus(onboardingExpireDate, ChronoUnit.DAYS).toLocalDateTime());
         return checkRoleAndRetrieveUsers(userRequests, List.of(PartyRole.MANAGER, PartyRole.DELEGATE))
                 .onItem().invoke(onboarding::setUsers).replaceWith(onboarding)
                 .onItem().transformToUni(this::checkProductAndReturnOnboarding)

--- a/onboarding-ms/src/main/resources/application.properties
+++ b/onboarding-ms/src/main/resources/application.properties
@@ -17,6 +17,7 @@ quarkus.mongodb.connection-string = ${MONGODB_CONNECTION_URI}
 quarkus.mongodb.database = selcOnboarding
 
 onboarding.institutions-allowed-list=${ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS}
+onboarding.expiring-date = ${ONBOARDING_EXPIRING_DATE:60}
 
 #quarkus.native.resources.includes=publicKey.pem
 

--- a/onboarding-sdk/onboarding-sdk-common/src/main/java/it/pagopa/selfcare/onboarding/common/OnboardingStatus.java
+++ b/onboarding-sdk/onboarding-sdk-common/src/main/java/it/pagopa/selfcare/onboarding/common/OnboardingStatus.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.onboarding.common;
+public enum OnboardingStatus {
+    ACTIVE,
+    PENDING,
+    TOBEVALIDATED,
+    SUSPENDED,
+    DELETED,
+    REJECTED
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Moved definition database and collection 'onboarding' from selfcare-infra to identity folder. In addition, added definition of new collection token.
* Implemented step "SaveToken" for onboarding async workflow
* Added expiring-date on onboarding, it indicates when an onboarding will expire before consumed
* Update README

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Onboarding async workflow include as second step saving token that contain information about the contract that will be sended to institution. It retrieves contract from storage, calculate digest and saving information in a collection 'tokens' on mongodb. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.