### PR TITLE
ops: disable automation pipeline for prod environment

### DIFF
--- a/.github/workflows/release_functions.yml
+++ b/.github/workflows/release_functions.yml
@@ -11,13 +11,21 @@ on:
       - "pom.xml"
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_function.yml
     name: '[Dev] OnBoarding function Release'
-    if: github.ref_name == 'main'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -26,7 +34,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_function.yml
     name: '[UAT] OnBoarding function Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ (startsWith(github.ref_name, 'releases/') == true && inputs.env == null) || inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat
@@ -35,7 +43,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_function.yml
     name: '[Prod] OnBoarding function Release'
-    if: startsWith(github.ref_name, 'releases/') 
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -12,6 +12,9 @@ on:
       - "pom.xml"
   
   workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
 
 jobs:
 

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -33,7 +33,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: ${{startsWith(github.ref_name, 'releases/') != true && inputs.env == null }} || ${{ inputs.env == 'dev' }}
+    if: ${{(startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -33,7 +33,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'dev' }}
+    if: ${{startsWith(github.ref_name, 'releases/') != true && inputs.env == null }} || ${{ inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Print if
         id: print-if
         run: |
-          echo "((startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'dev' }})""
+          echo "${{ inputs.env == null }}"
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -13,8 +13,13 @@ on:
   
   workflow_dispatch:
     inputs:
-      environment:
-        type: environment
+      env:
+        type: choice
+        description: Who to greet
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
@@ -39,7 +44,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Prod] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: "${{ github.event.inputs.env == 'prod' }}"
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -26,7 +26,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') != true && ${{ github.event.inputs.env != 'dev' }} ) || ${{ github.event.inputs.env == 'dev' }}
+    if: (startsWith(github.ref_name, 'releases/') != true && ${{ github.event.inputs.env == '' }} ) || ${{ github.event.inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -35,7 +35,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') == true && ${{ github.event.inputs.env != 'uat' }} ) || ${{ github.event.inputs.env == 'uat' }}
+    if: (startsWith(github.ref_name, 'releases/') == true && ${{ github.event.inputs.env == '' }} ) || ${{ github.event.inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Print if
         id: print-if
         run: |
-          echo "(startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }})"
+          echo "${{startsWith(github.ref_name, 'releases/') != true && inputs.env == null }}"
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -23,6 +23,7 @@ on:
 
 jobs:
   test:
+    runs-on: ubuntu-20.04
     steps:
       - name: Print if
         id: print-if

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -26,7 +26,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') != true) || ${{ github.event.inputs.env == 'dev' }}
+    if: (startsWith(github.ref_name, 'releases/') != true && ${{ github.event.inputs.env != 'dev' }} ) || ${{ github.event.inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -35,7 +35,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/') || ${{ github.event.inputs.env == 'uat' }}
+    if: (startsWith(github.ref_name, 'releases/') == true && ${{ github.event.inputs.env != 'uat' }} ) || ${{ github.event.inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -22,13 +22,6 @@ on:
         - prod
 
 jobs:
-  test:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Print if
-        id: print-if
-        run: |
-          echo "${{startsWith(github.ref_name, 'releases/') != true && inputs.env == null }}"
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Print if
         id: print-if
         run: |
-          echo "${{ inputs.env == null }}"
+          echo "(startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }})"
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -33,7 +33,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: ${{(startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -42,7 +42,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') == true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'uat' }}
+    if: ${{ (startsWith(github.ref_name, 'releases/') == true && inputs.env == null) || inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -22,6 +22,12 @@ on:
         - prod
 
 jobs:
+  test:
+    steps:
+      - name: Print if
+        id: print-if
+        run: |
+          echo "((startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'dev' }})""
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -26,7 +26,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/') != true
+    if: (startsWith(github.ref_name, 'releases/') != true) || ${{ github.event.inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -35,7 +35,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: startsWith(github.ref_name, 'releases/') || ${{ github.event.inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat
@@ -44,7 +44,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Prod] OnBoarding ms Release'
-    if: "${{ github.event.inputs.env == 'prod' }}"
+    if: ${{ github.event.inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_ms.yml
+++ b/.github/workflows/release_ms.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       env:
         type: choice
-        description: Who to greet
+        description: Environment
         options: 
         - dev
         - uat
@@ -26,7 +26,7 @@ jobs:
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') != true && ${{ github.event.inputs.env == '' }} ) || ${{ github.event.inputs.env == 'dev' }}
+    if: (startsWith(github.ref_name, 'releases/') != true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -35,7 +35,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: (startsWith(github.ref_name, 'releases/') == true && ${{ github.event.inputs.env == '' }} ) || ${{ github.event.inputs.env == 'uat' }}
+    if: (startsWith(github.ref_name, 'releases/') == true && ${{ inputs.env == null }} ) || ${{ inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat
@@ -44,7 +44,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Prod] OnBoarding ms Release'
-    if: ${{ github.event.inputs.env == 'prod' }}
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_pnpg_functions.yml
+++ b/.github/workflows/release_pnpg_functions.yml
@@ -11,13 +11,21 @@ on:
       - "pom.xml"
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_function.yml
     name: '[Dev] OnBoarding function Release'
-    if: startsWith(github.ref_name, 'releases/') != true
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -26,7 +34,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_function.yml
     name: '[UAT] OnBoarding function Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ (startsWith(github.ref_name, 'releases/') == true && inputs.env == null) || inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat
@@ -35,7 +43,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_function.yml
     name: '[Prod] OnBoarding function Release'
-    if: startsWith(github.ref_name, 'releases/') 
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_pnpg_ms.yml
+++ b/.github/workflows/release_pnpg_ms.yml
@@ -12,13 +12,21 @@ on:
       - "pom.xml"
   
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Dev] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/') != true
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -27,7 +35,7 @@ jobs:
   release_uat:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[UAT] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ (startsWith(github.ref_name, 'releases/') == true && inputs.env == null) || inputs.env == 'uat' }}
     secrets: inherit
     with:
       environment: uat
@@ -36,7 +44,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_ms.yml
     name: '[Prod] OnBoarding ms Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Prod workflow on ms and functions must be trigger manually selecting prod environment

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Every time a new release is created pipeline of uat and prod have been trigged. You have to approve or not for complete or reject their elaboration causing a lot of manually operation. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.