### PR TITLE
[SELC-4079] fix: Added custom method for upperCase on recipientCode in OnboardingMapper

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -14,13 +14,13 @@ import java.util.Objects;
 @Mapper(componentModel = "cdi")
 public interface OnboardingMapper {
 
-    @Mapping(target = "billing.recipientCode", expression = "java(toUpperCase(billing.getRecipientCode()))")
+    @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingPaRequest request);
-    @Mapping(target = "billing.recipientCode", expression = "java(toUpperCase(billing.getRecipientCode()))")
+    @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingPspRequest request);
-    @Mapping(target = "billing.recipientCode", expression = "java(toUpperCase(billing.getRecipientCode()))")
+    @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingDefaultRequest request);
-    @Mapping(target = "billing.recipientCode", expression = "java(toUpperCase(billing.getRecipientCode()))")
+    @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingSaRequest request);
 
     @Mapping(source = "taxCode", target = "institution.taxCode")
@@ -40,6 +40,7 @@ public interface OnboardingMapper {
     default String objectIdToString(ObjectId objectId) {
         return objectId.toHexString();
     }
+
     @Named("toUpperCase")
     default String toUpperCase(String recipientCode) {
         return Objects.nonNull(recipientCode) ? recipientCode.toUpperCase() : null;

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -150,6 +150,12 @@ class OnboardingControllerTest {
                 .post("/pa")
                 .then()
                 .statusCode(200);
+
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1))
+                .onboarding(captor.capture(), any());
+        assertEquals(captor.getValue().getBilling().getRecipientCode(), onboardingPaValid.getBilling().getRecipientCode().toUpperCase());
+
     }
 
     private OnboardingPaRequest dummyOnboardingPa() {


### PR DESCRIPTION
#### List of Changes

Added custom method for upperCase on recipientCode in OnboardingMapper

#### Motivation and Context

With previous code, although the implementation of mapper was formally corrected, the method into expression was not invoked. So, the expression was substituted with qualifiedByName directive

#### How Has This Been Tested?

A specific unit test was added to match this scenario.

