### PR TITLE
[SELC-3483] Feat: retrieve and add parentDescription for AOO and UO onboardings

### DIFF
--- a/.container_apps/onboarding-ms/env/dev/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/dev/terraform.tfvars
@@ -37,6 +37,10 @@ app_settings = [
   {
     name  = "MS_CORE_URL"
     value = "https://selc.internal.dev.selfcare.pagopa.it/ms-core/v1"
+  },
+  {
+    name  = "MS_PARTY_REGISTRY_URL"
+    value = "http://selc.internal.dev.selfcare.pagopa.it/party-registry-proxy/v1"
   }
 ]
 

--- a/.container_apps/onboarding-ms/env/prod/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/prod/terraform.tfvars
@@ -50,6 +50,10 @@ app_settings = [
   {
     name  = "MS_CORE_URL"
     value = "https://selc.internal.selfcare.pagopa.it/ms-core/v1"
+  },
+  {
+    name  = "MS_PARTY_REGISTRY_URL"
+    value = "http://selc.internal.selfcare.pagopa.it/party-registry-proxy/v1"
   }
 ]
 

--- a/.container_apps/onboarding-ms/env/uat/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/uat/terraform.tfvars
@@ -37,6 +37,10 @@ app_settings = [
   {
     name  = "MS_CORE_URL"
     value = "https://selc.internal.uat.selfcare.pagopa.it/ms-core/v1"
+  },
+  {
+    name  = "MS_PARTY_REGISTRY_URL"
+    value = "http://selc.internal.uat.selfcare.pagopa.it/party-registry-proxy/v1"
   }
 ]
 

--- a/apps/onboarding-ms/README.md
+++ b/apps/onboarding-ms/README.md
@@ -35,6 +35,8 @@ Before running you must set these properties as environment variables.
 | quarkus.rest-client."**.UserApi".api-key<br/>          | USER-REGISTRY-API-KEY                    |             |     yes      |
 | quarkus.rest-client."**.UserApi".url<br/>              | USER_REGISTRY_URL                        |             |     yes      |
 | quarkus.rest-client."**.CoreApi".url<br/>              | MS_CORE_URL                              |             |     yes      |
+| quarkus.rest-client."**.AooApi".url<br/>               | MS_PARTY_REGISTRY_URL                    |             |     yes      |
+| quarkus.rest-client."**.UoApi".url<br/>                | MS_PARTY_REGISTRY_URL                    |             |     yes      |
 | quarkus.rest-client."**.OrchestrationApi".url<br/>     | ONBOARDING_FUNCTIONS_URL                 |             |     yes      |
 | quarkus.rest-client."**.OrchestrationApi".api-key<br/> | ONBOARDING-FUNCTIONS-API-KEY             |             |     yes      |
 | onboarding.institutions-allowed-list<br/>              | ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS |             |      no      |
@@ -51,7 +53,7 @@ You can run your application in dev mode that enables live coding using:
 
 For some endpoints 
 
-> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8080/q/dev/.
+> **_NOTE:_**  Quarkus now ships with a Dev UI, which is available in dev mode only at http://localhost:8083/q/dev/.
 
 ## Packaging and running the application
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/constants/CustomError.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/constants/CustomError.java
@@ -4,7 +4,9 @@ public enum CustomError {
 
     DEFAULT_ERROR("0000", ""),
 
-    ROLES_NOT_ADMITTED_ERROR("0034","Roles %s are not admitted for this operation");
+    ROLES_NOT_ADMITTED_ERROR("0034","Roles %s are not admitted for this operation"),
+    AOO_NOT_FOUND("0000","AOO  %s not found"),
+    UO_NOT_FOUND("0000","UO %s not found");
 
     private final String code;
     private final String detail;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -36,4 +36,6 @@ public class Institution {
 
     private PaymentServiceProvider paymentServiceProvider;
     private DataProtectionOfficer dataProtectionOfficer;
+
+    private String parentDescription;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/exception/ResourceNotFoundException.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/exception/ResourceNotFoundException.java
@@ -1,0 +1,19 @@
+package it.pagopa.selfcare.onboarding.exception;
+
+public class ResourceNotFoundException extends  RuntimeException{
+    private final String code;
+
+    public ResourceNotFoundException(String message, String code) {
+        super(message);
+        this.code = code;
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+        this.code = "0000";
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/apps/onboarding-ms/src/main/openapi/party_registry_proxy.json
+++ b/apps/onboarding-ms/src/main/openapi/party_registry_proxy.json
@@ -1,0 +1,2126 @@
+{
+  "openapi" : "3.0.3",
+  "info" : {
+    "title" : "selc-party-registry-proxy",
+    "description" : "Party Registry Proxy API documentation",
+    "version" : "0.0.1-SNAPSHOT"
+  },
+  "servers" : [ {
+    "url" : "{url}:{port}{basePath}",
+    "variables" : {
+      "url" : {
+        "default" : "http://localhost"
+      },
+      "port" : {
+        "default" : "80"
+      },
+      "basePath" : {
+        "default" : ""
+      }
+    }
+  } ],
+  "tags" : [ {
+    "name" : "GeographicTaxonomies",
+    "description" : "Geographic Taxonomies Controller"
+  }, {
+    "name" : "aoo",
+    "description" : "AOO Controller"
+  }, {
+    "name" : "category",
+    "description" : "Category operations"
+  }, {
+    "name" : "infocamere",
+    "description" : "Info Camere Controller"
+  }, {
+    "name" : "institution",
+    "description" : "Institution operations"
+  }, {
+    "name" : "insurance-companies",
+    "description" : "Ivass Controller"
+  }, {
+    "name" : "nationalRegistries",
+    "description" : "National Registries Controller"
+  }, {
+    "name" : "stations",
+    "description" : "Station Controller"
+  }, {
+    "name" : "uo",
+    "description" : "UO Controller"
+  } ],
+  "paths" : {
+    "/aoo" : {
+      "get" : {
+        "tags" : [ "aoo" ],
+        "summary" : "Retrieve all AOO from IPA",
+        "description" : "Returns the AOO list",
+        "operationId" : "findAllUsingGET",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AOOsResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/aoo/{codiceUniAoo}" : {
+      "get" : {
+        "tags" : [ "aoo" ],
+        "summary" : "Retrieve an AOO given its code",
+        "description" : "Returns an AOO",
+        "operationId" : "findByUnicodeUsingGET",
+        "parameters" : [ {
+          "name" : "codiceUniAoo",
+          "in" : "path",
+          "description" : "AOO unique identifier, the same of Id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "Filter from origin category",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AOOResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/categories" : {
+      "get" : {
+        "tags" : [ "category" ],
+        "summary" : "Get all categories",
+        "description" : "Returns the categories list",
+        "operationId" : "findCategoriesUsingGET",
+        "parameters" : [ {
+          "name" : "origin",
+          "in" : "query",
+          "description" : "Describes which is the source of data",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CategoriesResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/origins/{origin}/categories/{code}" : {
+      "get" : {
+        "tags" : [ "category" ],
+        "summary" : "Get a category",
+        "description" : "Returns a category",
+        "operationId" : "findCategoryUsingGET",
+        "parameters" : [ {
+          "name" : "origin",
+          "in" : "path",
+          "description" : "Describes which is the source of data",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          }
+        }, {
+          "name" : "code",
+          "in" : "path",
+          "description" : "code",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CategoryResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/geotaxonomies" : {
+      "get" : {
+        "tags" : [ "GeographicTaxonomies" ],
+        "summary" : "retrieves the geographic taxonomies by description",
+        "description" : "retrieves the geographic taxonomies by description",
+        "operationId" : "retrieveGeoTaxonomiesByDescriptionUsingGET",
+        "parameters" : [ {
+          "name" : "description",
+          "in" : "query",
+          "description" : "geographic taxonomy description",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "identifies the page 0-based index, default to 0",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "identifies the number of entries in a page, default to 10",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/GeographicTaxonomyResource"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/geotaxonomies/{geotaxId}" : {
+      "get" : {
+        "tags" : [ "GeographicTaxonomies" ],
+        "summary" : "retrieves the geographic taxonomy by code",
+        "description" : "retrieves the geographic taxonomy by code",
+        "operationId" : "retrieveGeoTaxonomiesByCodeUsingGET",
+        "parameters" : [ {
+          "name" : "geotaxId",
+          "in" : "path",
+          "description" : "Geographic taxonomy unique identifier ",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GeographicTaxonomyResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/info-camere/institutions" : {
+      "post" : {
+        "tags" : [ "infocamere" ],
+        "summary" : "Get institutions by legal tax id",
+        "description" : "Get the list of companies represented by the tax code of the person (physical or juridical) passed as a parameter",
+        "operationId" : "institutionsByLegalTaxIdUsingPOST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/GetInstitutionsByLegalDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BusinessesResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/institutions" : {
+      "get" : {
+        "tags" : [ "institution" ],
+        "summary" : "Search institutions",
+        "description" : "Returns a list of Institutions.",
+        "operationId" : "searchUsingGET",
+        "parameters" : [ {
+          "name" : "search",
+          "in" : "query",
+          "description" : "if passed, the result is filtered based on the contained value.",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "Filter from origin category",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionsResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/institutions/{id}" : {
+      "get" : {
+        "tags" : [ "institution" ],
+        "summary" : "Find institution by ID",
+        "description" : "Returns a single institution. If 'origin' param is filled, the ID to find is treated as 'originId' ($ref: '#/components/schemas/Institution'); otherwise is treated as 'id' ($ref: '#/components/schemas/Institution') ",
+        "operationId" : "findInstitutionUsingGET",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "The institution ID. It change semantic based on the origin param value (see notes)",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "origin",
+          "in" : "query",
+          "description" : "Describes which is the source of data",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          }
+        }, {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "Filter from origin category",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/insurance-companies" : {
+      "get" : {
+        "tags" : [ "insurance-companies" ],
+        "summary" : "Search insurance company",
+        "description" : "Returns a list of insurance companies",
+        "operationId" : "searchUsingGET_1",
+        "parameters" : [ {
+          "name" : "search",
+          "in" : "query",
+          "description" : "Optional search field. Users can provide a search string to filter results",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InsuranceCompaniesResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/insurance-companies/{taxId}" : {
+      "get" : {
+        "tags" : [ "insurance-companies" ],
+        "summary" : "Search insurance company by its taxCode",
+        "description" : "Returns only one insurance company.",
+        "operationId" : "searchByTaxCodeUsingGET",
+        "parameters" : [ {
+          "name" : "taxId",
+          "in" : "path",
+          "description" : "taxCode of insurance company",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InsuranceCompanyResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/national-registries/legal-address" : {
+      "get" : {
+        "tags" : [ "nationalRegistries" ],
+        "summary" : "Retrieve data from AdE and InfoCamere",
+        "description" : "Get the legal address of the business",
+        "operationId" : "legalAddressUsingGET",
+        "parameters" : [ {
+          "name" : "taxId",
+          "in" : "query",
+          "description" : "taxId",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalAddressResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/national-registries/verify-legal" : {
+      "get" : {
+        "tags" : [ "nationalRegistries" ],
+        "summary" : "Retrieve data from AdE and InfoCamere",
+        "description" : "verify if given taxId is legal of given institution identified with vatNumber",
+        "operationId" : "verifyLegalUsingGET",
+        "parameters" : [ {
+          "name" : "taxId",
+          "in" : "query",
+          "description" : "taxId",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "vatNumber",
+          "in" : "query",
+          "description" : "vatNumber",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/LegalVerificationResult"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/stations" : {
+      "get" : {
+        "tags" : [ "stations" ],
+        "summary" : "Search station",
+        "description" : "Returns a list of station.",
+        "operationId" : "searchUsingGET_2",
+        "parameters" : [ {
+          "name" : "search",
+          "in" : "query",
+          "description" : "Optional search field. Users can provide a search string to filter results",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StationsResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/stations/{taxId}" : {
+      "get" : {
+        "tags" : [ "stations" ],
+        "summary" : "Search station by its taxCode",
+        "description" : "Returns only one station.",
+        "operationId" : "searchByTaxCodeUsingGET_1",
+        "parameters" : [ {
+          "name" : "taxId",
+          "in" : "path",
+          "description" : "taxCode of station",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StationResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/uo" : {
+      "get" : {
+        "tags" : [ "uo" ],
+        "summary" : "Retrieve all UO from IPA",
+        "description" : "Returns the UO list",
+        "operationId" : "findAllUsingGET_1",
+        "parameters" : [ {
+          "name" : "page",
+          "in" : "query",
+          "description" : "Desired page number for result pagination. It is optional, and the default value is 1 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "Maximum number of items per page. It is optional, and the default value is 10 when not specified",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UOsResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
+    "/uo/{codiceUniAoo}" : {
+      "get" : {
+        "tags" : [ "uo" ],
+        "summary" : "Retrieve a UO given its code",
+        "description" : "Returns a UO",
+        "operationId" : "findByUnicodeUsingGET_1",
+        "parameters" : [ {
+          "name" : "codiceUniAoo",
+          "in" : "path",
+          "description" : "UO unique identifier, the same of Id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "categories",
+          "in" : "query",
+          "description" : "Filter from origin category",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UOResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "AOOResource" : {
+        "title" : "AOOResource",
+        "type" : "object",
+        "properties" : {
+          "cap" : {
+            "type" : "string"
+          },
+          "codAoo" : {
+            "type" : "string",
+            "description" : "AOO code"
+          },
+          "codiceCatastaleComune" : {
+            "type" : "string",
+            "description" : "AOO land registry code"
+          },
+          "codiceComuneISTAT" : {
+            "type" : "string",
+            "description" : "AOO istat code"
+          },
+          "codiceFiscaleEnte" : {
+            "type" : "string",
+            "description" : "AOO fiscal code"
+          },
+          "codiceIpa" : {
+            "type" : "string",
+            "description" : "AOO ipa code"
+          },
+          "codiceUniAoo" : {
+            "type" : "string",
+            "description" : "AOO unique identifier, the same of Id"
+          },
+          "cognomeResponsabile" : {
+            "type" : "string",
+            "description" : "AOO manager lastname"
+          },
+          "dataAggiornamento" : {
+            "type" : "string",
+            "description" : "Identifies date of last update on the specific AOO"
+          },
+          "dataIstituzione" : {
+            "type" : "string",
+            "description" : "Identifies date of first creation for AOO"
+          },
+          "denominazioneAoo" : {
+            "type" : "string",
+            "description" : "AOO description"
+          },
+          "denominazioneEnte" : {
+            "type" : "string",
+            "description" : "AOO parent description"
+          },
+          "fax" : {
+            "type" : "string",
+            "description" : "AOO fax"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "indirizzo" : {
+            "type" : "string",
+            "description" : "AOO address"
+          },
+          "mail1" : {
+            "type" : "string"
+          },
+          "mailResponsabile" : {
+            "type" : "string",
+            "description" : "AOO manager email"
+          },
+          "nomeResponsabile" : {
+            "type" : "string",
+            "description" : "AOO manager firstname"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "{swagger.model.*.origin}",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          },
+          "protocolloInformatico" : {
+            "type" : "string",
+            "description" : "AOO IT protocol"
+          },
+          "telefono" : {
+            "type" : "string",
+            "description" : "AOO phone number"
+          },
+          "telefonoResponsabile" : {
+            "type" : "string",
+            "description" : "AOO manager phone number"
+          },
+          "tipoMail1" : {
+            "type" : "string"
+          },
+          "uriprotocolloInformatico" : {
+            "type" : "string"
+          }
+        }
+      },
+      "AOOsResource" : {
+        "title" : "AOOsResource",
+        "required" : [ "count", "items" ],
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer",
+            "description" : "Total count of items",
+            "format" : "int64"
+          },
+          "items" : {
+            "type" : "array",
+            "description" : "List of AOO resource",
+            "items" : {
+              "$ref" : "#/components/schemas/AOOResource"
+            }
+          }
+        }
+      },
+      "BusinessResource" : {
+        "title" : "BusinessResource",
+        "type" : "object",
+        "properties" : {
+          "businessName" : {
+            "type" : "string"
+          },
+          "businessTaxId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BusinessesResource" : {
+        "title" : "BusinessesResource",
+        "type" : "object",
+        "properties" : {
+          "businesses" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/BusinessResource"
+            }
+          },
+          "legalTaxId" : {
+            "type" : "string"
+          },
+          "requestDateTime" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CategoriesResource" : {
+        "title" : "CategoriesResource",
+        "required" : [ "items" ],
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CategoryResource"
+            }
+          }
+        }
+      },
+      "CategoryResource" : {
+        "title" : "CategoryResource",
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "kind" : {
+            "type" : "string"
+          },
+          "name" : {
+            "type" : "string"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Describes which is the source of data",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          }
+        }
+      },
+      "GeographicTaxonomyResource" : {
+        "title" : "GeographicTaxonomyResource",
+        "type" : "object",
+        "properties" : {
+          "code" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy unique identifier "
+          },
+          "country" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy country"
+          },
+          "country_abbreviation" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy country abbreviation"
+          },
+          "desc" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy description"
+          },
+          "enabled" : {
+            "type" : "boolean",
+            "description" : "Geographic taxonomy enabled",
+            "example" : false
+          },
+          "istat_code" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy istat code"
+          },
+          "province_abbreviation" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy province abbreviation"
+          },
+          "province_id" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy province unique identifier"
+          },
+          "region_id" : {
+            "type" : "string",
+            "description" : "Geographic taxonomy region unique identifier"
+          }
+        }
+      },
+      "GetInstitutionsByLegalDto" : {
+        "title" : "GetInstitutionsByLegalDto",
+        "type" : "object",
+        "properties" : {
+          "filter" : {
+            "$ref" : "#/components/schemas/GetInstitutionsByLegalFilterDto"
+          }
+        }
+      },
+      "GetInstitutionsByLegalFilterDto" : {
+        "title" : "GetInstitutionsByLegalFilterDto",
+        "type" : "object",
+        "properties" : {
+          "legalTaxId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "InstitutionResource" : {
+        "title" : "InstitutionResource",
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "description" : "Institution address"
+          },
+          "aoo" : {
+            "type" : "string",
+            "description" : "Area organizzativa omogenea"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "Institution category"
+          },
+          "description" : {
+            "type" : "string",
+            "description" : "Institution description"
+          },
+          "digitalAddress" : {
+            "type" : "string",
+            "description" : "Institution digital address"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "Semantic id to recognize a party between origins (or externalId)"
+          },
+          "istatCode" : {
+            "type" : "string",
+            "description" : "Institution istat Code"
+          },
+          "o" : {
+            "type" : "string",
+            "description" : "o"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Describes which is the source of data",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          },
+          "originId" : {
+            "type" : "string",
+            "description" : "Id of the institution from its origin"
+          },
+          "ou" : {
+            "type" : "string",
+            "description" : "ou"
+          },
+          "taxCode" : {
+            "type" : "string",
+            "description" : "Institution fiscal code"
+          },
+          "zipCode" : {
+            "type" : "string",
+            "description" : "Institution zipCode"
+          }
+        }
+      },
+      "InstitutionsResource" : {
+        "title" : "InstitutionsResource",
+        "required" : [ "count", "items" ],
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/InstitutionResource"
+            }
+          }
+        }
+      },
+      "InsuranceCompaniesResource" : {
+        "title" : "InsuranceCompaniesResource",
+        "required" : [ "count", "items" ],
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer",
+            "description" : "list of companies resource size",
+            "format" : "int64"
+          },
+          "items" : {
+            "type" : "array",
+            "description" : "list of insurance companies resource",
+            "items" : {
+              "$ref" : "#/components/schemas/InsuranceCompanyResource"
+            }
+          }
+        }
+      },
+      "InsuranceCompanyResource" : {
+        "title" : "InsuranceCompanyResource",
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "description" : "Identifies legal address of insurance company"
+          },
+          "description" : {
+            "type" : "string",
+            "description" : "insurance company's name"
+          },
+          "digitalAddress" : {
+            "type" : "string",
+            "description" : "insurance company's mail address"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "insurance company's unique identifier"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Describes which is the source of data",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          },
+          "originId" : {
+            "type" : "string",
+            "description" : "insurance company's IVASS unique identifier"
+          },
+          "registerType" : {
+            "type" : "string",
+            "description" : "Identifies register type for company"
+          },
+          "taxCode" : {
+            "type" : "string",
+            "description" : "taxCode of insurance company"
+          },
+          "workType" : {
+            "type" : "string",
+            "description" : "Identifies work type for company"
+          }
+        }
+      },
+      "InvalidParam" : {
+        "title" : "InvalidParam",
+        "required" : [ "name", "reason" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "Invalid parameter name."
+          },
+          "reason" : {
+            "type" : "string",
+            "description" : "Invalid parameter reason."
+          }
+        }
+      },
+      "LegalAddressResponse" : {
+        "title" : "LegalAddressResponse",
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string"
+          },
+          "zipCode" : {
+            "type" : "string"
+          }
+        }
+      },
+      "LegalVerificationResult" : {
+        "title" : "LegalVerificationResult",
+        "type" : "object",
+        "properties" : {
+          "resultCode" : {
+            "type" : "string"
+          },
+          "resultDetail" : {
+            "type" : "string"
+          },
+          "verificationResult" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "Problem" : {
+        "title" : "Problem",
+        "required" : [ "status", "title" ],
+        "type" : "object",
+        "properties" : {
+          "detail" : {
+            "type" : "string",
+            "description" : "Human-readable description of this specific problem."
+          },
+          "instance" : {
+            "type" : "string",
+            "description" : "A URI that describes where the problem occurred."
+          },
+          "invalidParams" : {
+            "type" : "array",
+            "description" : "A list of invalid parameters details.",
+            "items" : {
+              "$ref" : "#/components/schemas/InvalidParam"
+            }
+          },
+          "status" : {
+            "type" : "integer",
+            "description" : "The HTTP status code.",
+            "format" : "int32",
+            "example" : 500
+          },
+          "title" : {
+            "type" : "string",
+            "description" : "Short human-readable summary of the problem."
+          },
+          "type" : {
+            "type" : "string",
+            "description" : "A URL to a page with more details regarding the problem."
+          }
+        },
+        "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
+      },
+      "StationResource" : {
+        "title" : "StationResource",
+        "type" : "object",
+        "properties" : {
+          "anacEnabled" : {
+            "type" : "boolean",
+            "description" : "Identifies if ANAC station is enabled",
+            "example" : false
+          },
+          "anacEngaged" : {
+            "type" : "boolean",
+            "description" : "Identifies if ANAC station is engaged",
+            "example" : false
+          },
+          "description" : {
+            "type" : "string",
+            "description" : "station's name"
+          },
+          "digitalAddress" : {
+            "type" : "string",
+            "description" : "station's mail address"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "station's unique identifier"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Describes which is the source of data",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          },
+          "originId" : {
+            "type" : "string",
+            "description" : "station's anac unique identifier"
+          },
+          "taxCode" : {
+            "type" : "string",
+            "description" : "taxCode of station"
+          }
+        }
+      },
+      "StationsResource" : {
+        "title" : "StationsResource",
+        "required" : [ "count", "items" ],
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer",
+            "description" : "list of station resource size",
+            "format" : "int64"
+          },
+          "items" : {
+            "type" : "array",
+            "description" : "list of station resource",
+            "items" : {
+              "$ref" : "#/components/schemas/StationResource"
+            }
+          }
+        }
+      },
+      "UOResource" : {
+        "title" : "UOResource",
+        "type" : "object",
+        "properties" : {
+          "cap" : {
+            "type" : "string"
+          },
+          "codiceCatastaleComune" : {
+            "type" : "string",
+            "description" : "UO land registry code"
+          },
+          "codiceComuneISTAT" : {
+            "type" : "string",
+            "description" : "UO istat code"
+          },
+          "codiceFiscaleEnte" : {
+            "type" : "string",
+            "description" : "UO fiscal code"
+          },
+          "codiceIpa" : {
+            "type" : "string",
+            "description" : "UO ipa code"
+          },
+          "codiceUniAoo" : {
+            "type" : "string",
+            "description" : "AOO unique identifier, the same of Id"
+          },
+          "codiceUniUo" : {
+            "type" : "string",
+            "description" : "UO unique identifier, the same of Id"
+          },
+          "codiceUniUoPadre" : {
+            "type" : "string",
+            "description" : "UO parent code"
+          },
+          "cognomeResponsabile" : {
+            "type" : "string",
+            "description" : "UO manager lastname"
+          },
+          "dataAggiornamento" : {
+            "type" : "string",
+            "description" : "Identifies date of last update on the specific UO"
+          },
+          "dataIstituzione" : {
+            "type" : "string",
+            "description" : "Identifies date of first creation for UO"
+          },
+          "denominazioneEnte" : {
+            "type" : "string",
+            "description" : "UO parent description"
+          },
+          "descrizioneUo" : {
+            "type" : "string",
+            "description" : "UO description"
+          },
+          "fax" : {
+            "type" : "string",
+            "description" : "UO fax"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "indirizzo" : {
+            "type" : "string",
+            "description" : "UO address"
+          },
+          "mail1" : {
+            "type" : "string"
+          },
+          "mailResponsabile" : {
+            "type" : "string",
+            "description" : "UO manager email"
+          },
+          "nomeResponsabile" : {
+            "type" : "string",
+            "description" : "UO manager firstname"
+          },
+          "origin" : {
+            "type" : "string",
+            "description" : "Describes which is the source of data",
+            "enum" : [ "ANAC", "INFOCAMERE", "IPA", "IVASS", "static" ]
+          },
+          "telefono" : {
+            "type" : "string",
+            "description" : "UO phone number"
+          },
+          "telefonoResponsabile" : {
+            "type" : "string",
+            "description" : "UO manager phone number"
+          },
+          "tipoMail1" : {
+            "type" : "string"
+          },
+          "url" : {
+            "type" : "string",
+            "description" : "UO url"
+          }
+        }
+      },
+      "UOsResource" : {
+        "title" : "UOsResource",
+        "required" : [ "count", "items" ],
+        "type" : "object",
+        "properties" : {
+          "count" : {
+            "type" : "integer",
+            "description" : "Total count of items",
+            "format" : "int64"
+          },
+          "items" : {
+            "type" : "array",
+            "description" : "List of UO resource",
+            "items" : {
+              "$ref" : "#/components/schemas/UOResource"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "bearerAuth" : {
+        "type" : "http",
+        "description" : "A bearer token in the format of a JWS and conformed to the specifications included in [RFC8725](https://tools.ietf.org/html/RFC8725)",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
+      }
+    }
+  }
+}

--- a/apps/onboarding-ms/src/main/resources/application.properties
+++ b/apps/onboarding-ms/src/main/resources/application.properties
@@ -61,6 +61,13 @@ quarkus.openapi-generator.codegen.spec.core_json.enable-security-generation=fals
 quarkus.openapi-generator.codegen.spec.core_json.additional-api-type-annotations=@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders(it.pagopa.selfcare.onboarding.client.auth.AuthenticationPropagationHeadersFactory.class)
 quarkus.rest-client."org.openapi.quarkus.core_json.api.OnboardingApi".url=${MS_CORE_URL:http://localhost:8080}
 
+quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.mutiny=true
+quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.additional-model-type-annotations=@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
+quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.enable-security-generation=false
+quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.additional-api-type-annotations=@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders(it.pagopa.selfcare.onboarding.client.auth.AuthenticationPropagationHeadersFactory.class)
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.UoApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.AooApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
+
 ## AZURE STORAGE ##
 
 onboarding-ms.blob-storage.container-product=${STORAGE_CONTAINER_PRODUCT:selc-d-product}

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -395,7 +395,6 @@ public class OnboardingServiceDefaultTest {
 
         asserter.execute(() -> {
             PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
             PanacheMock.verifyNoMoreInteractions(Onboarding.class);
         });
     }
@@ -441,7 +440,6 @@ public class OnboardingServiceDefaultTest {
 
         asserter.execute(() -> {
             PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
             PanacheMock.verifyNoMoreInteractions(Onboarding.class);
         });
     }
@@ -516,21 +514,20 @@ public class OnboardingServiceDefaultTest {
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
+        WebApplicationException exception = mock(WebApplicationException.class);
+        Response response = mock(Response.class);
+        when(response.getStatus()).thenReturn(404);
+        when(exception.getResponse()).thenReturn(response);
+
         UOResource uoResource = new UOResource();
         uoResource.setDenominazioneEnte("TEST");
         asserter.execute(() -> when(uoApi.findByUnicodeUsingGET1(institutionBaseRequest.getSubunitCode(), null))
-                .thenReturn(Uni.createFrom().item(uoResource)));
-
-        WebApplicationException exception = mock(WebApplicationException.class);
-        Response response = mock(Response.class);
-        when(response.getStatus()).thenReturn(400);
-        when(exception.getResponse()).thenReturn(response);
+                .thenReturn(Uni.createFrom().failure(exception)));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(request), ResourceNotFoundException.class);
 
         asserter.execute(() -> {
             PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
             PanacheMock.verifyNoMoreInteractions(Onboarding.class);
         });
     }
@@ -563,21 +560,20 @@ public class OnboardingServiceDefaultTest {
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
-        UOResource uoResource = new UOResource();
-        uoResource.setDenominazioneEnte("TEST");
-        asserter.execute(() -> when(uoApi.findByUnicodeUsingGET1(institutionBaseRequest.getSubunitCode(), null))
-                .thenReturn(Uni.createFrom().item(uoResource)));
-
         WebApplicationException exception = mock(WebApplicationException.class);
         Response response = mock(Response.class);
         when(response.getStatus()).thenReturn(500);
         when(exception.getResponse()).thenReturn(response);
 
+        UOResource uoResource = new UOResource();
+        uoResource.setDenominazioneEnte("TEST");
+        asserter.execute(() -> when(uoApi.findByUnicodeUsingGET1(institutionBaseRequest.getSubunitCode(), null))
+                .thenReturn(Uni.createFrom().failure(exception)));
+
         asserter.assertFailedWith(() -> onboardingService.onboarding(request), WebApplicationException.class);
 
         asserter.execute(() -> {
             PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
             PanacheMock.verifyNoMoreInteractions(Onboarding.class);
         });
     }


### PR DESCRIPTION
#### List of Changes

retrieve and add parentDescription to onboarding Institution if it is AOO or UO

#### Motivation and Context

when onboarding AOO and UO we have to persist also parent description

#### How Has This Been Tested?
run in debug mode, call api to onboarding PA and check in onboarding institution data to persist, parentDescription field 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.