### PR TITLE
[SELC-3982] fix: update field createdAt to LocalDateTime in ImportedContract

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingImportContract.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingImportContract.java
@@ -1,11 +1,10 @@
 package it.pagopa.selfcare.onboarding.controller.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 
 @Data
 public class OnboardingImportContract {
@@ -16,5 +15,5 @@ public class OnboardingImportContract {
     private String filePath;
     private String contractType;
     @NotNull(message = "createdAt is required")
-    private OffsetDateTime createdAt;
+    private LocalDateTime createdAt;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -773,8 +773,8 @@ public class OnboardingServiceDefault implements OnboardingService {
         token.setContractVersion(product.getContractTemplateVersion());
         token.setContractSigned(contractImported.getFilePath());
         token.setContractFilename(contractImported.getFileName());
-        token.setCreatedAt(contractImported.getCreatedAt().toLocalDateTime());
-        token.setUpdatedAt(contractImported.getCreatedAt().toLocalDateTime());
+        token.setCreatedAt(contractImported.getCreatedAt());
+        token.setUpdatedAt(contractImported.getCreatedAt());
         token.setProductId(onboarding.getProductId());
         token.setType(TokenType.INSTITUTION);
         return token;

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1168,7 +1168,7 @@ class OnboardingServiceDefaultTest {
         OnboardingImportContract contractImported = new OnboardingImportContract();
         contractImported.setFileName("filename");
         contractImported.setFilePath("filepath");
-        contractImported.setCreatedAt(OffsetDateTime.now());
+        contractImported.setCreatedAt(LocalDateTime.now());
         contractImported.setContractType("type");
 
         mockPersistOnboarding(asserter);


### PR DESCRIPTION
#### List of Changes

Update field createdAt to LocalDateTime in ContractImported

#### Motivation and Context

This change has been implemented to align request's objects to codegen plugin and its setting to manage date fields as LocalDateTime
