### PR TITLE
[SELC-4056] ops: pnpg pipeline and release manually in prod

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -83,6 +83,21 @@ jobs:
           gh workflow run release_container_apps_infra.yml \
             --ref $NEW_BRANCH_NAME
 
+      - name: Trigger PNPG Functions Infra UAT Release
+        run: |
+          gh workflow run release_functions_pnpg_infra.yml \
+            --ref $NEW_BRANCH_NAME
+
+      - name: Trigger PNPG Mongo Infra UAT Release
+        run: |
+          gh workflow run release_mongo_pnpg_infra.yml \
+            --ref $NEW_BRANCH_NAME
+
+      - name: Trigger PNPG Container App Infra UAT Release
+        run: |
+          gh workflow run release_container_apps_pnpg_infra.yml \
+            --ref $NEW_BRANCH_NAME
+
       - name: Trigger Functions UAT Release
         run: |
           gh workflow run release_functions.yml \
@@ -91,4 +106,14 @@ jobs:
       - name: Trigger Onboarding ms UAT Release
         run: |
           gh workflow run release_ms.yml \
+            --ref $NEW_BRANCH_NAME
+
+      - name: Trigger PNPG Functions UAT Release
+        run: |
+          gh workflow run release_pnpg_functions.yml \
+            --ref $NEW_BRANCH_NAME
+
+      - name: Trigger PNPG Onboarding ms UAT Release
+        run: |
+          gh workflow run release_pnpg_ms.yml \
             --ref $NEW_BRANCH_NAME

--- a/.github/workflows/release_container_apps_infra.yml
+++ b/.github/workflows/release_container_apps_infra.yml
@@ -10,13 +10,21 @@ on:
       - './infra/container_apps/onboarding-ms/**'
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Dev] Container Apps Infra Release'
-    if: github.ref_name == 'main'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -38,7 +46,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Prod] Container Apps Infra Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_container_apps_pnpg_infra.yml
+++ b/.github/workflows/release_container_apps_pnpg_infra.yml
@@ -13,13 +13,21 @@ on:
       - './infra/container_apps/onboarding-ms/**'
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Dev] Container Apps Infra Release'
-    if: github.ref_name == 'main'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -43,7 +51,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Prod] Container Apps Infra Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_functions_infra.yml
+++ b/.github/workflows/release_functions_infra.yml
@@ -9,13 +9,21 @@ on:
       - './infra/functions/onboarding-functions/**'
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Dev] Functions Infra Release'
-    if: github.ref_name == 'main'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -33,7 +41,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Prod] Functions Infra Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_mongo_infra.yml
+++ b/.github/workflows/release_mongo_infra.yml
@@ -9,13 +9,21 @@ on:
       - './infra/mongo'
 
   workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
 
 jobs:
 
   release_dev:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Dev] Mongo Infra Release'
-    if: github.ref_name == 'main'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
     secrets: inherit
     with:
       environment: dev
@@ -33,7 +41,7 @@ jobs:
   release_prod:
     uses: ./.github/workflows/call_release_infra.yml
     name: '[Prod] Mongo Infra Release'
-    if: startsWith(github.ref_name, 'releases/')
+    if: ${{ inputs.env == 'prod' }}
     secrets: inherit
     with:
       environment: prod

--- a/.github/workflows/release_mongo_pnpg_infra.yml
+++ b/.github/workflows/release_mongo_pnpg_infra.yml
@@ -1,0 +1,51 @@
+name: Deploy PNPG mongo infra
+
+on:
+  push:
+    branches:
+      - main
+      - releases/*
+    paths:
+      - './infra/mongo'
+
+  workflow_dispatch:
+    inputs:
+      env:
+        type: choice
+        description: Environment
+        options: 
+        - dev
+        - uat
+        - prod
+
+jobs:
+
+  release_dev:
+    uses: ./.github/workflows/call_release_infra.yml
+    name: '[Dev] Mongo Infra Release'
+    if: ${{ (startsWith(github.ref_name, 'releases/') != true && inputs.env == null) || inputs.env == 'dev' }}
+    secrets: inherit
+    with:
+      environment: dev
+      tf_environment: dev-pnpg
+      dir: ./infra/mongo
+
+  release_uat:
+    uses: ./.github/workflows/call_release_infra.yml
+    name: '[UAT] Mongo Infra Release'
+    if: startsWith(github.ref_name, 'releases/')
+    secrets: inherit
+    with:
+      environment: uat
+      tf_environment: uat-pnpg
+      dir: ./infra/mongo
+
+  release_prod:
+    uses: ./.github/workflows/call_release_infra.yml
+    name: '[Prod] Mongo Infra Release'
+    if: ${{ inputs.env == 'prod' }}
+    secrets: inherit
+    with:
+      environment: prod
+      tf_environment: prod-pnpg
+      dir: ./infra/mongo


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Added release mongo infra for PNPG
* Added trigger for PNPG infra when create a release branch
* Set manually release for prod environment

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

PNPG environment misses mongo infra pipeline and others pipeline were not triggered when a create release branch was executed. 
In addition, I disable automatic release for prod environment because deployment in uat and prod env includes a lot of manual operations (for ex. approve) so we want that uat release is less expensive in this term

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.