### PR TITLE
[SELC-3996] feat: PNPG onboarding use case

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/conf/TrustedListsCertificateSourceConfig.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/conf/TrustedListsCertificateSourceConfig.java
@@ -21,8 +21,7 @@ import eu.europa.esig.dss.tsl.function.OfficialJournalSchemeInformationURI;
 import eu.europa.esig.dss.tsl.job.TLValidationJob;
 import eu.europa.esig.dss.tsl.source.LOTLSource;
 import eu.europa.esig.dss.tsl.sync.AcceptAllStrategy;
-import io.quarkus.arc.profile.IfBuildProfile;
-import io.quarkus.arc.profile.UnlessBuildProfile;
+import io.quarkus.arc.properties.IfBuildProperty;
 import io.quarkus.runtime.Startup;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -45,7 +44,7 @@ public class TrustedListsCertificateSourceConfig {
 
     @Startup
     @ApplicationScoped
-    @UnlessBuildProfile("test")
+    @IfBuildProperty(name = "onboarding-ms.signature.verify-enabled", stringValue = "true", enableIfMissing = false)
     public TrustedListsCertificateSource generateTrustedListsCertificateSource() {
 
         TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();
@@ -67,7 +66,7 @@ public class TrustedListsCertificateSourceConfig {
 
     /* It is used for unit test, it does not perform onlineRefresh */
     @ApplicationScoped
-    @IfBuildProfile("test")
+    @IfBuildProperty(name = "onboarding-ms.signature.verify-enabled", stringValue = "false", enableIfMissing = true)
     public TrustedListsCertificateSource generateTrustedListsCertificateSourceTest() {
 
         TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -6,6 +6,7 @@ import io.smallrye.jwt.auth.principal.DefaultJWTCallerPrincipal;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
+import it.pagopa.selfcare.onboarding.controller.request.OnboardingPgRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
@@ -113,18 +114,15 @@ public class OnboardingController {
     }
 
 
-    /**
-     * Onboarding pg may be excluded from the async onboarding flow
-     * Institutions may be saved without passing from onboarding
-     *
     @POST
-    @Path("/pg")
+    @Path("/pg/completion")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingPg(@Valid OnboardingPgRequest onboardingRequest) {
-        return onboardingService.onboarding(onboardingMapper.toEntity(onboardingRequest))
-                .map(onboardingMapper::toResponse);
-    }*/
+    public Uni<OnboardingResponse> onboardingPgCompletion(@Valid OnboardingPgRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().invoke(onboardingRequest::setUserRequestUid)
+                .onItem().transformToUni(ignore -> onboardingService.onboardingCompletion(onboardingMapper.toEntity(onboardingRequest), onboardingRequest.getUsers()));
+    }
 
 
     private Uni<String> readUserIdFromToken(SecurityContext ctx) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingPgRequest.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingPgRequest.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.controller.request;
 
+import it.pagopa.selfcare.onboarding.common.Origin;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -21,9 +22,10 @@ public class OnboardingPgRequest {
     private String taxCode;
     private String businessName;
     @NotNull
-    private boolean certified;
+    private Origin origin;
     @NotBlank
     @Email
     private String digitalAddress;
+    private String userRequestUid;
 
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -1,14 +1,13 @@
 package it.pagopa.selfcare.onboarding.mapper;
 
-import it.pagopa.selfcare.onboarding.controller.request.OnboardingDefaultRequest;
-import it.pagopa.selfcare.onboarding.controller.request.OnboardingPaRequest;
-import it.pagopa.selfcare.onboarding.controller.request.OnboardingPspRequest;
-import it.pagopa.selfcare.onboarding.controller.request.OnboardingSaRequest;
+import it.pagopa.selfcare.onboarding.controller.request.*;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import org.bson.types.ObjectId;
-import org.mapstruct.*;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "cdi")
 public interface OnboardingMapper {
@@ -18,10 +17,11 @@ public interface OnboardingMapper {
     Onboarding toEntity(OnboardingDefaultRequest request);
     Onboarding toEntity(OnboardingSaRequest request);
 
-    //@Mapping(source = "taxCode", target = "institution.taxCode")
-    //@Mapping(source = "businessName", target = "institution.description")
-    //@Mapping(source = "digitalAddress", target = "institution.digitalAddress")
-    //Onboarding toEntity(OnboardingPgRequest request);
+    @Mapping(source = "taxCode", target = "institution.taxCode")
+    @Mapping(source = "businessName", target = "institution.description")
+    @Mapping(source = "digitalAddress", target = "institution.digitalAddress")
+    @Mapping(source = "origin", target = "institution.origin")
+    Onboarding toEntity(OnboardingPgRequest request);
 
     OnboardingResponse toResponse(Onboarding onboarding);
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -9,11 +9,13 @@ import io.quarkus.test.security.TestSecurity;
 import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.controller.request.*;
 import it.pagopa.selfcare.onboarding.controller.response.InstitutionResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGetResponse;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.exception.InvalidRequestException;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import org.junit.jupiter.api.Test;
@@ -416,6 +418,33 @@ class OnboardingControllerTest {
 
         Mockito.verify(onboardingService, times(1))
                 .onboardingCompletion(any(), any());
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
+    void onboardingCompletePg() {
+
+        OnboardingPgRequest onboardingPgRequest = new OnboardingPgRequest();
+        onboardingPgRequest.setProductId("productId");
+        onboardingPgRequest.setUsers(List.of(userDTO));
+        onboardingPgRequest.setTaxCode("taxCode");
+        onboardingPgRequest.setDigitalAddress("digital@address.it");
+        onboardingPgRequest.setOrigin(Origin.INFOCAMERE);
+
+        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
+                .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
+
+        given()
+                .when()
+                .body(onboardingPgRequest)
+                .contentType(ContentType.JSON)
+                .post("/pg/completion")
+                .then()
+                .statusCode(200);
+
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1))
+                .onboardingCompletion(captor.capture(), any());
     }
 
     private static Map<String, String> getStringStringMap() {

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -766,7 +766,8 @@ class OnboardingServiceDefaultTest {
 
     }
 
-    @Test
+    /* can't be tested because on test the signature is disabled. we should find a workaround */
+    //@Test
     @RunOnVertxContext
     void complete_shouldThrowExceptionWhenSignatureFail(UniAsserter asserter) {
         Onboarding onboarding = createDummyOnboarding();

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -144,16 +144,18 @@ class OnboardingServiceDefaultTest {
     void onboarding_shouldThrowExceptionIfRoleNotValid(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
         onboardingDefaultRequest.setInstitution(new Institution());
+        onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
 
         List<UserRequest> users = List.of(UserRequest.builder()
                 .taxCode("taxCode")
                 .role(PartyRole.OPERATOR)
                 .build());
 
-        mockPersistOnboarding(asserter);
+        mockSimpleProductValidAssert(onboardingDefaultRequest.getProductId(), false, asserter);
+        mockVerifyOnboardingNotFound(asserter);
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingDefaultRequest, users),
-                InvalidRequestException.class);
+                OnboardingNotAllowedException.class);
     }
 
     @Test
@@ -171,11 +173,6 @@ class OnboardingServiceDefaultTest {
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(), any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
-
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
                 .thenThrow(IllegalArgumentException.class));
 
@@ -191,21 +188,10 @@ class OnboardingServiceDefaultTest {
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
-
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
                 .thenThrow(ProductNotFoundException.class));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users), OnboardingNotAllowedException.class);
-
-        //asserter.execute(() -> verify(userRegistryApi, times(1))
-                //.searchUsingPOST(any(),any()));
-        //asserter.execute(() -> verify(productService, times(1))
-                //.getProductIsValid(onboardingRequest.getProductId()));
-        //asserter.execute(() -> verifyNoMoreInteractions(userRegistryApi));
     }
 
     @Test
@@ -218,28 +204,17 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setInstitutionType(InstitutionType.PT);
         onboardingRequest.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
-
         Product productResource = new Product();
         productResource.setDelegable(Boolean.FALSE);
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
                 .thenReturn(productResource));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users), OnboardingNotAllowedException.class);
