### PR TITLE
fix: check validateProductRole if roles is exactly one

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -1,16 +1,5 @@
 name: Code Review
 
-on:
-  workflow_call:
-    inputs:
-      module:
-        required: true
-        type: choice
-        description: Select the module
-        options:
-          - onboarding-ms
-          - onboarding-functions
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
 

--- a/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -169,7 +169,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                     throw new IllegalArgumentException(String.format(ATLEAST_ONE_PRODUCT_ROLE_REQUIRED, userInfo.getRole()));
                 if(Objects.isNull((roleMappings.get(userInfo.getRole().name()).getRoles())))
                     throw new IllegalArgumentException(String.format(ATLEAST_ONE_PRODUCT_ROLE_REQUIRED, userInfo.getRole()));
-                if(roleMappings.get(userInfo.getRole().name()).getRoles().size() == 1)
+                if(roleMappings.get(userInfo.getRole().name()).getRoles().size() != 1)
                     throw new IllegalArgumentException(String.format(MORE_THAN_ONE_PRODUCT_ROLE_AVAILABLE, userInfo.getRole()));
                 userInfo.setProductRole(roleMappings.get(userInfo.getRole().name()).getRoles().get(0).getCode());
             });
@@ -187,7 +187,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                     throw new IllegalArgumentException(String.format(ATLEAST_ONE_PRODUCT_ROLE_REQUIRED, userInfo.getRole()));
                 if(Objects.isNull((roleMappings.get(userInfo.getRole().name()).getRoles())))
                     throw new IllegalArgumentException(String.format(ATLEAST_ONE_PRODUCT_ROLE_REQUIRED, userInfo.getRole()));
-                if(roleMappings.get(userInfo.getRole().name()).getRoles().size() == 1)
+                if(roleMappings.get(userInfo.getRole().name()).getRoles().size() != 1)
                     throw new IllegalArgumentException(String.format(MORE_THAN_ONE_PRODUCT_ROLE_AVAILABLE, userInfo.getRole()));
                 userInfo.setProductRole(roleMappings.get(userInfo.getRole().name()).getRoles().get(0).getCode());
             });

--- a/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/OnboardingControllerIT.java
+++ b/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/OnboardingControllerIT.java
@@ -1,9 +1,0 @@
-package it.pagopa.selfcare.onboarding;
-
-import io.quarkus.test.junit.QuarkusIntegrationTest;
-import it.pagopa.selfcare.onboarding.controller.OnboardingControllerTest;
-
-@QuarkusIntegrationTest
-public class OnboardingControllerIT extends OnboardingControllerTest {
-    // Execute the same tests but in packaged mode.
-}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Fix validateProductRole on check if roles is exactly one.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Replacing selfcare-commons with onboarding-sdk-common has introduced a bug in validateProductRole when an onboarding are submitted.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.