### PR TITLE
[SELC-2865] Feat: added new API for delete Onboarding

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -118,4 +118,14 @@ public class OnboardingController {
                         .status(HttpStatus.SC_NO_CONTENT)
                         .build());
     }
+
+    @PUT
+    @Path("/{onboardingId}/delete")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Uni<Response> delete(@PathParam(value = "onboardingId") String onboardingId) {
+        return onboardingService.deleteOnboarding(onboardingId)
+                .map(ignore -> Response
+                        .status(HttpStatus.SC_NO_CONTENT)
+                        .build());
+    }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -8,6 +8,7 @@ import it.pagopa.selfcare.onboarding.controller.request.ContractRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingImportContract;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldNameConstants;
 import org.bson.types.ObjectId;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
+@FieldNameConstants(asEnum = true)
 @MongoEntity(collection="onboardings")
 public class Onboarding extends ReactivePanacheMongoEntity  {
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.onboarding.service;
 
 import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
@@ -23,4 +24,6 @@ public interface OnboardingService {
     Uni<Onboarding> complete(String tokenId, File contract);
 
     Uni<Onboarding> completeWithoutSignatureVerification(String tokenId, File contract);
+
+    Uni<Long> deleteOnboarding(String onboardingId);
 }

--- a/libs/onboarding-sdk-common/src/main/java/it/pagopa/selfcare/onboarding/common/OnboardingStatus.java
+++ b/libs/onboarding-sdk-common/src/main/java/it/pagopa/selfcare/onboarding/common/OnboardingStatus.java
@@ -4,5 +4,6 @@ public enum OnboardingStatus {
     PENDING,
     COMPLETED,
     FAILED,
-    REJECTED
+    REJECTED,
+    DELETED
 }


### PR DESCRIPTION
#### List of Changes

- Added new API for Onboarding logical deletion. 
- Added new Onboarding Status DELETED

#### Motivation and Context

A new API is required for logical deletion of onboarding, by updating the status to DELETED

#### How Has This Been Tested?

tested in dev mode.
Called new API with 3 cases:

- Valid OnboardingId to update -> 204, status updated
- OnboardingId with wrong format -->  INVALID REQUEST with custom message
- OnboardingId already DELETED or NOT_FOUND --> INVALID REQUEST with custom message
- OnboardingId already NOT_FOUND --> INVALID REQUEST with custom message

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.