### PR TITLE
[SELC-4155] refactor: mongo entity id as string

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -4,7 +4,7 @@ package it.pagopa.selfcare.onboarding.entity;
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
-import org.bson.types.ObjectId;
+import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,9 +13,8 @@ import java.util.List;
 @MongoEntity(collection="onboardings")
 public class Onboarding  {
 
-    private ObjectId id;
-
-    private String onboardingId;
+    @BsonId
+    private String id;
     private String productId;
     private List<String> testEnvProductIds;
     private WorkflowType workflowType;
@@ -32,11 +31,11 @@ public class Onboarding  {
     private String userRequestUid;
     private String workflowInstanceId;
 
-    public ObjectId getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(ObjectId id) {
+    public void setId(String id) {
         this.id = id;
     }
 
@@ -102,14 +101,6 @@ public class Onboarding  {
 
     public void setStatus(OnboardingStatus status) {
         this.status = status;
-    }
-
-    public String getOnboardingId() {
-        return onboardingId;
-    }
-
-    public void setOnboardingId(String onboardingId) {
-        this.onboardingId = onboardingId;
     }
 
     public String getUserRequestUid() {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Token.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Token.java
@@ -2,7 +2,7 @@ package it.pagopa.selfcare.onboarding.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import it.pagopa.selfcare.onboarding.common.TokenType;
-import org.bson.types.ObjectId;
+import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +10,8 @@ import java.time.LocalDateTime;
 @MongoEntity(collection="tokens")
 public class Token {
 
-    private ObjectId id;
+    @BsonId
+    private String id;
     private TokenType type;
     private String onboardingId;
     private String productId;
@@ -25,11 +26,11 @@ public class Token {
     private LocalDateTime deletedAt;
     private LocalDateTime activatedAt;
 
-    public ObjectId getId() {
+    public String getId() {
         return id;
     }
 
-    public void setId(ObjectId id) {
+    public void setId(String id) {
         this.id = id;
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/repository/OnboardingRepository.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/repository/OnboardingRepository.java
@@ -1,10 +1,10 @@
 package it.pagopa.selfcare.onboarding.repository;
 
-import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
-public class OnboardingRepository implements PanacheMongoRepository<Onboarding> {
+public class OnboardingRepository implements PanacheMongoRepositoryBase<Onboarding, String> {
 
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/repository/TokenRepository.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/repository/TokenRepository.java
@@ -1,13 +1,13 @@
 package it.pagopa.selfcare.onboarding.repository;
 
-import io.quarkus.mongodb.panache.PanacheMongoRepository;
+import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 import it.pagopa.selfcare.onboarding.entity.Token;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.Optional;
 
 @ApplicationScoped
-public class TokenRepository implements PanacheMongoRepository<Token> {
+public class TokenRepository implements PanacheMongoRepositoryBase<Token, String> {
 
     public static final String ONBOARDING_ID_FIELD = "onboardingId";
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -88,7 +88,7 @@ public class CompletionServiceDefault implements CompletionService {
 
         onboardingRepository
                 .update("institution.id", institutionResponse.getId())
-                .where("_id", onboarding.getOnboardingId());
+                .where("_id", onboarding.getId());
 
         return institutionResponse.getId();
     }
@@ -210,7 +210,7 @@ public class CompletionServiceDefault implements CompletionService {
         );
         onboardingRequest.pricingPlan(onboarding.getPricingPlan());
         onboardingRequest.productId(onboarding.getProductId());
-        onboardingRequest.setTokenId(onboarding.getOnboardingId());
+        onboardingRequest.setTokenId(onboarding.getId());
 
         if(Objects.nonNull(onboarding.getBilling())) {
             BillingRequest billingRequest = new BillingRequest();
@@ -221,7 +221,7 @@ public class CompletionServiceDefault implements CompletionService {
         }
 
         //If contract exists we send the path of the contract
-        Optional<Token> optToken = tokenRepository.findByOnboardingId(onboarding.getOnboardingId());
+        Optional<Token> optToken = tokenRepository.findByOnboardingId(onboarding.getId());
         optToken.ifPresent(token -> onboardingRequest.setContractPath(token.getContractSigned()));
 
         institutionApi.onboardingInstitutionUsingPOST(onboarding.getInstitution().getId(), onboardingRequest);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
@@ -100,7 +100,7 @@ public class ContractServiceDefault implements ContractService {
 
             // Define the filename and path for storage.
             final String filename = CONTRACT_FILENAME_FUNC.apply(productName);
-            final String path = String.format("%s%s", azureStorageConfig.contractPath(), onboarding.getOnboardingId());
+            final String path = String.format("%s%s", azureStorageConfig.contractPath(), onboarding.getId());
 
             File signedPath = signPdf(temporaryPdfFile, institution.getDescription(), productId);
             azureBlobClient.uploadFile(path, filename, Files.readAllBytes(signedPath.toPath()));

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -114,7 +114,7 @@ public class OnboardingFunctionsTest {
     @Test
     void onboardingsOrchestratorContractRegistration() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.REQUEST);
         onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION);
 
@@ -130,13 +130,13 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_REGISTRATION_WITH_CONTRACT_ACTIVITY, captorActivity.getAllValues().get(2));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.PENDING);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
     }
 
     @Test
     void onboardingsOrchestratorForApprove() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.REQUEST);
         onboarding.setWorkflowType(WorkflowType.FOR_APPROVE);
 
@@ -151,13 +151,13 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY, captorActivity.getAllValues().get(0));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.TOBEVALIDATED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
     }
 
     @Test
     void onboardingsOrchestratorForApproveWhenToBeValidated() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
         onboarding.setWorkflowType(WorkflowType.FOR_APPROVE);
 
@@ -174,13 +174,13 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_REGISTRATION_WITH_CONTRACT_WHEN_APPROVE_ACTIVITY, captorActivity.getAllValues().get(2));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.PENDING);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
     }
 
     @Test
     void onboardingsOrchestratorConfirmation() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.PENDING);
         onboarding.setWorkflowType(WorkflowType.CONFIRMATION);
         onboarding.setInstitution(new Institution());
@@ -198,13 +198,13 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(2));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.COMPLETED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
     }
 
     @Test
     void onboardingsOrchestratorImport() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.PENDING);
         onboarding.setWorkflowType(WorkflowType.IMPORT);
         onboarding.setInstitution(new Institution());
@@ -220,13 +220,13 @@ public class OnboardingFunctionsTest {
         assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.COMPLETED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
     }
 
     @Test
     void onboardingsOrchestratorRegistrationRequestApprove() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.REQUEST);
         onboarding.setWorkflowType(WorkflowType.FOR_APPROVE_PT);
 
@@ -242,7 +242,7 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY, captorActivity.getAllValues().get(1));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.TOBEVALIDATED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
     }
 
 
