### PR TITLE
[SELC-2862] fix: onboarding confirmation and reject by onboardingId

### DIFF
--- a/.functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/.functions/onboarding-functions/env/dev/terraform.tfvars
@@ -50,5 +50,17 @@ app_settings = {
   "MAIL_SERVER_USERNAME" = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/smtp-not-pec-usr/)",
   "MAIL_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/smtp-not-pec-psw/)",
   "MAIL_TEMPLATE_REGISTRATION_NOTIFICATION_ADMIN_PATH" = "contracts/template/mail/registration-notification-admin/1.0.0.json",
-  "MAIL_TEMPLATE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-notification/1.0.0.json"
+  "MAIL_TEMPLATE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-notification/1.0.0.json",
+  "ADDRESS_EMAIL_NOTIFICATION_ADMIN" = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/portal-admin-operator-email/)",
+  "MAIL_TEMPLATE_COMPLETE_PATH" = "contracts/template/mail/onboarding-complete/1.0.0.json",
+  "MAIL_TEMPLATE_FD_COMPLETE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-complete-fd/1.0.0.json",
+  "MAIL_TEMPLATE_AUTOCOMPLETE_PATH"                    = "contracts/template/mail/import-massivo-io/1.0.0.json",
+  "MAIL_TEMPLATE_DELEGATION_NOTIFICATION_PATH"         = "contracts/template/mail/delegation-notification/1.0.0.json",
+  "MAIL_TEMPLATE_REGISTRATION_PATH" = "contracts/template/mail/1.0.0.json",
+  "MAIL_TEMPLATE_REJECT_PATH"                          = "contracts/template/mail/onboarding-refused/1.0.0.json",
+  "SELFCARE_ADMIN_NOTIFICATION_URL" : "https://dev.selfcare.pagopa.it/dashboard/admin/onboarding/",
+  "SELFCARE_URL"            = "https://selfcare.pagopa.it",
+  "MAIL_ONBOARDING_CONFIRMATION_LINK"    = "https://dev.selfcare.pagopa.it/onboarding/confirm?jwt=",
+  "MAIL_ONBOARDING_REJECTION_LINK"      = "https://dev.selfcare.pagopa.it/onboarding/cancel?jwt=",
+  "MAIL_ONBOARDING_URL" : "https://dev.selfcare.pagopa.it/onboarding/"
 }

--- a/.functions/onboarding-functions/env/uat/terraform.tfvars
+++ b/.functions/onboarding-functions/env/uat/terraform.tfvars
@@ -50,5 +50,17 @@ app_settings = {
   "MAIL_SERVER_USERNAME" = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/smtp-usr/)",
   "MAIL_SERVER_PASSWORD" = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/smtp-psw/)",
   "MAIL_TEMPLATE_REGISTRATION_NOTIFICATION_ADMIN_PATH" = "contracts/template/mail/registration-notification-admin/1.0.0.json",
