### PR TITLE
[SELC-2864] Feat: added API for get Onboarding with optional filters

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -119,7 +119,7 @@ public class OnboardingController {
                         .build());
     }
 
-    @Operation(summary = "The getOnboardingWithFilter API retrieves paged onboarding using optional filter, order by descending creation date")
+    @Operation(summary = "The API retrieves paged onboarding using optional filter, order by descending creation date")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<OnboardingGetResponse> getOnboardingWithFilter(@QueryParam(value = "productId") String productId,
@@ -128,10 +128,8 @@ public class OnboardingController {
                                                               @QueryParam(value = "to") String to,
                                                               @QueryParam(value = "status") String status,
                                                               @QueryParam(value = "page") @DefaultValue("0") Integer page,
-                                                              @QueryParam(value = "size") @DefaultValue("20") Integer size,
-                                                              @Context SecurityContext ctx) {
-        return readUserIdFromToken(ctx)
-                .onItem().transformToUni(ignore -> onboardingService.onboardingGet(productId, taxCode, status, from, to, page, size));
+                                                              @QueryParam(value = "size") @DefaultValue("20") Integer size) {
+        return onboardingService.onboardingGet(productId, taxCode, status, from, to, page, size);
     }
 
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -7,6 +7,7 @@ import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import jakarta.inject.Inject;
@@ -30,7 +31,7 @@ public class OnboardingController {
     @Inject
     CurrentIdentityAssociation currentIdentityAssociation;
 
-    final private OnboardingService onboardingService;
+    private final OnboardingService onboardingService;
 
     @Operation(summary = "Perform default onboarding request, it is used for GSP/SA/AS institution type." +
             "Users data will be saved on personal data vault if it doesn't already exist." +
@@ -117,4 +118,21 @@ public class OnboardingController {
                         .status(HttpStatus.SC_NO_CONTENT)
                         .build());
     }
+
+    @Operation(summary = "The getOnboardingWithFilter API retrieves paged onboarding using optional filter, order by descending creation date")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<OnboardingGetResponse> getOnboardingWithFilter(@QueryParam(value = "productId") String productId,
+                                                              @QueryParam(value = "taxCode") String taxCode,
+                                                              @QueryParam(value = "from") String from,
+                                                              @QueryParam(value = "to") String to,
+                                                              @QueryParam(value = "status") String status,
+                                                              @QueryParam(value = "page") @DefaultValue("0") Integer page,
+                                                              @QueryParam(value = "size") @DefaultValue("20") Integer size,
+                                                              @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(ignore -> onboardingService.onboardingGet(productId, taxCode, status, from, to, page, size));
+    }
+
+
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/ContractRequestResponse.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/ContractRequestResponse.java
@@ -1,0 +1,9 @@
+package it.pagopa.selfcare.onboarding.controller.response;
+
+import lombok.Data;
+
+@Data
+public class ContractRequestResponse {
+    private String version;
+    private String path;
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
@@ -14,8 +14,6 @@ public class OnboardingGet {
     private List<UserResponse> users;
     private String pricingPlan;
     private BillingResponse billing;
-    private ContractRequestResponse contract;
-    private OnboardingImportContractResponse contractImported;
     private Boolean signContract;
 
     private LocalDateTime createdAt;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
@@ -1,0 +1,26 @@
+package it.pagopa.selfcare.onboarding.controller.response;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class OnboardingGet {
+    private String id;
+    private String productId;
+    private String workflowType;
+    private InstitutionResponse institution;
+    private List<UserResponse> users;
+    private String pricingPlan;
+    private BillingResponse billing;
+    private ContractRequestResponse contract;
+    private OnboardingImportContractResponse contractImported;
+    private Boolean signContract;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime expiringDate;
+    private String status;
+    private String userRequestUid;
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGetResponse.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGetResponse.java
@@ -1,0 +1,11 @@
+package it.pagopa.selfcare.onboarding.controller.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class OnboardingGetResponse {
+    Long count;
+    List<OnboardingGet> items;
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingImportContractResponse.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingImportContractResponse.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.onboarding.controller.response;
+
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+public class OnboardingImportContractResponse {
+    private String fileName;
+    private String filePath;
+    private String contractType;
+    private OffsetDateTime createdAt;
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -8,6 +8,7 @@ import it.pagopa.selfcare.onboarding.controller.request.ContractRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingImportContract;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldNameConstants;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
+@FieldNameConstants(asEnum = true)
 @MongoEntity(collection="onboardings")
 public class Onboarding extends ReactivePanacheMongoEntity  {
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -4,9 +4,11 @@ import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingSaRequest;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
-import org.mapstruct.Mapper;
+import org.bson.types.ObjectId;
+import org.mapstruct.*;
 
 @Mapper(componentModel = "cdi")
 public interface OnboardingMapper {
@@ -22,4 +24,12 @@ public interface OnboardingMapper {
     //Onboarding toEntity(OnboardingPgRequest request);
 
     OnboardingResponse toResponse(Onboarding onboarding);
+
+    @Mapping(target = "id", expression = "java(objectIdToString(model.getId()))")
+    OnboardingGet toGetResponse(Onboarding model);
+
+    @Named("objectIdToString")
+    default String objectIdToString(ObjectId objectId) {
+       return objectId.toHexString();
+    }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingSaRequest;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 
@@ -23,4 +24,6 @@ public interface OnboardingService {
     Uni<Onboarding> complete(String tokenId, File contract);
 
     Uni<Onboarding> completeWithoutSignatureVerification(String tokenId, File contract);
+
+    Uni<OnboardingGetResponse> onboardingGet(String productId, String taxCode, String status, String from, String to, Integer page, Integer size);
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -28,6 +28,7 @@ import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.service.strategy.OnboardingValidationStrategy;
 import it.pagopa.selfcare.onboarding.util.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.util.QueryUtils;
+import it.pagopa.selfcare.onboarding.util.SortEnum;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
 import it.pagopa.selfcare.product.service.ProductService;
@@ -515,7 +516,7 @@ public class OnboardingServiceDefault implements OnboardingService {
 
     @Override
     public Uni<OnboardingGetResponse> onboardingGet(String productId, String taxCode, String status, String from, String to, Integer page, Integer size) {
-        Document sort = QueryUtils.buildSortForOnboardingCollection();
+        Document sort = QueryUtils.buildSortDocument(Onboarding.Fields.createdAt.name(), SortEnum.DESC);
         Map<String, String> queryParameter = QueryUtils.createMapForOnboardingQueryParameter(productId, taxCode, status, from, to);
         Document query = QueryUtils.buildQuery(queryParameter);
 
@@ -523,7 +524,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                         runQuery(query, sort).page(page, size).list(),
                         runQuery(query, null).count()
                 ).asTuple()
-                .onItem().transform(this::constructOnboardingGetResponse);
+                .map(this::constructOnboardingGetResponse);
     }
 
     private ReactivePanacheQuery<Onboarding> runQuery(Document query, Document sort) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -1,9 +1,11 @@
 package it.pagopa.selfcare.onboarding.service;
 
 import io.quarkus.mongodb.panache.common.reactive.Panache;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.tuples.Tuple2;
 import io.smallrye.mutiny.unchecked.Unchecked;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
@@ -12,6 +14,8 @@ import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.constants.CustomError;
 import it.pagopa.selfcare.onboarding.controller.request.*;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.Token;
@@ -23,6 +27,7 @@ import it.pagopa.selfcare.onboarding.exception.UpdateNotAllowedException;
 import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
 import it.pagopa.selfcare.onboarding.service.strategy.OnboardingValidationStrategy;
 import it.pagopa.selfcare.onboarding.util.InstitutionPaSubunitType;
+import it.pagopa.selfcare.onboarding.util.QueryUtils;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
 import it.pagopa.selfcare.product.service.ProductService;
@@ -30,6 +35,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -46,7 +52,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -129,7 +134,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     public Uni<OnboardingResponse> fillUsersAndOnboarding(Onboarding onboarding, List<UserRequest> userRequests) {
-        onboarding.setExpiringDate(OffsetDateTime.now().plus(onboardingExpireDate, ChronoUnit.DAYS).toLocalDateTime());
+        onboarding.setExpiringDate(OffsetDateTime.now().plusDays(onboardingExpireDate).toLocalDateTime());
         onboarding.setCreatedAt(LocalDateTime.now());
         onboarding.setWorkflowType(getWorkflowType(onboarding));
         onboarding.setStatus(OnboardingStatus.REQUEST);
@@ -177,7 +182,7 @@ public class OnboardingServiceDefault implements OnboardingService {
         final List<Onboarding> onboardings = new ArrayList<>();
         onboardings.add(onboarding);
 
-        if(onboardingOrchestrationEnabled) {
+        if (Boolean.TRUE.equals(onboardingOrchestrationEnabled)) {
             return Onboarding.persistOrUpdate(onboardings)
                     .onItem().transformToUni(saved -> orchestrationApi.apiStartOnboardingOrchestrationGet(onboarding.getId().toHexString())
                     .replaceWith(onboarding));
@@ -190,7 +195,8 @@ public class OnboardingServiceDefault implements OnboardingService {
     /**
      * Identify which workflow must be trigger during onboarding process.
      * Each workflow consist of different activities such as creating contract or sending appropriate mail.
-     * For more information look at https://pagopa.atlassian.net/wiki/spaces/SCP/pages/776339638/DR+-+Domain+Onboarding
+     * For more information look at <a href="https://pagopa.atlassian.net/wiki/spaces/SCP/pages/776339638/DR+-+Domain+Onboarding">...</a>
+     *
      * @param onboarding actual onboarding request
      * @return WorkflowType
      */
@@ -406,7 +412,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     @Override
     public Uni<Onboarding> complete(String onboardingId, File contract) {
 
-        if(isVerifyEnabled) {
+        if (Boolean.TRUE.equals(isVerifyEnabled)) {
             //Retrieve as Tuple: managers fiscal-code from user registry and contract digest
             //At least, verify contract signature using both
             Function<Onboarding, Uni<Onboarding>> verification = onboarding -> Uni.combine().all()
@@ -441,11 +447,11 @@ public class OnboardingServiceDefault implements OnboardingService {
                 )
                 //Upload contract on storage
                 .onItem().transformToUni(onboarding -> uploadSignedContract(onboardingId, contract)
-                            .map(ignore -> onboarding))
+                        .map(ignore -> onboarding))
                 // Start async activity if onboardingOrchestrationEnabled is true
                 .onItem().transformToUni(onboarding -> onboardingOrchestrationEnabled
                         ? orchestrationApi.apiStartOnboardingCompletionOrchestrationGet(onboarding.getId().toHexString())
-                            .map(ignore -> onboarding)
+                        .map(ignore -> onboarding)
                         : Uni.createFrom().item(onboarding));
     }
 
@@ -507,4 +513,33 @@ public class OnboardingServiceDefault implements OnboardingService {
                 .onItem().transform(usersResource -> usersResource.stream().map(UserResource::getFiscalCode).toList());
     }
 
+    @Override
+    public Uni<OnboardingGetResponse> onboardingGet(String productId, String taxCode, String status, String from, String to, Integer page, Integer size) {
+        Document sort = QueryUtils.buildSortForOnboardingCollection();
+        Map<String, String> queryParameter = QueryUtils.createMapForOnboardingQueryParameter(productId, taxCode, status, from, to);
+        Document query = QueryUtils.buildQuery(queryParameter);
+
+        return Uni.combine().all().unis(
+                        runQuery(query, sort).page(page, size).list(),
+                        runQuery(query, null).count()
+                ).asTuple()
+                .onItem().transform(this::constructOnboardingGetResponse);
+    }
+
+    private ReactivePanacheQuery<Onboarding> runQuery(Document query, Document sort) {
+        return Onboarding.find(query, sort);
+    }
+
+    private OnboardingGetResponse constructOnboardingGetResponse(Tuple2<List<Onboarding>, Long> tuple) {
+        OnboardingGetResponse onboardingGetResponse = new OnboardingGetResponse();
+        onboardingGetResponse.setCount(tuple.getItem2());
+        onboardingGetResponse.setItems(convertOnboardingListToResponse(tuple.getItem1()));
+        return onboardingGetResponse;
+    }
+
+    private List<OnboardingGet> convertOnboardingListToResponse(List<Onboarding> item1) {
+        return item1.stream()
+                .map(onboardingMapper::toGetResponse)
+                .toList();
+    }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -1,0 +1,79 @@
+package it.pagopa.selfcare.onboarding.util;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.Document;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodec;
+import org.bson.conversions.Bson;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor(access = AccessLevel.NONE)
+public class QueryUtils {
+
+    public static Document buildQuery(Map<String, String> parameters) {
+        if (!parameters.isEmpty()) {
+            return bsonToDocument(Filters.and(constructBsonFilter(parameters)));
+        } else {
+            return new Document();
+        }
+    }
+
+    /**
+     * The constructBsonFilter function takes a Map of parameters and returns a List of Bson objects.
+     * The function iterates over the entries in the parameter map, and for each entry it creates
+     * either an equality filter or a range filter depending on whether the key is &quot;from&quot; or &quot;to&quot;.
+     */
+    private static List<Bson> constructBsonFilter(Map<String, String> parameters) {
+        return parameters.entrySet().stream()
+                .map(entry -> {
+                    if (StringUtils.equalsIgnoreCase(entry.getKey(), "from")) {
+                        return Filters.gte(Onboarding.Fields.createdAt.name(), LocalDate.parse(entry.getValue(), DateTimeFormatter.ISO_LOCAL_DATE));
+                    } else if (StringUtils.equalsIgnoreCase(entry.getKey(), "to")) {
+                        return Filters.lt(Onboarding.Fields.createdAt.name(), LocalDate.parse(entry.getValue(), DateTimeFormatter.ISO_LOCAL_DATE).plusDays(1));
+                    }
+                    return Filters.eq(entry.getKey(), entry.getValue());
+                }).toList();
+    }
+
+    private static Document bsonToDocument(Bson bson) {
+        BsonDocument bsonDocument = bson.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+        DocumentCodec codec = new DocumentCodec();
+        DecoderContext decoderContext = DecoderContext.builder().build();
+        return codec.decode(new BsonDocumentReader(bsonDocument), decoderContext);
+    }
+
+    /**
+     * The createMapForOnboardingQueryParameter function creates a map of query parameters for the Onboarding Collection.
+     */
+    public static Map<String, String> createMapForOnboardingQueryParameter(String productId, String taxCode, String status, String from, String to) {
+        Map<String, String> queryParameterMap = new HashMap<>();
+        Optional.ofNullable(productId).ifPresent(value -> queryParameterMap.put("productId", value));
+        Optional.ofNullable(taxCode).ifPresent(value -> queryParameterMap.put("institution.taxCode", value));
+        Optional.ofNullable(status).ifPresent(value -> queryParameterMap.put("status", value));
+        Optional.ofNullable(from).ifPresent(value -> queryParameterMap.put("from", value));
+        Optional.ofNullable(to).ifPresent(value -> queryParameterMap.put("to", value));
+        return queryParameterMap;
+    }
+
+    /**
+     * The buildSortForOnboardingCollection function returns a Document object that represents the sort criteria for
+     * the Onboarding collection. The sort criteria is to order by descending creation date.
+     */
+    public static Document buildSortForOnboardingCollection() {
+        return bsonToDocument(Sorts.descending(Onboarding.Fields.createdAt.name()));
+    }
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -69,11 +69,11 @@ public class QueryUtils {
         return queryParameterMap;
     }
 
-    /**
-     * The buildSortForOnboardingCollection function returns a Document object that represents the sort criteria for
-     * the Onboarding collection. The sort criteria is to order by descending creation date.
-     */
-    public static Document buildSortForOnboardingCollection() {
-        return bsonToDocument(Sorts.descending(Onboarding.Fields.createdAt.name()));
+    public static Document buildSortDocument(String field, SortEnum order) {
+        if(SortEnum.ASC == order) {
+            return bsonToDocument(Sorts.ascending(field));
+        }else{
+            return bsonToDocument(Sorts.descending(field));
+        }
     }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/SortEnum.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/SortEnum.java
@@ -1,0 +1,6 @@
+package it.pagopa.selfcare.onboarding.util;
+
+public enum SortEnum {
+    ASC,
+    DESC
+}

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -10,6 +10,8 @@ import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.controller.request.*;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
+import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import org.junit.jupiter.api.Test;
@@ -89,17 +91,17 @@ public class OnboardingControllerTest {
     public void onboarding_shouldNotValidBody() {
 
         given()
-          .when()
+                .when()
                 .body(new OnboardingDefaultRequest())
                 .contentType(ContentType.JSON)
                 .post()
-          .then()
-             .statusCode(400);
+                .then()
+                .statusCode(400);
     }
 
     @ParameterizedTest
     @TestSecurity(user = "userJwt")
-    @ValueSource(strings = {"/psp","/pa"})
+    @ValueSource(strings = {"/psp", "/pa"})
     public void onboarding_shouldNotValidPspBody(String path) {
 
         given()
@@ -116,7 +118,7 @@ public class OnboardingControllerTest {
     public void onboarding() {
 
         Mockito.when(onboardingService.onboarding(any()))
-                        .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
+                .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
         given()
                 .when()
@@ -203,7 +205,7 @@ public class OnboardingControllerTest {
         File testFile = new File("src/test/resources/application.properties");
         String onboardingId = "actual-onboarding-id";
 
-        when(onboardingService.complete(any(),any()))
+        when(onboardingService.complete(any(), any()))
                 .thenReturn(Uni.createFrom().nullItem());
 
         given()
@@ -219,6 +221,28 @@ public class OnboardingControllerTest {
         verify(onboardingService, times(1))
                 .complete(expectedId.capture(), any());
         assertEquals(expectedId.getValue(), onboardingId);
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
+    void getOnboarding(){
+
+        OnboardingGet onboarding = new OnboardingGet();
+        onboarding.setId("id");
+        OnboardingGetResponse response = new OnboardingGetResponse();
+        response.setCount(1L);
+        response.setItems(List.of(onboarding));
+        when(onboardingService.onboardingGet(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(Uni.createFrom().item(response));
+
+        given()
+                .when()
+                .get()
+                .then()
+                .statusCode(200);
+
+        verify(onboardingService, times(1))
+                .onboardingGet(any(), any(), any(), any(), any(), any(), any());
     }
 
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -10,6 +10,7 @@ import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.controller.request.*;
+import it.pagopa.selfcare.onboarding.controller.response.InstitutionResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
@@ -22,7 +23,9 @@ import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -226,23 +229,45 @@ public class OnboardingControllerTest {
     @Test
     @TestSecurity(user = "userJwt")
     void getOnboarding(){
-
-        OnboardingGet onboarding = new OnboardingGet();
-        onboarding.setId("id");
-        OnboardingGetResponse response = new OnboardingGetResponse();
-        response.setCount(1L);
-        response.setItems(List.of(onboarding));
-        when(onboardingService.onboardingGet(any(), any(), any(), any(), any(), any(), any()))
+        OnboardingGetResponse response = getOnboardingGetResponse();
+        when(onboardingService.onboardingGet("prod-io", "taxCode", "ACTIVE", "2023-12-01", "2023-12-31", 0, 20))
                 .thenReturn(Uni.createFrom().item(response));
+
+        Map<String, String> queryParameterMap = getStringStringMap();
 
         given()
                 .when()
+                .queryParams(queryParameterMap)
                 .get()
                 .then()
                 .statusCode(200);
 
         verify(onboardingService, times(1))
-                .onboardingGet(any(), any(), any(), any(), any(), any(), any());
+                .onboardingGet("prod-io", "taxCode", "ACTIVE", "2023-12-01", "2023-12-31", 0, 20);
+    }
+
+    private static Map<String, String> getStringStringMap() {
+        Map<String, String> queryParameterMap = new HashMap<>();
+        queryParameterMap.put("productId","prod-io");
+        queryParameterMap.put("taxCode","taxCode");
+        queryParameterMap.put("from","2023-12-01");
+        queryParameterMap.put("to","2023-12-31");
+        queryParameterMap.put("status","ACTIVE");
+        return queryParameterMap;
+    }
+
+    private static OnboardingGetResponse getOnboardingGetResponse() {
+        OnboardingGet onboarding = new OnboardingGet();
+        onboarding.setId("id");
+        onboarding.setStatus("ACTIVE");
+        onboarding.setProductId("prod-io");
+        InstitutionResponse institutionResponse = new InstitutionResponse();
+        institutionResponse.setTaxCode("taxCode");
+        onboarding.setInstitution(institutionResponse);
+        OnboardingGetResponse response = new OnboardingGetResponse();
+        response.setCount(1L);
+        response.setItems(List.of(onboarding));
+        return response;
     }
 
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.service;
 
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
 import io.quarkus.panache.mock.PanacheMock;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -909,6 +910,20 @@ public class OnboardingServiceDefaultTest {
 
         asserter.assertThat(() -> onboardingService.complete(onboarding.getId().toHexString(), testFile),
                 Assertions::assertNotNull);
+    }
+    @Test
+    @RunOnVertxContext
+    void testOnboardingGet(UniAsserter asserter) {
+        int page = 0, size = 3;
+        mockFindOnboarding();
+        asserter.assertThat(() -> onboardingService.onboardingGet("prod-io", null, null, "2023-11-10", "2021-12-10", page,size),
+                Assertions::assertNotNull);
+    }
+
+    private void mockFindOnboarding() {
+        Onboarding onboarding = createDummyOnboarding();
+        ReactivePanacheQuery<Onboarding> query = mock(ReactivePanacheQuery.class);
+        when(query.list()).thenReturn(Uni.createFrom().item(List.of(onboarding)));
     }
 
     private void mockFindToken(UniAsserter asserter, String onboardingId) {

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.onboarding.service;
 
 import io.quarkus.mongodb.panache.common.reactive.ReactivePanacheUpdate;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheQuery;
 import io.quarkus.panache.mock.PanacheMock;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.common.QuarkusTestResource;


### PR DESCRIPTION
#### List of Changes

Added API for get Onboarding with optional filters and pagination

#### Motivation and Context

An API is needed to retrieve onboardings

#### How Has This Been Tested?
tested in dev mode.
Called new API with single, multiple or none filters, and with different pageNumber and pageSize.

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.