@@ -250,7 +250,7 @@ public class OnboardingFunctionsTest {
     @Test
     void onboardingsOrchestratorForApprovePtWhenToBeValidated() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setInstitution(new Institution());
         onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
         onboarding.setWorkflowType(WorkflowType.FOR_APPROVE_PT);
@@ -267,13 +267,13 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(2));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.COMPLETED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
     }
 
     TaskOrchestrationContext mockTaskOrchestrationContext(Onboarding onboarding) {
         TaskOrchestrationContext orchestrationContext = mock(TaskOrchestrationContext.class);
-        when(orchestrationContext.getInput(String.class)).thenReturn(onboarding.getOnboardingId());
-        when(service.getOnboarding(onboarding.getOnboardingId())).thenReturn(Optional.of(onboarding));
+        when(orchestrationContext.getInput(String.class)).thenReturn(onboarding.getId());
+        when(service.getOnboarding(onboarding.getId())).thenReturn(Optional.of(onboarding));
 
         Task task = mock(Task.class);
         when(orchestrationContext.callActivity(any(),any(),any(),any())).thenReturn(task);
@@ -368,7 +368,7 @@ public class OnboardingFunctionsTest {
     @Test
     void onboardingCompletionOrchestrator() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.PENDING);
         onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION);
         onboarding.setInstitution(new Institution());
@@ -386,7 +386,7 @@ public class OnboardingFunctionsTest {
         assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(2));
 
         Mockito.verify(service, times(1))
-                .updateOnboardingStatus(onboarding.getOnboardingId(), OnboardingStatus.COMPLETED);
+                .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
     }
 
 
@@ -395,7 +395,7 @@ public class OnboardingFunctionsTest {
     @Test
     void onboardingRejectedOrchestrator() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setOnboardingId("onboardingId");
+        onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.REJECTED);
         onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION);
         onboarding.setInstitution(new Institution());

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -7,11 +7,11 @@ import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
-import it.pagopa.selfcare.onboarding.entity.*;
 import it.pagopa.selfcare.onboarding.entity.Billing;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.Token;
