### PR TITLE
[SELC-4041] feat: onboarding test environment products configured by testEnvProductIds

### DIFF
--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -21,7 +21,7 @@
     <quarkus.platform.version>3.5.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.1.7</onboarding-sdk.version>
+    <onboarding-sdk.version>0.1.8</onboarding-sdk.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -17,6 +17,7 @@ public class Onboarding  {
 
     private String onboardingId;
     private String productId;
+    private List<String> testEnvProductIds;
     private WorkflowType workflowType;
     private Institution institution;
     private List<User> users;
@@ -133,5 +134,13 @@ public class Onboarding  {
 
     public void setWorkflowInstanceId(String workflowInstanceId) {
         this.workflowInstanceId = workflowInstanceId;
+    }
+
+    public List<String> getTestEnvProductIds() {
+        return testEnvProductIds;
+    }
+
+    public void setTestEnvProductIds(List<String> testEnvproductIds) {
+        this.testEnvProductIds = testEnvproductIds;
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -179,9 +179,9 @@ public class OnboardingFunctions {
     }
 
     @FunctionName(CREATE_INSTITUTION_ACTIVITY)
-    public void createInstitutionAndPersistInstitutionId(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
+    public String createInstitutionAndPersistInstitutionId(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
         context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, CREATE_INSTITUTION_ACTIVITY, onboardingString));
-        completionService.createInstitutionAndPersistInstitutionId(readOnboardingValue(objectMapper, onboardingString));
+        return completionService.createInstitutionAndPersistInstitutionId(readOnboardingValue(objectMapper, onboardingString));
     }
 
     @FunctionName(CREATE_ONBOARDING_ACTIVITY)

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -178,21 +178,10 @@ public class OnboardingFunctions {
         service.sendMailOnboardingApprove(readOnboardingValue(objectMapper, onboardingString));
     }
 
-    /**
-     * This is the activity function that gets invoked by the orchestrator function.
-     */
-    @FunctionName(SEND_MAIL_CONFIRMATION_ACTIVITY)
-    public String sendMailConfirmation(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
-        context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, SEND_MAIL_CONFIRMATION_ACTIVITY, onboardingString));
-        throw new RuntimeException("");
-    }
-
-
-
     @FunctionName(CREATE_INSTITUTION_ACTIVITY)
-    public String createInstitutionAndPersistInstitutionId(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
+    public void createInstitutionAndPersistInstitutionId(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
         context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, CREATE_INSTITUTION_ACTIVITY, onboardingString));