-  "MAIL_TEMPLATE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-notification/1.0.0.json"
+  "MAIL_TEMPLATE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-notification/1.0.0.json",
+  "ADDRESS_EMAIL_NOTIFICATION_ADMIN" = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/portal-admin-operator-email/)",
+  "MAIL_TEMPLATE_COMPLETE_PATH" = "contracts/template/mail/onboarding-complete/1.0.0.json",
+  "MAIL_TEMPLATE_FD_COMPLETE_NOTIFICATION_PATH" = "contracts/template/mail/onboarding-complete-fd/1.0.0.json",
+  "MAIL_TEMPLATE_AUTOCOMPLETE_PATH"                    = "contracts/template/mail/import-massivo-io/1.0.0.json",
+  "MAIL_TEMPLATE_DELEGATION_NOTIFICATION_PATH"         = "contracts/template/mail/delegation-notification/1.0.0.json",
+  "MAIL_TEMPLATE_REGISTRATION_PATH" = "contracts/template/mail/1.0.0.json",
+  "MAIL_TEMPLATE_REJECT_PATH"                          = "contracts/template/mail/onboarding-refused/1.0.0.json",
+  "SELFCARE_ADMIN_NOTIFICATION_URL" : "https://uat.selfcare.pagopa.it/dashboard/admin/onboarding/",
+  "SELFCARE_URL"            = "https://selfcare.pagopa.it",
+  "MAIL_ONBOARDING_CONFIRMATION_LINK"    = "https://uat.selfcare.pagopa.it/onboarding/confirm?jwt=",
+  "MAIL_ONBOARDING_REJECTION_LINK"      = "https://uat.selfcare.pagopa.it/onboarding/cancel?jwt=",
+  "MAIL_ONBOARDING_URL" : "https://uat.selfcare.pagopa.it/onboarding/"
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationService.java
@@ -9,5 +9,5 @@ public interface NotificationService {
 
     void sendMailOnboardingApprove(String institutionName, String name, String username, String productName, String onboardingId);
 
-    void sendMailRegistrationWithContract(String onboardingId, String destination, String name, String username, String productName, String token);
+    void sendMailRegistrationWithContract(String onboardingId, String destination, String name, String username, String productName);
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -39,7 +39,6 @@ public class OnboardingService {
 
     public static final String USERS_FIELD_LIST = "fiscalCode,familyName,name";
     public static final String USERS_WORKS_FIELD_LIST = "fiscalCode,familyName,name,workContacts";
-    public static final String TOKEN_DOES_NOT_EXISTS_FOR_ONBOARDING_S = "Token does not exists for onboarding %s";
     public static final String USER_REQUEST_DOES_NOT_FOUND = "User request does not found for onboarding %s";
 
     @RestClient
@@ -134,13 +133,12 @@ public class OnboardingService {
 
     public void sendMailRegistrationWithContract(Onboarding onboarding) {
 
-        SendMailInput sendMailInput = builderWithTokenAndProductAndUserRequest(onboarding);
+        SendMailInput sendMailInput = builderWithProductAndUserRequest(onboarding);
 
         notificationService.sendMailRegistrationWithContract(onboarding.getOnboardingId(),
                 onboarding.getInstitution().getDigitalAddress(),
                 sendMailInput.userRequestName, sendMailInput.userRequestSurname,
-                sendMailInput.product.getTitle(),
-                sendMailInput.token.getId().toHexString());
+                sendMailInput.product.getTitle());
     }
 
     public void sendMailRegistrationApprove(Onboarding onboarding) {
@@ -175,15 +173,6 @@ public class OnboardingService {
                         GenericError.MANAGER_NOT_FOUND_GENERIC_ERROR.getCode()));
     }
 
-    private SendMailInput builderWithTokenAndProductAndUserRequest(Onboarding onboarding) {
-        Token token = tokenRepository.findByOnboardingId(onboarding.getOnboardingId())
-                .orElseThrow(() -> new GenericOnboardingException(String.format(TOKEN_DOES_NOT_EXISTS_FOR_ONBOARDING_S, onboarding.getId())));
-
-        SendMailInput sendMailInput = builderWithProductAndUserRequest(onboarding);
-        sendMailInput.token = token;
-        return sendMailInput;
-    }
-
     private SendMailInput builderWithProductAndUserRequest(Onboarding onboarding) {
         SendMailInput sendMailInput = new SendMailInput();
         sendMailInput.product = productService.getProduct(onboarding.getProductId());
@@ -198,7 +187,6 @@ public class OnboardingService {
 
     static class SendMailInput {
         Product product;
-        Token token;
         String userRequestName;
         String userRequestSurname;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
@@ -32,6 +32,7 @@ public class PdfMapper {
     public static final String INSTITUTION_REGISTER_LABEL_VALUE = "institutionRegisterLabelValue";
 
     public static final Function<String, String> workContactsKey = onboardingId -> String.format("obg_%s", onboardingId);
+    public static final String ORIGIN_ID_LABEL = "<li class=\"c19 c39 li-bullet-0\"><span class=\"c1\">codice di iscrizione all&rsquo;Indice delle Pubbliche Amministrazioni e dei gestori di pubblici servizi (I.P.A.) <span class=\"c3\">${originId}</span> </span><span class=\"c1\"></span></li>";
 
 
     public static Map<String, Object> setUpCommonData(UserResource manager, List<UserResource> users, Onboarding onboarding) {
@@ -50,8 +51,8 @@ public class PdfMapper {
         map.put("address", institution.getAddress());
         map.put("institutionTaxCode", institution.getTaxCode());
         map.put("zipCode", institution.getZipCode());
-        map.put("managerName", manager.getName());
-        map.put("managerSurname", manager.getFamilyName());
+        map.put("managerName", Optional.ofNullable(manager.getName()).map(CertifiableFieldResourceOfstring::getValue).orElse(""));
+        map.put("managerSurname", Optional.ofNullable(manager.getFamilyName()).map(CertifiableFieldResourceOfstring::getValue).orElse(""));
         map.put("originId", Optional.ofNullable(institution.getOrigin()).map(Origin::name).orElse(""));
         map.put("institutionMail", institution.getDigitalAddress());
         map.put("managerTaxCode", manager.getFiscalCode());
@@ -109,11 +110,9 @@ public class PdfMapper {
 
         map.put("institutionTypeCode", institution.getInstitutionType());
         decodePricingPlan(onboarding.getPricingPlan(), onboarding.getProductId(), map);
-        if (Objects.nonNull(institution.getOrigin())) {
-            map.put("originIdLabelValue", Origin.IPA.equals(institution.getOrigin()) ?
-                    "<li class=\"c19 c39 li-bullet-0\"><span class=\"c1\">codice di iscrizione all&rsquo;Indice delle Pubbliche Amministrazioni e dei gestori di pubblici servizi (I.P.A.) <span class=\"c3\">${originId}</span> </span><span class=\"c1\"></span></li>"
-                    : "");
-        }
+
+        map.put("originIdLabelValue", Origin.IPA.equals(institution.getOrigin()) ? ORIGIN_ID_LABEL : "");
+
         addInstitutionRegisterLabelValue(institution, map);
         if (onboarding.getBilling() != null) {
             map.put("institutionRecipientCode",onboarding.getBilling().getRecipientCode());

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -36,7 +36,7 @@ onboarding-functions.mail-template.path.onboarding.complete-path-fd = ${MAIL_TEM
 
 onboarding-functions.mail-template.path.onboarding.autocomplete-path = ${MAIL_TEMPLATE_AUTOCOMPLETE_PATH:default}
 onboarding-functions.mail-template.path.onboarding.delegation-notification-path = ${MAIL_TEMPLATE_DELEGATION_NOTIFICATION_PATH:default}
-onboarding-functions.mail-template.path.onboarding.registration-path = ${MAIL_TEMPLATE_REGISTRATION_PATH:default}
+onboarding-functions.mail-template.path.onboarding.registration-path = ${MAIL_TEMPLATE_REGISTRATION_PATH:contracts/template/mail/1.0.0.json}
 
 onboarding-functions.mail-template.path.onboarding.onboarding-approve-path = ${MAIL_TEMPLATE_NOTIFICATION_PATH:default}
 onboarding-functions.mail-template.path.onboarding.registration-request-path = ${MAIL_TEMPLATE_REGISTRATION_REQUEST_PT_PATH:default}
@@ -49,16 +49,16 @@ onboarding-functions.mail-template.placeholders.onboarding.user-name = requester
 onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
 onboarding-functions.mail-template.placeholders.onboarding.product-name = productName
 onboarding-functions.mail-template.placeholders.onboarding.institution-description = institutionName
-onboarding-functions.mail-template.placeholders.onboarding.admin-link = ${SELFCARE_ADMIN_NOTIFICATION_URL:default}
+onboarding-functions.mail-template.placeholders.onboarding.admin-link = ${SELFCARE_ADMIN_NOTIFICATION_URL:https://dev.selfcare.pagopa.it/dashboard/admin/onboarding/}
 
 onboarding-functions.mail-template.placeholders.onboarding.complete-selfcare-name = selfcareURL
 onboarding-functions.mail-template.placeholders.onboarding.complete-product-name = productName
-onboarding-functions.mail-template.placeholders.onboarding.complete-selfcare-placeholder= ${SELFCARE_URL:default}
+onboarding-functions.mail-template.placeholders.onboarding.complete-selfcare-placeholder= ${SELFCARE_URL:https://selfcare.pagopa.it}
 
 onboarding-functions.mail-template.placeholders.onboarding.confirm-token-name= confirmTokenURL
-onboarding-functions.mail-template.placeholders.onboarding.confirm-token-placeholder = ${MAIL_ONBOARDING_CONFIRMATION_LINK:default}
+onboarding-functions.mail-template.placeholders.onboarding.confirm-token-placeholder = ${MAIL_ONBOARDING_CONFIRMATION_LINK:https://dev.selfcare.pagopa.it/onboarding/confirm?jwt=}
 
-onboarding-functions.mail-template.placeholders.onboarding.reject-token-placeholder = ${MAIL_ONBOARDING_REJECTION_LINK:default}
+onboarding-functions.mail-template.placeholders.onboarding.reject-token-placeholder = ${MAIL_ONBOARDING_REJECTION_LINK:https://dev.selfcare.pagopa.it/onboarding/cancel?jwt=}
 onboarding-functions.mail-template.placeholders.onboarding.reject-token-name = rejectTokenURL
 
 onboarding-functions.mail-template.placeholders.onboarding.notification-product-name = productName

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -67,7 +67,7 @@ onboarding-functions.mail-template.placeholders.onboarding.notification-requeste
 
 onboarding-functions.mail-template.placeholders.onboarding.reject-product-name=productName
 onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-placeholder=onboardingUrl
-onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-value=${MAIL_ONBOARDING_URL:default}
+onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-value=${MAIL_ONBOARDING_URL:https://dev.selfcare.pagopa.it/onboarding/}
 
 ## MAIL SERVER
 quarkus.mailer.host=${MAIL_SERVER_HOST:smtp.gmail.com}

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefaultTest.java
@@ -65,7 +65,7 @@ class NotificationServiceDefaultTest {
                 .thenReturn(mailTemplate);
         Mockito.doNothing().when(mailer).send(any());
 
-        notificationService.sendMailRegistrationWithContract(onboardingId, destination,"","", productName,"");
+        notificationService.sendMailRegistrationWithContract(onboardingId, destination,"","", productName);
 
         Mockito.verify(azureBlobClient, Mockito.times(1))
                 .getFileAsText(any());
@@ -82,7 +82,7 @@ class NotificationServiceDefaultTest {
         final String productName = "productName";
         final File file = mock(File.class);
         Mockito.when(contractService.retrieveContractNotSigned(onboardingId, productName)).thenReturn(file);
-        assertThrows(RuntimeException.class, () -> notificationService.sendMailRegistrationWithContract(onboardingId,  "example@pagopa.it","mario","rossi","prod-example","token"));
+        assertThrows(RuntimeException.class, () -> notificationService.sendMailRegistrationWithContract(onboardingId,  "example@pagopa.it","mario","rossi","prod-example"));
     }
 
     @Test

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
@@ -224,12 +224,12 @@ class OnboardingServiceTest {
         when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, onboarding.getUserRequestUid()))
                 .thenReturn(userResource);
         doNothing().when(notificationService)
-                .sendMailRegistrationWithContract(any(), any(), any(),any(),any(),any());
+                .sendMailRegistrationWithContract(any(), any(), any(),any(),any());
 
         onboardingService.sendMailRegistrationWithContract(onboarding);
 
         Mockito.verify(notificationService, times(1))
-                .sendMailRegistrationWithContract(any(), any(), any(),any(),any(),any());
+                .sendMailRegistrationWithContract(any(), any(), any(),any(),any());
     }
 
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
@@ -212,6 +212,7 @@ class OnboardingServiceTest {
     void sendMailRegistrationWithContract() {
 
         Onboarding onboarding = createOnboarding();
+        Product product = createDummyProduct();
         UserResource userResource = createUserResource();
         Token token = new Token();
         token.setId(ObjectId.get());
@@ -219,17 +220,23 @@ class OnboardingServiceTest {
         when(tokenRepository.findByOnboardingId(onboarding.getOnboardingId()))
                 .thenReturn(Optional.of(token));
         when(productService.getProduct(onboarding.getProductId()))
-                .thenReturn(createDummyProduct());
+                .thenReturn(product);
 
         when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, onboarding.getUserRequestUid()))
                 .thenReturn(userResource);
         doNothing().when(notificationService)
-                .sendMailRegistrationWithContract(any(), any(), any(),any(),any());
+                .sendMailRegistrationWithContract(onboarding.getOnboardingId(),
+                        onboarding.getInstitution().getDigitalAddress(),
+                        userResource.getName().getValue(), userResource.getFamilyName().getValue(),
+                        product.getTitle());
 
         onboardingService.sendMailRegistrationWithContract(onboarding);
 
         Mockito.verify(notificationService, times(1))
-                .sendMailRegistrationWithContract(any(), any(), any(),any(),any());
+                .sendMailRegistrationWithContract(onboarding.getOnboardingId(),
+                        onboarding.getInstitution().getDigitalAddress(),
+                        userResource.getName().getValue(), userResource.getFamilyName().getValue(),
+                        product.getTitle());
     }
 
 
@@ -246,18 +253,25 @@ class OnboardingServiceTest {
     void sendMailRegistration() {
 
         UserResource userResource = createUserResource();
+        Product product = createDummyProduct();
         Onboarding onboarding = createOnboarding();
 
         when(productService.getProduct(onboarding.getProductId()))
-                .thenReturn(createDummyProduct());
+                .thenReturn(product);
         when(userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, onboarding.getUserRequestUid()))
                 .thenReturn(userResource);
-        doNothing().when(notificationService).sendMailRegistration(any(), any(), any(),any(),any());
+        doNothing().when(notificationService).sendMailRegistration(onboarding.getInstitution().getDescription(),
+                        onboarding.getInstitution().getDigitalAddress(),
+                        userResource.getName().getValue(), userResource.getFamilyName().getValue(),
+                        product.getTitle());
 
         onboardingService.sendMailRegistration(onboarding);
 
         Mockito.verify(notificationService, times(1))
-                .sendMailRegistration(any(), any(), any(),any(),any());
+                .sendMailRegistration(onboarding.getInstitution().getDescription(),
+                    onboarding.getInstitution().getDigitalAddress(),
+                    userResource.getName().getValue(), userResource.getFamilyName().getValue(),
+                    product.getTitle());
     }
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Set onboardingId as reference at confirmation and rejection link when sending mail
* Fix user name and surname in contract
* Added dev and uat environment variables

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This modification is crucial for the onboarding process. Previously, the completion email contained a link with a token reference, which was not as direct or specific as needed. By switching to an Onboarding entity reference, the link now directly relates to the specific onboarding request, improving the process's efficiency and user experience. This change ensures that upon successful onboarding requests, the email sent to the entity or admin contains a more relevant and accurate link for completing the onboarding process, directly tied to the Onboarding collection record.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.