### PR TITLE
ops: using cache and 3.9.5 version about maven on workflow

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -20,14 +20,14 @@ jobs:
     name: Add label to PR based on the paths of files being changed
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # pin@v4
 
   check_pr_size:
     name: Check PR size doesn't break set limit
     runs-on: ubuntu-latest
     steps:
       # checkout your code with your git history
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/code_review_functions.yml
+++ b/.github/workflows/code_review_functions.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.11.0
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # pin@v1.11.0
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/code_review_functions.yml
+++ b/.github/workflows/code_review_functions.yml
@@ -22,18 +22,14 @@ jobs:
       packages: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1.11.0
         with:
-          sparse-checkout: |
-            apps/onboarding-functions
-            libs/
-            test-coverage/
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
+          checkout-fetch-depth: 0
           java-version: 17
-          distribution: 'temurin'
+          java-distribution: 'temurin'
+          maven-version: '3.9.5'
+          cache-enabled: true
 
       - name: Build and analyze on Pull Requests
         shell: bash
@@ -43,7 +39,7 @@ jobs:
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
           -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
-          -Dsonar.pullrequest.base=${{ github.base_ref }}
+          -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/code_review_libs.yml
+++ b/.github/workflows/code_review_libs.yml
@@ -23,7 +23,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.11.0
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # pin@v1.11.0
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/code_review_libs.yml
+++ b/.github/workflows/code_review_libs.yml
@@ -22,13 +22,13 @@ jobs:
       packages: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1.11.0
         with:
+          checkout-fetch-depth: 0
           java-version: 17
-          distribution: 'temurin'
+          java-distribution: 'temurin'
+          maven-version: '3.9.5'
 
       - name: Build and analyze on Pull Requests
         shell: bash
@@ -38,7 +38,7 @@ jobs:
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
           -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
-          -Dsonar.pullrequest.base=${{ github.base_ref }}
+          -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/code_review_libs.yml
+++ b/.github/workflows/code_review_libs.yml
@@ -26,7 +26,6 @@ jobs:
         uses: s4u/setup-maven-action@v1.11.0
         with:
           checkout-fetch-depth: 0
-          checkout-ref: ${{ github.ref_name }}
           java-version: 17
           java-distribution: 'temurin'
           maven-version: '3.9.5'

--- a/.github/workflows/code_review_libs.yml
+++ b/.github/workflows/code_review_libs.yml
@@ -26,9 +26,11 @@ jobs:
         uses: s4u/setup-maven-action@v1.11.0
         with:
           checkout-fetch-depth: 0
+          checkout-ref: ${{ github.ref_name }}
           java-version: 17
           java-distribution: 'temurin'
           maven-version: '3.9.5'
+          cache-enabled: true
 
       - name: Build and analyze on Pull Requests
         shell: bash

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@1
+        uses: s4u/setup-maven-action@v1
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -24,6 +24,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -39,7 +41,7 @@ jobs:
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
           -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
-          -Dsonar.pullrequest.base=${{ github.base_ref }}
+          -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -27,7 +27,6 @@ jobs:
         uses: s4u/setup-maven-action@v1.11.0
         with:
           checkout-fetch-depth: 0
-          checkout-ref: ${{ github.ref_name }}
           java-version: 17
           java-distribution: 'temurin'
           maven-version: '3.9.5'

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -37,7 +37,7 @@ jobs:
           -Dsonar.organization=pagopa
           -Dsonar.projectKey=pagopa_selfcare-onboarding
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.pullrequest.key=50
+          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
           -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -35,7 +35,7 @@ jobs:
           cache: maven
       - name: Run tests
         shell: bash
-        run: mvn compile test
+        run: mvn --projects :onboarding-ms --also-make compile test
 
       - name: Build and analyze on Pull Requests
         shell: bash

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -31,6 +31,7 @@ jobs:
           java-version: 17
           java-distribution: 'temurin'
           maven-version: '3.9.5'
+          cache-enabled: true
 
       - name: Build and analyze on Pull Requests
         shell: bash

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -39,7 +39,7 @@ jobs:
           -Dsonar.organization=pagopa
           -Dsonar.projectKey=pagopa_selfcare-onboarding
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.pullrequest.key=50
+          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
           -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: maven
+      - name: Run tests
+        shell: bash
+        run: mvn compile test
 
       - name: Build and analyze on Pull Requests
         shell: bash

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1
+        uses: s4u/setup-maven-action@v1.11.0
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -12,8 +12,9 @@ on:
       - reopened
     paths:
       - 'apps/onboarding-ms/**'
-  
+
   workflow_dispatch:
+
 
 jobs:
 