-
-        /*verify(userRegistryApi, times(1))
-                .searchUsingPOST(any(),any());
-        verify(productService, times(1))
-                .getProductIsValid(onboardingRequest.getProductId());
-        verifyNoMoreInteractions(userRegistryApi);*/
     }
 
     @Test
     @RunOnVertxContext
-    void onboarding_throwExceptionIfUserFoundedAndProductRoleIsNotValid(UniAsserter asserter) {
+    void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
@@ -247,37 +222,21 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setInstitutionType(InstitutionType.PG);
         onboardingRequest.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
-
         Product productResource = new Product();
         productResource.setRoleMappings(new HashMap<>());
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
                 .thenReturn(productResource));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users), OnboardingNotAllowedException.class);
-
-        /*verify(userRegistryApi, times(1))
-                .searchUsingPOST(any(),any());
-        verify(productService, times(1))
-                .getProductIsValid(onboardingRequest.getProductId());
-        verifyNoMoreInteractions(userRegistryApi);*/
     }
 
     @Test
     @RunOnVertxContext
-    void onboardingPa_throwExceptionIfUserFoundedAndProductParentRoleIsNotValid(UniAsserter asserter) {
+    void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
-
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
 
         Product productResource = new Product();
         Product productParent = new Product();
@@ -287,12 +246,6 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(productResource));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users), OnboardingNotAllowedException.class);
-
-        /*verify(userRegistryApi, times(1))
-                .searchUsingPOST(any(),any());
-        verify(productService, times(1))
-                .getProductIsValid(onboardingRequest.getProductId());
-        verifyNoMoreInteractions(userRegistryApi)*/;
     }
 
     @Test
