### PR TITLE
feat: save and persist contract signed path when onboarding

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -187,7 +187,7 @@ public class CompletionServiceDefault implements CompletionService {
 
         //If contract exists we send the path of the contract
         Optional<Token> optToken = tokenRepository.findByOnboardingId(onboarding.getOnboardingId());
-        optToken.ifPresent(token -> onboardingRequest.setContractPath(token.getContractFilename()));
+        optToken.ifPresent(token -> onboardingRequest.setContractPath(token.getContractSigned()));
 
         institutionApi.onboardingInstitutionUsingPOST(onboarding.getInstitution().getId(), onboardingRequest);
     }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -220,7 +220,7 @@ public class CompletionServiceDefaultTest {
         when(institutionApi.onboardingInstitutionUsingPOST(any(), any()))
                 .thenReturn(new InstitutionResponse());
         Token token = new Token();
-        token.setContractFilename("contract-filename");
+        token.setContractSigned("contract-signed-path");
         when(tokenRepository.findByOnboardingId(onboarding.getOnboardingId()))
                 .thenReturn(Optional.of(token));
 
@@ -239,7 +239,7 @@ public class CompletionServiceDefaultTest {
         assertEquals(1, actual.getUsers().size());
         assertEquals(MANAGER_WORKCONTRACT_MAIL, actual.getUsers().get(0).getEmail());
         assertEquals(manager.getRole().name(), actual.getUsers().get(0).getRole().name());
-        assertEquals(token.getContractFilename(), actual.getContractPath());
+        assertEquals(token.getContractSigned(), actual.getContractPath());
     }
 
     @Test

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -442,7 +442,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                         .onItem().transformToUni(product -> verifyAlreadyOnboardingForProductAndProductParent(onboarding, product))
                 )
                 //Upload contract on storage
-                .onItem().transformToUni(onboarding -> uploadSignedContract(onboardingId, contract)
+                .onItem().transformToUni(onboarding -> uploadSignedContractAndUpdateToken(onboardingId, contract)
                             .map(ignore -> onboarding))
                 // Start async activity if onboardingOrchestrationEnabled is true
                 .onItem().transformToUni(onboarding -> onboardingOrchestrationEnabled
@@ -451,7 +451,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                         : Uni.createFrom().item(onboarding));
     }
 
-    private Uni<String> uploadSignedContract(String onboardingId, File contract) {
+    private Uni<String> uploadSignedContractAndUpdateToken(String onboardingId, File contract) {
         return retrieveToken(onboardingId)
             .onItem().transformToUni(token -> Uni.createFrom().item(Unchecked.supplier(() -> {
                     final String path = String.format("%s%s", pathContracts, onboardingId);
@@ -464,7 +464,11 @@ public class OnboardingServiceDefault implements OnboardingService {
                                 "Error on upload contract for onboarding with id " + onboardingId);
                     }
                 }))
-                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool()));
+                .runSubscriptionOn(Infrastructure.getDefaultWorkerPool())
+                .onItem().transformToUni(filepath -> Token.update("contractSigned", filepath)
+                                .where("_id", token.getId())
+                                .replaceWith(filepath))
+            );
     }
 
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -55,6 +55,7 @@ import java.util.*;
 import static it.pagopa.selfcare.onboarding.common.ProductId.PROD_INTEROP;
 import static it.pagopa.selfcare.onboarding.service.OnboardingServiceDefault.USERS_FIELD_TAXCODE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 
@@ -851,6 +852,10 @@ class OnboardingServiceDefaultTest {
         mockSimpleProductValidAssert(onboarding.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
+        final String filepath = "upload-file-path";
+        when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn(filepath);
+        mockUpdateToken(asserter, filepath);
+
         asserter.assertThat(() -> onboardingService.completeWithoutSignatureVerification(onboarding.getId().toHexString(), testFile),
                 Assertions::assertNotNull);
 
@@ -908,7 +913,9 @@ class OnboardingServiceDefaultTest {
         mockSimpleProductValidAssert(onboarding.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
-        when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn("upload-file");
+        final String filepath = "upload-file-path";
+        when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn(filepath);
+        mockUpdateToken(asserter, filepath);
 
         asserter.assertThat(() -> onboardingService.complete(onboarding.getId().toHexString(), testFile),
                 Assertions::assertNotNull);
@@ -920,6 +927,17 @@ class OnboardingServiceDefaultTest {
         asserter.execute(() -> PanacheMock.mock(Token.class));
         asserter.execute(() -> when(Token.list("onboardingId", onboardingId))
                 .thenReturn(Uni.createFrom().item(List.of(token))));
+    }
+
+    private void mockUpdateToken(UniAsserter asserter, String filepath) {
+
+        //Mock token updat
+        asserter.execute(() -> PanacheMock.mock(Token.class));
+        ReactivePanacheUpdate panacheUpdate = mock(ReactivePanacheUpdate.class);
+        asserter.execute(() -> when(panacheUpdate.where("contractSigned", filepath))
+                .thenReturn(Uni.createFrom().item(1L)));
+        asserter.execute(() -> when(Token.update(anyString(),any(Object[].class)))
+                .thenReturn(panacheUpdate));
     }
 
     private Onboarding createDummyOnboarding() {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added functionality for saving the path of the signed contract in the attribute '_contractSigned_'.
* Modified the 'persistOnboarding' call to 'ms-core' to include the 'contractSigned' attribute.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change is required to enhance the onboarding process by ensuring that the path of the signed and validated contract is stored and subsequently sent to 'ms-core' for persistence. This addition will allow the path to be included in the event queue.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.