@@ -24,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.11.0
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # pin@v1.11.0
         with:
           checkout-fetch-depth: 0
           java-version: 17

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -24,11 +24,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            apps/onboarding-ms
-            libs/
-            test-coverage/
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: refs/remotes/origin/develop
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -27,6 +27,7 @@ jobs:
         uses: s4u/setup-maven-action@v1.11.0
         with:
           checkout-fetch-depth: 0
+          checkout-ref: ${{ github.ref_name }}
           java-version: 17
           java-distribution: 'temurin'
           maven-version: '3.9.5'

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -39,7 +39,7 @@ jobs:
           -Dsonar.organization=pagopa
           -Dsonar.projectKey=pagopa_selfcare-onboarding
           -Dsonar.token=${{ secrets.SONAR_TOKEN }}
-          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+          -Dsonar.pullrequest.key=50
           -Dsonar.pullrequest.branch=${{ github.head_ref }}
           -Dsonar.pullrequest.base=refs/remotes/origin/${{ github.base_ref }}
         env:

--- a/.github/workflows/code_review_ms.yml
+++ b/.github/workflows/code_review_ms.yml
@@ -23,20 +23,13 @@ jobs:
       packages: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@1
         with:
-          fetch-depth: 0
-          ref: refs/remotes/origin/develop
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
+          checkout-fetch-depth: 0
           java-version: 17
-          distribution: 'temurin'
-          cache: maven
-      - name: Run tests
-        shell: bash
-        run: mvn --projects :onboarding-ms --also-make compile test
+          java-distribution: 'temurin'
+          maven-version: '3.9.5'
 
       - name: Build and analyze on Pull Requests
         shell: bash

--- a/.github/workflows/deploy_onboarding_functions.yml
+++ b/.github/workflows/deploy_onboarding_functions.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     name: Build Onboarding Functions
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == 'true') }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true) }}
     environment: "${{ inputs.environment != null && inputs.environment || (github.base_ref == 'main' && 'prod' || (github.base_ref == 'develop' && 'uat' || 'dev')) }}-cd"
     permissions:
       packages: write
@@ -42,16 +42,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout
+      - name: Setup Maven Action
+        uses: s4u/setup-maven-action@v1.11.0
         with:
-          ref: ${{ github.ref_name }}
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
+          checkout-fetch-depth: 0
+          checkout-ref: ${{ github.ref_name }}
           java-version: 17
-          distribution: 'temurin'
+          java-distribution: 'temurin'
+          maven-version: '3.9.5'
+          cache-enabled: true
 
       - name: "Build Functions and dependencies"
         shell: bash

--- a/.github/workflows/deploy_onboarding_functions.yml
+++ b/.github/workflows/deploy_onboarding_functions.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.11.0
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # pin@v1.11.0
         with:
           checkout-fetch-depth: 0
           checkout-ref: ${{ github.ref_name }}

--- a/.github/workflows/release_onboarding_sdk.yml
+++ b/.github/workflows/release_onboarding_sdk.yml
@@ -3,6 +3,7 @@ name: Release onboarding sdk
 on:
   workflow_dispatch:
 
+
 jobs:
   setup:
     name: Release
@@ -10,18 +11,18 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           ref: ${{ github.ref_name }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # pin@v3
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: maven
 
-      - uses: s4u/maven-settings-action@v2.8.0
+      - uses: s4u/maven-settings-action@60912582505985be4cc55d2b890eb32767f8de5f # pin@v2.8.0
         with:
           servers: '[{"id": "selfcare-github", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.mongodb.MongoTestResource;
 import io.quarkus.test.vertx.RunOnVertxContext;
 import io.quarkus.test.vertx.UniAsserter;
 import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.controller.request.*;
@@ -59,6 +60,9 @@ public class OnboardingServiceDefaultTest {
 
     @InjectMock
     ProductService productService;
+
+    @InjectMock
+    AzureBlobClient azureBlobClient;
 
     @InjectMock
     SignatureService signatureService;
@@ -598,6 +602,8 @@ public class OnboardingServiceDefaultTest {
 
         mockSimpleProductValidAssert(onboarding.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
+
+        when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn("upload-file");
 
         asserter.assertThat(() -> onboardingService.complete(onboarding.getId().toHexString(), testFile),
                 Assertions::assertNotNull);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

1. Implemented the use of the **s4u/setup-maven-action** action in the GitHub workflows.
2. Set the Maven version to **3.9.5**.
3. Enabled Maven cache to reduce the execution time of the workflows significantly.
4. Fix onboarding-ms unit test

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The entire repository is set up to perform builds using Maven with version **3.9.x.** In the current GitHub workflows, using the setup-java action alone results in the use of an older version of Maven. This change is required to ensure that the workflows use the correct Maven version (**3.9.x**), aligning with the repository's setup. Additionally, the use of Maven cache is crucial for significantly reducing the execution time of the workflows by caching the Java libraries.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.