### PR TITLE
ops: decrease pdv client timeout

### DIFF
--- a/.github/workflows/create_release_branch.yml
+++ b/.github/workflows/create_release_branch.yml
@@ -130,8 +130,8 @@ jobs:
           gh workflow run release_ms.yml \
             --ref $NEW_BRANCH_NAME
 
-       - name: Trigger PNPG Functions UAT Release
-         run: |
+      - name: Trigger PNPG Functions UAT Release
+        run: |
            gh workflow run release_pnpg_functions.yml \
              --ref $NEW_BRANCH_NAME
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
@@ -7,14 +7,19 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.quarkus.arc.DefaultBean;
 import io.quarkus.arc.properties.IfBuildProperty;
+import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.json.jackson.DatabindCodec;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.azurestorage.AzureBlobClientDefault;
 import it.pagopa.selfcare.onboarding.crypto.*;
+import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import it.pagopa.selfcare.product.service.ProductService;
 import it.pagopa.selfcare.product.service.ProductServiceCacheable;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Produces;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,7 +27,11 @@ import java.io.InputStream;
 @ApplicationScoped
 public class OnboardingFunctionConfig {
 
+    private static final Logger log = LoggerFactory.getLogger(OnboardingFunctionConfig.class);
 
+    void onStart(@Observes StartupEvent ev, OnboardingRepository repository) {
+        log.info(String.format("Database %s is starting...", repository.mongoDatabase().getName()));
+    }
 
     @Produces
     public ObjectMapper objectMapper(){

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -28,6 +28,7 @@ onboarding-functions.purge.all-to = 120
 
 quarkus.openapi-generator.user_registry_json.auth.api_key.api-key = ${USER_REGISTRY_API_KEY:example-api-key}
 quarkus.rest-client."org.openapi.quarkus.user_registry_json.api.UserApi".url=${USER_REGISTRY_URL:http://localhost:8080}
+quarkus.rest-client."org.openapi.quarkus.user_registry_json.api.UserApi".read-timeout=5000
 
 quarkus.openapi-generator.codegen.spec.core_json.enable-security-generation=false
 quarkus.openapi-generator.codegen.spec.core_json.additional-api-type-annotations=@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders(it.pagopa.selfcare.onboarding.client.auth.AuthenticationPropagationHeadersFactory.class)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

* Decrease read timeout of pdv rest client, it permits a fast retry azure functions in case of failures
* Enable startup of mongo client also for functions

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We observe some exceptional timeout errors on pdv rest client. Having 60sec to throw timeout exception delay retry of azure functions

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.