### PR TITLE
[SELC-3452] feat: start async onboarding completion

### DIFF
--- a/.container_apps/onboarding-ms/env/dev/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/dev/terraform.tfvars
@@ -24,7 +24,7 @@ app_settings = [
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
-    value = "https://selc-d-func.azurewebsites.net"
+    value = "https://selc-d-onboarding-fn.azurewebsites.net"
   },
   {
     name  = "ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS"
@@ -52,6 +52,7 @@ key_vault = {
     "mongodb-connection-string",
     "user-registry-api-key",
     "onboarding-functions-api-key",
-    "blob-storage-product-connection-string"
+    "blob-storage-product-connection-string",
+    "start-completion-functions-api-key"
   ]
 }

--- a/.container_apps/onboarding-ms/env/prod/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/prod/terraform.tfvars
@@ -37,7 +37,7 @@ app_settings = [
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
-    value = "https://selc-p-func.azurewebsites.net"
+    value = "https://selc-p-onboarding-fn.azurewebsites.net"
   },
   {
     name  = "ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS"
@@ -64,6 +64,7 @@ key_vault = {
     "jwt-public-key",
     "mongodb-connection-string",
     "user-registry-api-key",
-    "onboarding-functions-api-key"
+    "onboarding-functions-api-key",
+    "start-completion-functions-api-key"
   ]
 }

--- a/.container_apps/onboarding-ms/env/uat/terraform.tfvars
+++ b/.container_apps/onboarding-ms/env/uat/terraform.tfvars
@@ -24,7 +24,7 @@ app_settings = [
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
-    value = "https://selc-u-func.azurewebsites.net"
+    value = "https://selc-u-onboarding-fn.azurewebsites.net"
   },
   {
     name  = "ONBOARDING_ALLOWED_INSTITUTIONS_PRODUCTS"
@@ -51,6 +51,7 @@ key_vault = {
     "jwt-public-key",
     "mongodb-connection-string",
     "user-registry-api-key",
-    "onboarding-functions-api-key"
+    "onboarding-functions-api-key",
+    "start-completion-functions-api-key"
   ]
 }

--- a/apps/onboarding-ms/src/main/openapi/onboarding_functions.json
+++ b/apps/onboarding-ms/src/main/openapi/onboarding_functions.json
@@ -64,6 +64,43 @@
           }
         ]
       }
+    },
+    "/api/StartOnboardingCompletionOrchestration": {
+      "get": {
+        "tags": [
+          "Orchestration"
+        ],
+        "summary": "",
+        "description": "",
+        "parameters": [
+          {
+            "name": "onboardingId",
+            "in": "query",
+            "description": "Onboarding id about item to process",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrchestrationResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key_complete": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -114,6 +151,11 @@
     },
     "securitySchemes": {
       "api_key": {
+        "type": "apiKey",
+        "name": "x-functions-key",
+        "in": "header"
+      },
+      "api_key_complete": {
         "type": "apiKey",
         "name": "x-functions-key",
         "in": "header"

--- a/apps/onboarding-ms/src/main/resources/application.properties
+++ b/apps/onboarding-ms/src/main/resources/application.properties
@@ -48,6 +48,7 @@ quarkus.log.category."org.jboss.resteasy.reactive.client.logging".level=DEBUG
 quarkus.openapi-generator.codegen.spec.onboarding_functions_json.mutiny=true
 quarkus.openapi-generator.codegen.spec.onboarding_functions_json.additional-model-type-annotations=@lombok.Builder; @lombok.NoArgsConstructor; @lombok.AllArgsConstructor
 quarkus.openapi-generator.onboarding_functions_json.auth.api_key.api-key = ${ONBOARDING-FUNCTIONS-API-KEY:example-api-key}
+quarkus.openapi-generator.onboarding_functions_json.auth.api_key_complete.api-key = ${START-COMPLETION-FUNCTIONS-API-KEY:example-api-key}
 quarkus.rest-client."org.openapi.quarkus.onboarding_functions_json.api.OrchestrationApi".url=${ONBOARDING_FUNCTIONS_URL:http://localhost:8080}
 
 quarkus.openapi-generator.codegen.spec.user_registry_json.mutiny=true

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -23,6 +23,7 @@ import it.pagopa.selfcare.onboarding.util.InstitutionPaSubunitType;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRole;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
+import it.pagopa.selfcare.product.exception.ProductNotFoundException;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
@@ -180,7 +181,7 @@ public class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().item(managerResource)));
 
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
-                .thenReturn(null));
+                .thenThrow(ProductNotFoundException.class));
 
         asserter.assertFailedWith(() -> onboardingService.onboardingPa(onboardingRequest), OnboardingNotAllowedException.class);
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added **start-completion-functions-api-key** as secret
* Fix ONBOARDING_FUNCTIONS_URL env value
* Change retrieving product as Uni avoiding thread blocked if it takes a lot of time
* Added rest api call to execute onboarding completion process async.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Start of orchestration described at this [PR](https://github.com/pagopa/selfcare-onboarding/pull/58). It is the last operation executed by completion onboarding process sync.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.