### PR TITLE
[SELC-3577] feat: functions for purge durable history table

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/PurgeConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/PurgeConfig.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.onboarding.config;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "onboarding-functions.purge")
+public interface PurgeConfig {
+
+    Long completedFrom();
+    Long completedTo();
+    Long allFrom();
+    Long allTo();
+
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/CommonFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/CommonFunctions.java
@@ -2,10 +2,22 @@ package it.pagopa.selfcare.onboarding.functions;
 
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.TimerTrigger;
+import com.microsoft.durabletask.OrchestrationRuntimeStatus;
+import com.microsoft.durabletask.PurgeInstanceCriteria;
+import com.microsoft.durabletask.PurgeResult;
 import com.microsoft.durabletask.azurefunctions.DurableActivityTrigger;
+import com.microsoft.durabletask.azurefunctions.DurableClientContext;
+import com.microsoft.durabletask.azurefunctions.DurableClientInput;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.config.PurgeConfig;
 import it.pagopa.selfcare.onboarding.functions.utils.SaveOnboardingStatusInput;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 public class CommonFunctions {
 
@@ -14,8 +26,11 @@ public class CommonFunctions {
 
     private final OnboardingService service;
 
-    public CommonFunctions(OnboardingService service) {
+    private final PurgeConfig purgeConfig;
+
+    public CommonFunctions(OnboardingService service, PurgeConfig purgeConfig) {
         this.service = service;
+        this.purgeConfig = purgeConfig;
     }
 
     @FunctionName(SAVE_ONBOARDING_STATUS_ACTIVITY)
@@ -23,5 +38,30 @@ public class CommonFunctions {
         SaveOnboardingStatusInput saveOnboardingStatusInput = SaveOnboardingStatusInput.readJsonString(saveOnboardingStatusInputString);
         context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, SAVE_ONBOARDING_STATUS_ACTIVITY, saveOnboardingStatusInput.getOnboardingId()));
         service.savePendingState(saveOnboardingStatusInput.getOnboardingId(), OnboardingStatus.valueOf(saveOnboardingStatusInput.getStatus()));
+    }
+
+    @FunctionName("PurgeInstancesCompleted")
+    public void purgeInstances(
+            @TimerTrigger(name = "purgeTimer", schedule = "0 0 11 * * *") String timerInfo,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            ExecutionContext context) throws TimeoutException {
+        PurgeInstanceCriteria criteria = new PurgeInstanceCriteria()
+                .setCreatedTimeFrom(Instant.now().minus(Duration.ofDays(purgeConfig.completedFrom())))
+                .setCreatedTimeTo(Instant.now().minus(Duration.ofDays(purgeConfig.completedTo())))
+                .setRuntimeStatusList(List.of(OrchestrationRuntimeStatus.COMPLETED));
+        PurgeResult result = durableContext.getClient().purgeInstances(criteria);
+        context.getLogger().info(String.format("Purged %d instance(s)", result.getDeletedInstanceCount()));
+    }
+
+    @FunctionName("PurgeInstancesAll")
+    public void purgeInstancesAll(
+            @TimerTrigger(name = "purgeTimer", schedule = "0 0 12 * * *") String timerInfo,
+            @DurableClientInput(name = "durableContext") DurableClientContext durableContext,
+            ExecutionContext context) throws TimeoutException {
+        PurgeInstanceCriteria criteria = new PurgeInstanceCriteria()
+                .setCreatedTimeFrom(Instant.now().minus(Duration.ofDays(purgeConfig.allFrom())))
+                .setCreatedTimeTo(Instant.now().minus(Duration.ofDays(purgeConfig.allTo())));
+        PurgeResult result = durableContext.getClient().purgeInstances(criteria);
+        context.getLogger().info(String.format("Purged %d instance(s)", result.getDeletedInstanceCount()));
     }
 }

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -9,9 +9,16 @@ quarkus.index-dependency.commons.artifact-id=selc-commons-base
 quarkus.index-dependency.onboarding.group-id=it.pagopa.selfcare
 quarkus.index-dependency.onboarding.artifact-id=onboarding-sdk-common
 
+## RETRY POLICY FUNCTION ##
+# Max number of attempts: The maximum number of attempts. If set to 1, there will be no retry.
+# First retry interval: The amount of time to wait before the first retry attempt.
+# Backoff coefficient: The coefficient used to determine rate of increase of backoff. Defaults to 1.
 onboarding-functions.retry.max-attempts = 5
 onboarding-functions.retry.first-retry-interval = 30
 onboarding-functions.retry.backoff-coefficient = 5
+
+## PURGE FUNCTION ##
+# configuration for the start and end dates of the two functions
 onboarding-functions.purge.completed-from = 60
 onboarding-functions.purge.completed-to = 30
 onboarding-functions.purge.all-from = 150

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -12,6 +12,10 @@ quarkus.index-dependency.onboarding.artifact-id=onboarding-sdk-common
 onboarding-functions.retry.max-attempts = 5
 onboarding-functions.retry.first-retry-interval = 30
 onboarding-functions.retry.backoff-coefficient = 5
+onboarding-functions.purge.completed-from = 60
+onboarding-functions.purge.completed-to = 30
+onboarding-functions.purge.all-from = 150
+onboarding-functions.purge.all-to = 120
 
 ## REST CLIENT #
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added two scheduled functions for executing purge history based on start and end dates.
* The '**PurgeInstancesCompleted**' function performs the purge of only COMPLETED workflows with a static schedule at 11 AM daily.
* The '**PurgeInstancesAll**' function performs the purge of all workflows with a static schedule at 12 PM daily.
* Added configuration for the start and end dates of the two functions, currently set to 60 to 30 days and 150 to 120 days respectively.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Azure Durable Functions used for executing workflows save metadata on Azure storage. If not appropriately purged, these data can accumulate, unnecessarily filling the storage and consuming resources. To address this, Azure provides APIs for purging the history of Durable Functions. The changes introduced in this pull request leverage these APIs to automate the purging process, ensuring efficient management of storage resources by scheduling the deletion of historical data at specified intervals.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.