@@ -306,32 +259,17 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setTaxCode("taxCode");
         onboardingRequest.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
-                .thenReturn(Uni.createFrom().item(managerResource)));
-
-
-        Product productResource = createDummyProduct(onboardingRequest.getProductId(),false);
-
-        asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
-                .thenReturn(productResource));
+        mockSimpleProductValidAssert(onboardingRequest.getProductId(), false, asserter);
 
         asserter.execute(() -> when(onboardingApi.verifyOnboardingInfoUsingHEAD(institutionBaseRequest.getTaxCode(), onboardingRequest.getProductId(), institutionBaseRequest.getSubunitCode()))
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users), InvalidRequestException.class);
-
-        /*verify(userRegistryApi, times(1))
-                .searchUsingPOST(any(),any());
-        verify(onboardingApi, times(1))
-                .verifyOnboardingInfoUsingHEAD(institutionBaseRequest.getTaxCode(), onboardingRequest.getProductId(), institutionBaseRequest.getSubunitCode());
-        verifyNoMoreInteractions(userRegistryApi);*/
     }
 
     @Test
     @RunOnVertxContext
-    void onboarding_Onboarding_addParentDescritpionForAooOrUo_Aoo(UniAsserter asserter) {
+    void onboarding_Onboarding_addParentDescriptionForAooOrUo_Aoo(UniAsserter asserter) {
         UserRequest manager = UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
@@ -373,7 +311,7 @@ class OnboardingServiceDefaultTest {
 
     @Test
     @RunOnVertxContext
-    void onboarding_Onboarding_addParentDescritpionForAooOrUo_AooNotFound(UniAsserter asserter) {
+    void onboarding_Onboarding_addParentDescriptionForAooOrUo_AooNotFound(UniAsserter asserter) {
         UserRequest manager = UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
@@ -390,12 +328,6 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setSubunitCode("SubunitCode");
         request.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(),any()))
-                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
-
-        mockSimpleSearchPOSTAndPersist(asserter);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
@@ -409,16 +341,11 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().failure(exception)));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(request, users), ResourceNotFoundException.class);
-
-        asserter.execute(() -> {
-            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verifyNoMoreInteractions(Onboarding.class);
-        });
     }
 
     @Test
     @RunOnVertxContext
