### PR TITLE
[SELC-3504] feat: saving onboarding status

### DIFF
--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -21,7 +21,7 @@
     <quarkus.platform.version>3.5.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.1.2</onboarding-sdk.version>
+    <onboarding-sdk.version>0.1.3</onboarding-sdk.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/CommonFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/CommonFunctions.java
@@ -1,0 +1,27 @@
+package it.pagopa.selfcare.onboarding.functions;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.durabletask.azurefunctions.DurableActivityTrigger;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.functions.utils.SaveOnboardingStatusInput;
+import it.pagopa.selfcare.onboarding.service.OnboardingService;
+
+public class CommonFunctions {
+
+    public static final String FORMAT_LOGGER_ONBOARDING_STRING = "%s: %s";
+    public static final String SAVE_ONBOARDING_STATUS_ACTIVITY = "SaveOnboardingStatus";
+
+    private final OnboardingService service;
+
+    public CommonFunctions(OnboardingService service) {
+        this.service = service;
+    }
+
+    @FunctionName(SAVE_ONBOARDING_STATUS_ACTIVITY)
+    public void savePendingState(@DurableActivityTrigger(name = "onboardingString") String saveOnboardingStatusInputString, final ExecutionContext context) {
+        SaveOnboardingStatusInput saveOnboardingStatusInput = SaveOnboardingStatusInput.readJsonString(saveOnboardingStatusInputString);
+        context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, SAVE_ONBOARDING_STATUS_ACTIVITY, saveOnboardingStatusInput.getOnboardingId()));
+        service.savePendingState(saveOnboardingStatusInput.getOnboardingId(), OnboardingStatus.valueOf(saveOnboardingStatusInput.getStatus()));
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/SaveOnboardingStatusInput.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/SaveOnboardingStatusInput.java
@@ -1,0 +1,60 @@
+package it.pagopa.selfcare.onboarding.functions.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class SaveOnboardingStatusInput {
+
+    private String status;
+    private String onboardingId;
+
+    public String getOnboardingId() {
+        return onboardingId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setOnboardingId(String onboardingId) {
+        this.onboardingId = onboardingId;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public static SaveOnboardingStatusInput build(String onboardingId, String status) {
+        SaveOnboardingStatusInput statusInput = new SaveOnboardingStatusInput();
+        statusInput.setStatus(status);
+        statusInput.setOnboardingId(onboardingId);
+        return statusInput;
+    }
+
+    public static String buildAsJsonString(String onboardingId, String status) {
+        SaveOnboardingStatusInput statusInput = new SaveOnboardingStatusInput();
+        statusInput.setStatus(status);
+        statusInput.setOnboardingId(onboardingId);
+        return jsonString(statusInput);
+    }
+
+    public static String jsonString(SaveOnboardingStatusInput entity) {
+
+        String jsonString;
+        try {
+            jsonString = new ObjectMapper().writeValueAsString(entity);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+
+    public static SaveOnboardingStatusInput readJsonString(String jsonString) {
+        try {
+            return new ObjectMapper().readValue(jsonString, SaveOnboardingStatusInput.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.onboarding.service;
 import eu.europa.esig.dss.enumerations.DigestAlgorithm;
 import eu.europa.esig.dss.model.DSSDocument;
 import eu.europa.esig.dss.model.FileDocument;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.Token;
@@ -183,6 +184,12 @@ public class OnboardingService {
         sendMailInput.userRequestName = Optional.ofNullable(userRequest.getName()).map(CertifiableFieldResourceOfstring::getValue).orElse("");
         sendMailInput.userRequestSurname = Optional.ofNullable(userRequest.getFamilyName()).map(CertifiableFieldResourceOfstring::getValue).orElse("");
         return sendMailInput;
+    }
+
+    public void savePendingState(String onboardingId, OnboardingStatus status) {
+        repository
+                .update("status", status.name())
+                .where("_id", onboardingId);
     }
 
     static class SendMailInput {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
@@ -13,6 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.onboarding.functions.OnboardingCompletionFunctions;
 import it.pagopa.selfcare.onboarding.service.CompletionService;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import jakarta.inject.Inject;
@@ -27,7 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static it.pagopa.selfcare.onboarding.OnboardingCompletionFunctions.*;
+import static it.pagopa.selfcare.onboarding.functions.OnboardingCompletionFunctions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingCompletionFunctionsTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import static it.pagopa.selfcare.onboarding.functions.CommonFunctions.SAVE_ONBOARDING_STATUS_ACTIVITY;
 import static it.pagopa.selfcare.onboarding.functions.OnboardingCompletionFunctions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -118,11 +119,12 @@ public class OnboardingCompletionFunctionsTest {
         function.onboardingCompletionOrchestrator(orchestrationContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(orchestrationContext, times(3))
+        Mockito.verify(orchestrationContext, times(4))
                 .callActivity(captorActivity.capture(), any(), any(),any());
         assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
         assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
         assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(2));
+        assertEquals(SAVE_ONBOARDING_STATUS_ACTIVITY, captorActivity.getAllValues().get(3));
     }
 
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingFunctionsTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import static it.pagopa.selfcare.onboarding.functions.CommonFunctions.SAVE_ONBOARDING_STATUS_ACTIVITY;
 import static it.pagopa.selfcare.onboarding.functions.OnboardingFunctions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -113,15 +114,16 @@ public class OnboardingFunctionsTest {
 
         function.onboardingsOrchestrator(orchestrationContext);
 
-        Mockito.verify(orchestrationContext, times(3))
+        Mockito.verify(orchestrationContext, times(4))
                 .callActivity(any(), any(), any(),any());
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(orchestrationContext, times(3))
+        Mockito.verify(orchestrationContext, times(4))
                 .callActivity(captorActivity.capture(), any(), any(),any());
         assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(0));
         assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
         assertEquals(SEND_MAIL_REGISTRATION_WITH_CONTRACT_ACTIVITY, captorActivity.getAllValues().get(2));
+        assertEquals(SAVE_ONBOARDING_STATUS_ACTIVITY, captorActivity.getAllValues().get(3));
     }
 
     @Test
@@ -135,9 +137,10 @@ public class OnboardingFunctionsTest {
         function.onboardingsOrchestrator(orchestrationContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(orchestrationContext, times(1))
+        Mockito.verify(orchestrationContext, times(2))
                 .callActivity(captorActivity.capture(), any(), any(),any());
-        assertEquals(SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY, captorActivity.getValue());
+        assertEquals(SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY, captorActivity.getAllValues().get(0));
+        assertEquals(SAVE_ONBOARDING_STATUS_ACTIVITY, captorActivity.getAllValues().get(1));
     }
 
     @Test
@@ -151,9 +154,10 @@ public class OnboardingFunctionsTest {
         function.onboardingsOrchestrator(orchestrationContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(orchestrationContext, times(1))
+        Mockito.verify(orchestrationContext, times(2))
                 .callActivity(captorActivity.capture(), any(), any(),any());
-        assertEquals(SEND_MAIL_CONFIRMATION_ACTIVITY, captorActivity.getValue());
+        assertEquals(SEND_MAIL_CONFIRMATION_ACTIVITY, captorActivity.getAllValues().get(0));
+        assertEquals(SAVE_ONBOARDING_STATUS_ACTIVITY, captorActivity.getAllValues().get(1));
     }
 
     @Test
@@ -167,10 +171,11 @@ public class OnboardingFunctionsTest {
         function.onboardingsOrchestrator(orchestrationContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(orchestrationContext, times(2))
+        Mockito.verify(orchestrationContext, times(3))
                 .callActivity(captorActivity.capture(), any(), any(),any());
         assertEquals(SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY, captorActivity.getAllValues().get(0));
         assertEquals(SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY, captorActivity.getAllValues().get(1));
+        assertEquals(SAVE_ONBOARDING_STATUS_ACTIVITY, captorActivity.getAllValues().get(2));
     }
 
     TaskOrchestrationContext mockTaskOrchestrationContext(Onboarding onboarding) {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingFunctionsTest.java
@@ -13,6 +13,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.onboarding.functions.OnboardingFunctions;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static it.pagopa.selfcare.onboarding.OnboardingFunctions.*;
+import static it.pagopa.selfcare.onboarding.functions.OnboardingFunctions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -22,7 +22,7 @@
     <quarkus.platform.version>3.5.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.1.2</onboarding-sdk.version>
+    <onboarding-sdk.version>0.1.3</onboarding-sdk.version>
     <quarkus-openapi-generator.version>2.2.13</quarkus-openapi-generator.version>
   </properties>
   <dependencyManagement>

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.controller.request.ContractRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingImportContract;
@@ -32,5 +33,6 @@ public class Onboarding extends ReactivePanacheMongoEntity  {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime expiringDate;
+    private OnboardingStatus status;
     private String userRequestUid;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -7,6 +7,7 @@ import io.smallrye.mutiny.infrastructure.Infrastructure;
 import io.smallrye.mutiny.unchecked.Unchecked;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.constants.CustomError;
@@ -35,7 +36,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.jboss.resteasy.reactive.ClientWebApplicationException;
 import org.openapi.quarkus.core_json.api.OnboardingApi;
-import org.openapi.quarkus.core_json.model.Institution;
 import org.openapi.quarkus.onboarding_functions_json.api.OrchestrationApi;
 import org.openapi.quarkus.party_registry_proxy_json.api.AooApi;
 import org.openapi.quarkus.party_registry_proxy_json.api.UoApi;
@@ -133,6 +133,7 @@ public class OnboardingServiceDefault implements OnboardingService {
         onboarding.setExpiringDate(OffsetDateTime.now().plus(onboardingExpireDate, ChronoUnit.DAYS).toLocalDateTime());
         onboarding.setCreatedAt(LocalDateTime.now());
         onboarding.setWorkflowType(getWorkflowType(onboarding));
+        onboarding.setStatus(OnboardingStatus.REQUEST);
 
         return Panache.withTransaction(() -> Onboarding.persist(onboarding).replaceWith(onboarding)
                 .onItem().transformToUni(onboardingPersisted -> checkRoleAndRetrieveUsers(userRequests, onboardingPersisted.id.toHexString())


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

1. Using 0.1.3 onboarding-sdk 
2. Introduce common azure function for saving onboarding status, it is called at the end for each workflow
3. Save status REQUEST at first step of onboarding
3. Save status PENDING at the end of onboarding functions
3. Save status COMPLETED at the end of onboarding completion functions

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Implementation of onboarding-ms and onboarding-functions about this [PR](https://github.com/pagopa/selfcare-onboarding/pull/64)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.