### PR TITLE
[SELC-4182] fix: send mail when persist onboarding if present

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -195,15 +195,21 @@ public class CompletionServiceDefault implements CompletionService {
         onboardingRequest.setUsers(onboarding.getUsers().stream()
                 .map(user -> {
                     UserResource userResource = userRegistryApi.findByIdUsingGET(USERS_WORKS_FIELD_LIST, user.getId());
-                    String mailWork = Optional.ofNullable(userResource.getWorkContacts())
-                            .map(worksContract -> worksContract.get(user.getUserMailUuid()))
-                            .map(workContactResource -> workContactResource.getEmail())
-                            .map(certifiable -> certifiable.getValue())
-                            .orElseThrow(() -> new GenericOnboardingException("Work contract not found!"));
                     Person person = userMapper.toPerson(userResource);
-                    person.setEmail(mailWork);
                     person.setProductRole(user.getProductRole());
                     person.setRole(Person.RoleEnum.valueOf(user.getRole().name()));
+
+                    //Retrieve mail if exists (for PNPG is not stored)
+                    if(Objects.nonNull(user.getUserMailUuid())) {
+                        String mailWork = Optional.ofNullable(userResource.getWorkContacts())
+                                .map(worksContract -> worksContract.get(user.getUserMailUuid()))
+                                .map(workContactResource -> workContactResource.getEmail())
+                                .map(certifiable -> certifiable.getValue())
+                                .orElse(null);
+
+                        person.setEmail(mailWork);
+                    }
+
                     return person;
                 })
                 .toList()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Handle use case PNPG where user mail is not present, it will not be stored as userUuidMail but will ignored. In addition, it will be send empty if is not present when persisting onboarding

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

PNPG use case does not require user mail during onboarding process

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.