### PR TITLE
feat: propagate jwt token for calling ms-core

### DIFF
--- a/.functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/.functions/onboarding-functions/env/dev/terraform.tfvars
@@ -63,5 +63,6 @@ app_settings = {
   "MAIL_ONBOARDING_CONFIRMATION_LINK"    = "https://dev.selfcare.pagopa.it/onboarding/confirm?jwt=",
   "MAIL_ONBOARDING_REJECTION_LINK"      = "https://dev.selfcare.pagopa.it/onboarding/cancel?jwt=",
   "MAIL_ONBOARDING_URL" : "https://dev.selfcare.pagopa.it/onboarding/",
-  "MS_CORE_URL" = "https://selc.internal.dev.selfcare.pagopa.it/ms-core/v1"
+  "MS_CORE_URL" = "https://selc.internal.dev.selfcare.pagopa.it/ms-core/v1",
+  "JWT_BEARER_TOKEN" = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)"
 }

--- a/.functions/onboarding-functions/env/uat/terraform.tfvars
+++ b/.functions/onboarding-functions/env/uat/terraform.tfvars
@@ -63,5 +63,6 @@ app_settings = {
   "MAIL_ONBOARDING_CONFIRMATION_LINK"    = "https://uat.selfcare.pagopa.it/onboarding/confirm?jwt=",
   "MAIL_ONBOARDING_REJECTION_LINK"      = "https://uat.selfcare.pagopa.it/onboarding/cancel?jwt=",
   "MAIL_ONBOARDING_URL" : "https://uat.selfcare.pagopa.it/onboarding/",
-  "MS_CORE_URL" : "https://selc.internal.uat.selfcare.pagopa.it/ms-core/v1"
+  "MS_CORE_URL" : "https://selc.internal.uat.selfcare.pagopa.it/ms-core/v1",
+  "JWT_BEARER_TOKEN" = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)"
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactory.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactory.java
@@ -9,6 +9,8 @@ public class AuthenticationPropagationHeadersFactory implements ClientHeadersFac
 
     @Override
     public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders, MultivaluedMap<String, String> clientOutgoingHeaders) {
+        String bearerToken = System.getenv("JWT_BEARER_TOKEN");
+        clientOutgoingHeaders.put("Authorization", List.of("Bearer " + bearerToken));
         return clientOutgoingHeaders;
     }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Implemented the retrieval of a default JWT token from a secret, and propagated this token in calls to ms-core.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change addresses the need for asynchronous onboarding workflows to authenticate with ms-core endpoints that are protected by Bearer Authentication. Since these asynchronous functions lack a user-derived bearer token to propagate, a default token stored in a secret is now used for these endpoint calls. This approach serves as a temporary solution while a more secure and structured method for accessing JWT token-protected services is developed.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.