### PR TITLE
[SELC-3506] feat: persist sending contract path and id

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -4,10 +4,12 @@ import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.entity.Token;
 import it.pagopa.selfcare.onboarding.exception.GenericOnboardingException;
 import it.pagopa.selfcare.onboarding.mapper.InstitutionMapper;
 import it.pagopa.selfcare.onboarding.mapper.UserMapper;
 import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
+import it.pagopa.selfcare.onboarding.repository.TokenRepository;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -48,6 +50,9 @@ public class CompletionServiceDefault implements CompletionService {
 
     @Inject
     OnboardingRepository onboardingRepository;
+
+    @Inject
+    TokenRepository tokenRepository;
 
     @Inject
     UserMapper userMapper;
@@ -170,6 +175,7 @@ public class CompletionServiceDefault implements CompletionService {
         );
         onboardingRequest.pricingPlan(onboarding.getPricingPlan());
         onboardingRequest.productId(onboarding.getProductId());
+        onboardingRequest.setTokenId(onboarding.getOnboardingId());
 
         if(Objects.nonNull(onboarding.getBilling())) {
             BillingRequest billingRequest = new BillingRequest();
@@ -178,6 +184,10 @@ public class CompletionServiceDefault implements CompletionService {
             billingRequest.vatNumber(onboarding.getBilling().getVatNumber());
             onboardingRequest.billing(billingRequest);
         }
+
+        //If contract exists we send the path of the contract
+        Optional<Token> optToken = tokenRepository.findByOnboardingId(onboarding.getOnboardingId());
+        optToken.ifPresent(token -> onboardingRequest.setContractPath(token.getContractFilename()));
 
         institutionApi.onboardingInstitutionUsingPOST(onboarding.getInstitution().getId(), onboardingRequest);
     }

--- a/apps/onboarding-functions/src/main/openapi/core.json
+++ b/apps/onboarding-functions/src/main/openapi/core.json
@@ -6155,10 +6155,16 @@
           "billing" : {
             "$ref" : "#/components/schemas/BillingRequest"
           },
+          "contractPath" : {
+            "type" : "string"
+          },
           "pricingPlan" : {
             "type" : "string"
           },
           "productId" : {
+            "type" : "string"
+          },
+          "tokenId" : {
             "type" : "string"
           },
           "users" : {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Update persist onboarding step sending also contractPath and onboardingId

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When persist an onboarding, ms-core send notification to queue with institution and onboarding data. ContractPath and onboardingId are needed about notification.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.