### PR TITLE
[SELC-3452] feat: completion async orchestration

### DIFF
--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -21,7 +21,7 @@
     <quarkus.platform.version>3.5.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.1.1</onboarding-sdk.version>
+    <onboarding-sdk.version>0.1.2</onboarding-sdk.version>
   </properties>
 
   <dependencyManagement>

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctions.java
@@ -1,0 +1,76 @@
+package it.pagopa.selfcare.onboarding;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientInput;
+import com.microsoft.durabletask.azurefunctions.DurableOrchestrationTrigger;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.onboarding.service.OnboardingService;
+
+import java.util.Optional;
+
+import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingString;
+
+public class OnboardingCompletionFunctions {
+
+    public static final String CREATED_NEW_ONBOARDING_COMPLETION_ORCHESTRATION_WITH_INSTANCE_ID_MSG = "Created new Onboarding completion orchestration with instance ID = ";
+
+    public static final String ONBOARDING_COMPLETION_ACTIVITY = "OnboardingCompletion";
+    public static final String CREATE_INSTITUTION_ACTIVITY = "CreateInstitution";
+    public static final String CREATE_ONBOARDING_ACTIVITY = "CreateOnboarding";
+    public static final String SEND_MAIL_COMPLETION_ACTIVITY = "SendMailCompletion";
+    private final OnboardingService service;
+
+    private final ObjectMapper objectMapper;
+
+    public OnboardingCompletionFunctions(OnboardingService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * This HTTP-triggered function starts the orchestration.
+     */
+    @FunctionName("StartOnboardingCompletionOrchestration")
+    public HttpResponseMessage startOrchestration(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Optional<String>> request,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            final ExecutionContext context) {
+        context.getLogger().info("StartOnboardingCompletionOrchestration trigger processed a request.");
+
+        final String onboardingId = request.getQueryParameters().get("onboardingId");
+
+        DurableTaskClient client = durableContext.getClient();
+        String instanceId = client.scheduleNewOrchestrationInstance(ONBOARDING_COMPLETION_ACTIVITY, onboardingId);
+        context.getLogger().info(String.format("%s %s", CREATED_NEW_ONBOARDING_COMPLETION_ORCHESTRATION_WITH_INSTANCE_ID_MSG, instanceId));
+
+        return durableContext.createCheckStatusResponse(request, instanceId);
+    }
+
+    /**
+     * This is the orchestrator function, which can schedule activity functions, create durable timers,
+     * or wait for external events in a way that's completely fault-tolerant.
+     */
+    @FunctionName(ONBOARDING_COMPLETION_ACTIVITY)
+    public void onboardingCompletionOrchestrator(
+            @DurableOrchestrationTrigger(name = "taskOrchestrationContext") TaskOrchestrationContext ctx) {
+        String onboardingId = ctx.getInput(String.class);
+        Onboarding onboarding = service.getOnboarding(onboardingId)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format("Onboarding with id %s not found!", onboardingId)));
+        String onboardingString = getOnboardingString(objectMapper, onboarding);
+
+        //ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingString, optionsRetry, String.class).await();
+        //ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingString, optionsRetry, String.class).await();
+        //ctx.callActivity(SEND_MAIL_REGISTRATION_WITH_CONTRACT_ACTIVITY, onboardingString, optionsRetry, String.class).await() ;
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
@@ -1,5 +1,10 @@
 package it.pagopa.selfcare.onboarding.utils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.exception.FunctionOrchestratedException;
+
 import java.util.function.Function;
 
 public class Utils {
@@ -8,4 +13,25 @@ public class Utils {
 
     public static final Function<String, String> CONTRACT_FILENAME_FUNC =
             productName -> String.format(PDF_FORMAT_FILENAME, productName.replaceAll("\\s+","_"));
+
+
+
+    public static Onboarding readOnboardingValue(ObjectMapper objectMapper, String onboardingString) {
+        try {
+            return objectMapper.readValue(onboardingString, Onboarding.class);
+        } catch (JsonProcessingException e) {
+            throw new FunctionOrchestratedException(e);
+        }
+    }
+
+    public static String getOnboardingString(ObjectMapper objectMapper, Onboarding onboarding) {
+
+        String onboardingString;
+        try {
+            onboardingString = objectMapper.writeValueAsString(onboarding);
+        } catch (JsonProcessingException e) {
+            throw new FunctionOrchestratedException(e);
+        }
+        return onboardingString;
+    }
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
@@ -1,0 +1,100 @@
+package it.pagopa.selfcare.onboarding;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.durabletask.DurableTaskClient;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientContext;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.onboarding.service.OnboardingService;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static it.pagopa.selfcare.onboarding.OnboardingCompletionFunctions.ONBOARDING_COMPLETION_ACTIVITY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+public class OnboardingCompletionFunctionsTest {
+
+
+    @Inject
+    OnboardingCompletionFunctions function;
+
+    @InjectMock
+    OnboardingService service;
+
+    final String onboardinString = "{\"onboardingId\":\"onboardingId\"}";
+
+    /**
+     * Unit test for HttpTriggerJava method.
+     */
+    @Test
+    public void testHttpTriggerJava() {
+        // Setup
+        @SuppressWarnings("unchecked")
+        final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        final HttpResponseMessage res = mock(HttpResponseMessage.class);
+
+        final Map<String, String> queryParams = new HashMap<>();
+        final String onboardingId = "onboardingId";
+        queryParams.put("onboardingId", onboardingId);
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        final Optional<String> queryBody = Optional.empty();
+        doReturn(queryBody).when(req).getBody();
+
+        doAnswer(new Answer<HttpResponseMessage.Builder>() {
+            @Override
+            public HttpResponseMessage.Builder answer(InvocationOnMock invocation) {
+                HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+            }
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        final DurableClientContext durableContext = mock(DurableClientContext.class);
+        final DurableTaskClient client = mock(DurableTaskClient.class);
+        final String scheduleNewOrchestrationInstance = "scheduleNewOrchestrationInstance";
+        doReturn(client).when(durableContext).getClient();
+        doReturn(scheduleNewOrchestrationInstance).when(client).scheduleNewOrchestrationInstance(ONBOARDING_COMPLETION_ACTIVITY, onboardingId);
+        doReturn(res).when(durableContext).createCheckStatusResponse(any(), any());
+
+        // Invoke
+        function.startOrchestration(req, durableContext, context);
+
+        // Verify
+        ArgumentCaptor<String> captorInstanceId = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(durableContext, times(1))
+                .createCheckStatusResponse(any(), captorInstanceId.capture());
+        assertEquals(scheduleNewOrchestrationInstance, captorInstanceId.getValue());
+    }
+
+
+
+    @Test
+    void onboardingsOrchestrator_thorwExceptionIfOnboardingNotPresent() {
+        final String onboardingId = "onboardingId";
+        TaskOrchestrationContext orchestrationContext = mock(TaskOrchestrationContext.class);
+        when(orchestrationContext.getInput(String.class)).thenReturn(onboardingId);
+        when(service.getOnboarding(onboardingId)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> function.onboardingCompletionOrchestrator(orchestrationContext));
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

1. **Creation of a Trigger for Starting Asynchronous Onboarding Completion Activities**: Implemented the trigger mechanism designed to initiate the asynchronous processes necessary for completing the onboarding.
2. **Development Azure Functions for Business Logic Execution**: Each function is responsible for carrying out a specific part of the onboarding completion process, in the next PRs will be implemented the business logic related. 

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Completing an onboarding ends with a series of asynchronous operations performed by some azure functions. These activities consist of creating the institution, creating onboarding with its associated users and sending the onboarding confirmation email to the institution

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.