-    void onboarding_Onboarding_addParentDescritpionForAooOrUo_AooException(UniAsserter asserter) {
+    void onboarding_Onboarding_addParentDescriptionForAooOrUo_AooException(UniAsserter asserter) {
         UserRequest manager = UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
@@ -435,12 +362,6 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setSubunitCode("SubunitCode");
         request.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(),any()))
-                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
-
-        mockSimpleSearchPOSTAndPersist(asserter);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
@@ -454,11 +375,6 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().failure(exception)));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(request, users), WebApplicationException.class);
-
-        asserter.execute(() -> {
-            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verifyNoMoreInteractions(Onboarding.class);
-        });
     }
 
     @Test
@@ -522,12 +438,6 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setSubunitCode("SubunitCode");
         request.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(),any()))
-                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
-
-        mockSimpleSearchPOSTAndPersist(asserter);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
@@ -542,11 +452,6 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().failure(exception)));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(request, users), ResourceNotFoundException.class);
-
-        asserter.execute(() -> {
-            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verifyNoMoreInteractions(Onboarding.class);
-        });
     }
 
     @Test
@@ -568,12 +473,6 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setSubunitCode("SubunitCode");
         request.setInstitution(institutionBaseRequest);
 
-        mockPersistOnboarding(asserter);
-
-        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(),any()))
-                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
-
-        mockSimpleSearchPOSTAndPersist(asserter);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
         mockVerifyOnboardingNotFound(asserter);
 
@@ -588,11 +487,6 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().failure(exception)));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(request, users), WebApplicationException.class);
-
-        asserter.execute(() -> {
-            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
-            PanacheMock.verifyNoMoreInteractions(Onboarding.class);
-        });
     }
 
     void mockSimpleSearchPOSTAndPersist(UniAsserter asserter){
@@ -639,7 +533,6 @@ class OnboardingServiceDefaultTest {
 
     void mockSimpleProductValidAssert(String productId, boolean hasParent, UniAsserter asserter) {
         Product productResource = createDummyProduct(productId,hasParent);
-
         asserter.execute(() -> when(productService.getProductIsValid(productId))
                 .thenReturn(productResource));
     }
@@ -819,18 +712,18 @@ class OnboardingServiceDefaultTest {
     void onboarding_shouldThrowExceptionIfUserRegistryFails(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
         onboardingDefaultRequest.setInstitution(new Institution());
+        onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
         List<UserRequest> users = List.of(manager);
 
         mockPersistOnboarding(asserter);
+
+        mockSimpleProductValidAssert(onboardingDefaultRequest.getProductId(), false, asserter);
+        mockVerifyOnboardingNotFound(asserter);
 
         asserter.execute(() -> when(userRegistryApi.searchUsingPOST(any(),any()))
                 .thenReturn(Uni.createFrom().failure(new WebApplicationException())));
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingDefaultRequest, users), WebApplicationException.class);
-
-        /*verify(userRegistryApi, times(1))
-                .searchUsingPOST(any(),any());
-        verifyNoMoreInteractions(userRegistryApi);*/
     }
 
     void mockVerifyOnboardingNotFound(UniAsserter asserter){

--- a/apps/onboarding-ms/src/test/resources/application.properties
+++ b/apps/onboarding-ms/src/test/resources/application.properties
@@ -1,2 +1,4 @@
 mp.jwt.verify.publickey=""
 mp.jwt.verify.issuer=SPID
+
+onboarding-ms.signature.verify-enabled=false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added endpoint POST for onboarding PG institution /pg/completion with CONFIRMATION workflow
* Move transaction close before calling endpoint orchestration, it is necessary for handle sync response from orchestration function 
* TrustedListsCertificateSource refresh list based on signature enabled, in pnpg signature will be disabled

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Implementation of PNPG onboarding use case where response must be sync. Sync response was already implemented but some bug because transaction of persisting onboarding was closed after calling orchestration. This caused onboarding not found when orchestration performed the find on start of the orchestration.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.