+import it.pagopa.selfcare.onboarding.entity.*;
 import it.pagopa.selfcare.onboarding.exception.GenericOnboardingException;
 import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import it.pagopa.selfcare.onboarding.repository.TokenRepository;
@@ -19,7 +19,6 @@ import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
-import org.bson.types.ObjectId;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,8 +37,8 @@ import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
 
 import java.util.*;
 
-import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_WORKS_FIELD_LIST;
 import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_FIELD_LIST;
+import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_WORKS_FIELD_LIST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -108,7 +107,7 @@ public class CompletionServiceDefaultTest {
 
     void mockOnboardingUpdateAndExecuteCreateInstitution(Onboarding onboarding, InstitutionResponse institutionResponse){
         PanacheUpdate panacheUpdateMock = mock(PanacheUpdate.class);
-        when(panacheUpdateMock.where("_id", onboarding.getOnboardingId()))
+        when(panacheUpdateMock.where("_id", onboarding.getId()))
                 .thenReturn(Long.valueOf(1));
         when(onboardingRepository.update("institution.id", institutionResponse.getId()))
                 .thenReturn(panacheUpdateMock);
@@ -343,7 +342,7 @@ public class CompletionServiceDefaultTest {
                 .thenReturn(new InstitutionResponse());
         Token token = new Token();
         token.setContractSigned("contract-signed-path");
-        when(tokenRepository.findByOnboardingId(onboarding.getOnboardingId()))
+        when(tokenRepository.findByOnboardingId(onboarding.getId()))
                 .thenReturn(Optional.of(token));
 
         completionServiceDefault.persistOnboarding(onboarding);
@@ -353,7 +352,7 @@ public class CompletionServiceDefaultTest {
                 .onboardingInstitutionUsingPOST(any(), captor.capture());
 
         verify(tokenRepository, times(1))
-                .findByOnboardingId(onboarding.getOnboardingId());
+                .findByOnboardingId(onboarding.getId());
 
         InstitutionOnboardingRequest actual = captor.getValue();
         assertEquals(onboarding.getProductId(), actual.getProductId());
@@ -421,8 +420,7 @@ public class CompletionServiceDefaultTest {
 
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setId(ObjectId.get());
-        onboarding.setOnboardingId(onboarding.getId().toHexString());
+        onboarding.setId(onboarding.getId());
         onboarding.setProductId(productId);
         onboarding.setPricingPlan("pricingPlan");
         onboarding.setUsers(List.of());

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
@@ -11,7 +11,6 @@ import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.User;
 import jakarta.inject.Inject;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -55,8 +54,7 @@ class ContractServiceDefaultTest {
 
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setId(ObjectId.get());
-        onboarding.setOnboardingId("example");
+        onboarding.setId("example");
         onboarding.setProductId("productId");
         onboarding.setUsers(List.of());
 
@@ -168,7 +166,7 @@ class ContractServiceDefaultTest {
 
         Mockito.when(azureBlobClient.uploadFile(any(), any(), any())).thenReturn(contractHtml);
 
-        assertNotNull(contractService.loadContractPDF(contractFilepath, onboarding.getId().toHexString(), productNameExample));
+        assertNotNull(contractService.loadContractPDF(contractFilepath, onboarding.getId(), productNameExample));
     }
 
     @Test
@@ -179,12 +177,12 @@ class ContractServiceDefaultTest {
         File pdf = mock(File.class);
         Mockito.when(azureBlobClient.getFileAsPdf(any())).thenReturn(pdf);
 
-        contractService.retrieveContractNotSigned(onboarding.getOnboardingId(), productNameExample);
+        contractService.retrieveContractNotSigned(onboarding.getId(), productNameExample);
 
         ArgumentCaptor<String> filepathActual = ArgumentCaptor.forClass(String.class);
         Mockito.verify(azureBlobClient, times(1))
                 .getFileAsPdf(filepathActual.capture());
-        assertTrue(filepathActual.getValue().contains(onboarding.getOnboardingId()));
+        assertTrue(filepathActual.getValue().contains(onboarding.getId()));
         assertTrue(filepathActual.getValue().contains(productNameExample));
     }
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -1,13 +1,13 @@
 package it.pagopa.selfcare.onboarding.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
-import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntityBase;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.FieldNameConstants;
-import org.bson.types.ObjectId;
+import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,9 +16,10 @@ import java.util.List;
 @Data
 @FieldNameConstants(asEnum = true)
 @MongoEntity(collection="onboardings")
-public class Onboarding extends ReactivePanacheMongoEntity  {
+public class Onboarding extends ReactivePanacheMongoEntityBase {
 
-    public ObjectId id;
+    @BsonId
+    public String id;
 
     private String productId;
     private List<String> testEnvProductIds;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Token.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Token.java
@@ -1,20 +1,21 @@
 package it.pagopa.selfcare.onboarding.entity;
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
-import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntity;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntityBase;
 import it.pagopa.selfcare.onboarding.common.TokenType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.bson.types.ObjectId;
+import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.time.LocalDateTime;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
 @MongoEntity(collection="tokens")
-public class Token extends ReactivePanacheMongoEntity {
+public class Token extends ReactivePanacheMongoEntityBase {
 
-    private ObjectId id;
+    @BsonId
+    private String id;
     private TokenType type;
     private String onboardingId;
     private String productId;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -4,22 +4,26 @@ import it.pagopa.selfcare.onboarding.controller.request.*;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingGet;
 import it.pagopa.selfcare.onboarding.controller.response.OnboardingResponse;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
-import org.bson.types.ObjectId;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
 import java.util.Objects;
+import java.util.UUID;
 
-@Mapper(componentModel = "cdi")
+@Mapper(componentModel = "cdi", imports = UUID.class)
 public interface OnboardingMapper {
 
+    @Mapping(target = "id", expression = "java(UUID.randomUUID().toString())")
     @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
-    Onboarding toEntity(OnboardingPaRequest request);
+    Onboarding toEntity(OnboardingPaRequest model);
+    @Mapping(target = "id", expression = "java(UUID.randomUUID().toString())")
     @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingPspRequest request);
+    @Mapping(target = "id", expression = "java(UUID.randomUUID().toString())")
     @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingDefaultRequest request);
+    @Mapping(target = "id", expression = "java(UUID.randomUUID().toString())")
     @Mapping(target = "billing.recipientCode", source = "billing.recipientCode", qualifiedByName = "toUpperCase")
     Onboarding toEntity(OnboardingSaRequest request);
     Onboarding toEntity(OnboardingImportRequest request);
@@ -29,18 +33,12 @@ public interface OnboardingMapper {
     @Mapping(source = "digitalAddress", target = "institution.digitalAddress")
     @Mapping(source = "origin", target = "institution.origin")
     @Mapping(source = "institutionType", target = "institution.institutionType")
+    @Mapping(target = "id", expression = "java(UUID.randomUUID().toString())")
     Onboarding toEntity(OnboardingPgRequest request);
 
-    @Mapping(target = "id", expression = "java(objectIdToString(model.getId()))")
     OnboardingResponse toResponse(Onboarding model);
 
-    @Mapping(target = "id", expression = "java(objectIdToString(model.getId()))")
     OnboardingGet toGetResponse(Onboarding model);
-
-    @Named("objectIdToString")
-    default String objectIdToString(ObjectId objectId) {
-        return objectId.toHexString();
-    }
 
     @Named("toUpperCase")
     default String toUpperCase(String recipientCode) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/TokenMapper.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/mapper/TokenMapper.java
@@ -2,20 +2,10 @@ package it.pagopa.selfcare.onboarding.mapper;
 
 import it.pagopa.selfcare.onboarding.controller.response.TokenResponse;
 import it.pagopa.selfcare.onboarding.entity.Token;
-import org.bson.types.ObjectId;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
 @Mapper(componentModel = "cdi")
 public interface TokenMapper {
 
-    @Mapping(target = "id", expression = "java(objectIdToString(entity.getId()))")
     TokenResponse toResponse(Token entity);
-
-
-    @Named("objectIdToString")
-    default String objectIdToString(ObjectId objectId) {
-        return objectId.toHexString();
-    }
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/TokenControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/TokenControllerTest.java
@@ -10,10 +10,10 @@ import io.restassured.http.ContentType;
 import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.entity.Token;
 import it.pagopa.selfcare.onboarding.service.TokenService;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
@@ -32,7 +32,7 @@ public class TokenControllerTest {
 
         final String onboardingId = "onboardingId";
         Token token = new Token();
-        token.setId(ObjectId.get());
+        token.setId(UUID.randomUUID().toString());
         when(tokenService.getToken(onboardingId))
                 .thenReturn(Uni.createFrom().item(List.of(token)));
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Replace id type of mongo entity with String

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Migration from ms-core need to have id of entity as string instead ObjectId. It is necessary for maintain compatibility interactions with other products

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.