-        return completionService.createInstitutionAndPersistInstitutionId(readOnboardingValue(objectMapper, onboardingString));
+        completionService.createInstitutionAndPersistInstitutionId(readOnboardingValue(objectMapper, onboardingString));
     }
 
     @FunctionName(CREATE_ONBOARDING_ACTIVITY)

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -10,7 +10,6 @@ public class ActivityName {
     public static final String SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY = "SendMailRegistrationRequest";
     public static final String SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY = "SendMailRegistrationApprove";
     public static final String SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY = "SendMailOnboardingApprove";
-    public static final String SEND_MAIL_CONFIRMATION_ACTIVITY = "SendMailConfirmation";
 
 
     public static final String ONBOARDING_COMPLETION_ACTIVITY = "OnboardingCompletion";

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
@@ -1,15 +1,20 @@
 package it.pagopa.selfcare.onboarding.workflow;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.durabletask.Task;
 import com.microsoft.durabletask.TaskOptions;
 import com.microsoft.durabletask.TaskOrchestrationContext;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
 import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingString;
+import static it.pagopa.selfcare.onboarding.utils.Utils.readOnboardingValue;
 
 public interface WorkflowExecutor {
 
@@ -32,15 +37,32 @@ public interface WorkflowExecutor {
     }
 
     default Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding) {
-        String onboardingString = getOnboardingString(objectMapper(), onboarding);
+        final String onboardingString = getOnboardingString(objectMapper(), onboarding);
 
         //CreateInstitution activity return an institutionId that is used by CreateOnboarding activity
         String institutionId = ctx.callActivity(CREATE_INSTITUTION_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
         onboarding.getInstitution().setId(institutionId);
-        onboardingString = getOnboardingString(objectMapper(), onboarding);
+        final String onboardingWithInstitutionIdString = getOnboardingString(objectMapper(), onboarding);
 
-        ctx.callActivity(CREATE_ONBOARDING_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
-        ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
+        ctx.callActivity(CREATE_ONBOARDING_ACTIVITY, onboardingWithInstitutionIdString, optionsRetry(), String.class).await();
+
+        // Create onboarding for test env if exists (ex. prod-interop-coll)
+        if(Objects.nonNull(onboarding.getTestEnvProductIds()) || !onboarding.getTestEnvProductIds().isEmpty()) {
+            // Schedule each task to run in parallel
+            List<Task<String>> parallelTasks = onboarding.getTestEnvProductIds().stream()
+                    .map(testEnvProductId -> {
+                        Onboarding onboardingTestEnv = readOnboardingValue(objectMapper(), onboardingWithInstitutionIdString);
+                        onboardingTestEnv.setProductId(testEnvProductId);
+                        return onboardingTestEnv;
+                    })
+                    .map(item -> ctx.callActivity(CREATE_ONBOARDING_ACTIVITY, getOnboardingString(objectMapper(), item), optionsRetry(), String.class))
+                    .collect(Collectors.toList());
+
+            // Wait for all tasks to complete
+            ctx.allOf(parallelTasks).await();
+        }
+
+        ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, onboardingWithInstitutionIdString, optionsRetry(), String.class).await();
 
         return Optional.of(OnboardingStatus.COMPLETED);
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
@@ -20,6 +20,7 @@ public interface WorkflowExecutor {
 
     Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, Onboarding onboarding);
     Optional<OnboardingStatus> executeToBeValidatedState(TaskOrchestrationContext ctx, Onboarding onboarding);
+    Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding);
 
     ObjectMapper objectMapper();
 
@@ -36,7 +37,7 @@ public interface WorkflowExecutor {
 
     }
 
-    default Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding) {
+    default Optional<OnboardingStatus> onboardingCompletionActivity(TaskOrchestrationContext ctx, Onboarding onboarding) {
         final String onboardingString = getOnboardingString(objectMapper(), onboarding);
 
         //CreateInstitution activity return an institutionId that is used by CreateOnboarding activity

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmation.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmation.java
@@ -28,6 +28,11 @@ public class WorkflowExecutorConfirmation implements WorkflowExecutor {
     }
 
     @Override
+    public Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding) {
+        return onboardingCompletionActivity(ctx, onboarding);
+    }
+
+    @Override
     public ObjectMapper objectMapper() {
         return this.objectMapper;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistration.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistration.java
@@ -35,6 +35,11 @@ public class WorkflowExecutorContractRegistration implements WorkflowExecutor {
     }
 
     @Override
+    public Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding) {
+        return onboardingCompletionActivity(ctx, onboarding);
+    }
+
+    @Override
     public ObjectMapper objectMapper() {
         return this.objectMapper;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprove.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprove.java
@@ -37,6 +37,11 @@ public class WorkflowExecutorForApprove implements WorkflowExecutor {
     }
 
     @Override
+    public Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, Onboarding onboarding) {
+        return onboardingCompletionActivity(ctx, onboarding);
+    }
+
+    @Override
     public ObjectMapper objectMapper() {
         return this.objectMapper;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprovePt.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprovePt.java
@@ -31,7 +31,7 @@ public class WorkflowExecutorForApprovePt implements WorkflowExecutor {
 
     @Override
     public Optional<OnboardingStatus> executeToBeValidatedState(TaskOrchestrationContext ctx, Onboarding onboarding) {
-        return WorkflowExecutor.super.executePendingState(ctx, onboarding);
+        return onboardingCompletionActivity(ctx, onboarding);
     }
 
     @Override

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -391,13 +391,15 @@ public class OnboardingFunctionsTest {
 
     @Test
     void createInstitutionAndPersistInstitutionId() {
-        
+
+        final String institutionId = "institutionId";
         when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
         when(completionService.createInstitutionAndPersistInstitutionId(any()))
-                .thenReturn("id");
+                .thenReturn(institutionId);
 
-        function.createInstitutionAndPersistInstitutionId(onboardinString, executionContext);
+        String actualInstitutionId = function.createInstitutionAndPersistInstitutionId(onboardinString, executionContext);
 
+        assertEquals(institutionId, actualInstitutionId);
         Mockito.verify(completionService, times(1))
                 .createInstitutionAndPersistInstitutionId(any());
     }

--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -22,7 +22,7 @@
     <quarkus.platform.version>3.5.2</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.1.7</onboarding-sdk.version>
+    <onboarding-sdk.version>0.1.8</onboarding-sdk.version>
     <quarkus-openapi-generator.version>2.2.13</quarkus-openapi-generator.version>
   </properties>
   <dependencyManagement>

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -23,6 +23,7 @@ public class Onboarding extends ReactivePanacheMongoEntity  {
     public ObjectId id;
 
     private String productId;
+    private List<String> testEnvProductIds;
     private WorkflowType workflowType;
     private Institution institution;
     private List<User> users;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -158,6 +158,8 @@ public class OnboardingServiceDefault implements OnboardingService {
 
         return validationProductDataAndOnboardingExists(onboarding)
                 .onItem().transformToUni(product -> OnboardingUtils.customValidationOnboardingData(onboarding, product)
+                    /* if product has some test environments, request must also onboard them (for ex. prod-interop-coll) */
+                    .onItem().invoke(() -> onboarding.setTestEnvProductIds(product.getTestEnvProductIds()))
                     .onItem().transformToUni(this::addParentDescriptionForAooOrUo)
                     /* I have to retrieve onboarding id for saving reference to pdv */
                     .onItem().transformToUni(current -> Panache.withTransaction(() -> Onboarding.persist(onboarding).replaceWith(onboarding)
@@ -259,8 +261,6 @@ public class OnboardingServiceDefault implements OnboardingService {
                 .onFailure().transform(ex -> new OnboardingNotAllowedException(String.format(UNABLE_TO_COMPLETE_THE_ONBOARDING_FOR_INSTITUTION_FOR_PRODUCT_DISMISSED,
                         onboarding.getInstitution().getTaxCode(),
                         onboarding.getProductId()), DEFAULT_ERROR.getCode()))
-                /* if product has some test environments, request must also onboard them (for ex. prod-interop-coll) */
-                .onItem().invoke(product -> onboarding.setTestEnvProductIds(product.getTestEnvProductIds()))
                 .onItem().transformToUni(product -> verifyAlreadyOnboardingForProductAndProductParent(onboarding.getInstitution().getTaxCode(), onboarding.getInstitution().getSubunitCode(),
                             product.getId(), product.getParentId())
                     .replaceWith(product));

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -259,6 +259,8 @@ public class OnboardingServiceDefault implements OnboardingService {
                 .onFailure().transform(ex -> new OnboardingNotAllowedException(String.format(UNABLE_TO_COMPLETE_THE_ONBOARDING_FOR_INSTITUTION_FOR_PRODUCT_DISMISSED,
                         onboarding.getInstitution().getTaxCode(),
                         onboarding.getProductId()), DEFAULT_ERROR.getCode()))
+                /* if product has some test environments, request must also onboard them (for ex. prod-interop-coll) */
+                .onItem().invoke(product -> onboarding.setTestEnvProductIds(product.getTestEnvProductIds()))
                 .onItem().transformToUni(product -> verifyAlreadyOnboardingForProductAndProductParent(onboarding.getInstitution().getTaxCode(), onboarding.getInstitution().getSubunitCode(),
                             product.getId(), product.getParentId())
                     .replaceWith(product));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added business logic for onboarding test environment products configured using this [PR](https://github.com/pagopa/selfcare-onboarding/pull/143) when current product is onboarded
* Remove SEND_MAIL_CONFIRMATION_ACTIVITY function

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

A common use case is when we want to onboard for certain product also the test environment, for example for prod-interop we also onboard prod-interop-coll. This logic will replace the [onboarding interceptor](https://github.com/pagopa/selfcare-ms-onboarding-interceptor) behaviour and it will be dismissed

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.