### PR TITLE
[SELC - 4393]feat: implemented new method for onboarding reject API

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -578,6 +578,15 @@
             "type" : "string"
           }
         } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ReasonRequest"
+              }
+            }
+          }
+        },
         "responses" : {
           "200" : {
             "description" : "OK",
@@ -1147,6 +1156,9 @@
           },
           "userRequestUid" : {
             "type" : "string"
+          },
+          "reasonForReject" : {
+            "type" : "string"
           }
         }
       },
@@ -1362,6 +1374,14 @@
           },
           "vatNumberGroup" : {
             "type" : "boolean"
+          }
+        }
+      },
+      "ReasonRequest" : {
+        "type" : "object",
+        "properties" : {
+          "reasonForReject" : {
+            "type" : "string"
           }
         }
       },

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -415,6 +415,11 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReasonRequest'
       responses:
         "200":
           description: OK
@@ -825,6 +830,8 @@ components:
           type: string
         userRequestUid:
           type: string
+        reasonForReject:
+          type: string
     OnboardingGetResponse:
       type: object
       properties:
@@ -1003,6 +1010,11 @@ components:
           type: string
         vatNumberGroup:
           type: boolean
+    ReasonRequest:
+      type: object
+      properties:
+        reasonForReject:
+          type: string
     TokenResponse:
       type: object
       properties:

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -206,9 +206,11 @@ public class OnboardingController {
     @Operation(summary = "Perform reject operation of an onboarding request receiving onboarding id." +
             "Function change status to REJECT for an onboarding request that is not COMPLETED. " )
     @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{onboardingId}/reject")
-    public Uni<Response> delete(@PathParam(value = "onboardingId") String onboardingId) {
-        return onboardingService.rejectOnboarding(onboardingId)
+    public Uni<Response> delete(@PathParam(value = "onboardingId") String onboardingId, @Valid ReasonRequest reason) {
+        String reasonForReject = reason.getReasonForReject();
+        return onboardingService.rejectOnboarding(onboardingId, reasonForReject)
                 .map(ignore -> Response
                         .status(HttpStatus.SC_NO_CONTENT)
                         .build());

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/ReasonRequest.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/ReasonRequest.java
@@ -1,0 +1,8 @@
+package it.pagopa.selfcare.onboarding.controller.request;
+
+import lombok.Data;
+
+@Data
+public class ReasonRequest {
+    private String reasonForReject;
+}

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/response/OnboardingGet.java
@@ -22,4 +22,5 @@ public class OnboardingGet {
     private LocalDateTime expiringDate;
     private String status;
     private String userRequestUid;
+    private String reasonForReject;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -36,4 +36,5 @@ public class Onboarding extends ReactivePanacheMongoEntityBase {
     private OnboardingStatus status;
     private String userRequestUid;
     private AdditionalInformations additionalInformations;
+    private String reasonForReject;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -26,7 +26,7 @@ public interface OnboardingService {
 
     Uni<OnboardingGetResponse> onboardingGet(String productId, String taxCode, String status, String from, String to, Integer page, Integer size);
 
-    Uni<Long> rejectOnboarding(String onboardingId);
+    Uni<Long> rejectOnboarding(String onboardingId, String reasonForReject);
 
     Uni<OnboardingGet> onboardingPending(String onboardingId);
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.onboarding.util;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.Updates;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +70,13 @@ public class QueryUtils {
         return queryParameterMap;
     }
 
+    public static Map<String, String> createMapForOnboardingReject(String reasonForReject, String onboardingStatus) {
+        Map<String, String> queryParameterMap = new HashMap<>();
+        Optional.ofNullable(reasonForReject).ifPresent(value -> queryParameterMap.put("reasonForReject", value));
+        Optional.ofNullable(onboardingStatus).ifPresent(value -> queryParameterMap.put("status", value));
+        return queryParameterMap;
+    }
+
     public static Document buildSortDocument(String field, SortEnum order) {
         if(SortEnum.ASC == order) {
             return bsonToDocument(Sorts.ascending(field));
@@ -76,4 +84,20 @@ public class QueryUtils {
             return bsonToDocument(Sorts.descending(field));
         }
     }
+
+    public static Document buildUpdateDocument(Map<String, String> parameters) {
+        if (!parameters.isEmpty()) {
+            return bsonToDocument(Updates.combine(constructBsonUpdate(parameters)));
+        } else {
+            return new Document();
+        }
+    }
+
+    private static List<Bson> constructBsonUpdate(Map<String, String> parameters) {
+        return parameters.entrySet()
+                .stream()
+                .map(stringStringEntry -> Updates.set(stringStringEntry.getKey(), stringStringEntry.getValue()))
+                .toList();
+    }
+
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -278,12 +278,16 @@ class OnboardingControllerTest {
     @TestSecurity(user = "userJwt")
     void deleteOK(){
         String onboardingId = "actual-onboarding-id";
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setReasonForReject("string");
 
-        when(onboardingService.rejectOnboarding(onboardingId))
+        when(onboardingService.rejectOnboarding(onboardingId, "string"))
                 .thenReturn(Uni.createFrom().item(1L));
 
         given()
                 .when()
+                .body(reasonRequest)
+                .contentType(ContentType.JSON)
                 .pathParam("onboardingId", onboardingId)
                 .put("/{onboardingId}/reject")
                 .then()
@@ -291,7 +295,7 @@ class OnboardingControllerTest {
 
         ArgumentCaptor<String> expectedId = ArgumentCaptor.forClass(String.class);
         verify(onboardingService, times(1))
-                .rejectOnboarding(expectedId.capture());
+                .rejectOnboarding(expectedId.capture(), eq("string"));
         assertEquals(expectedId.getValue(), onboardingId);
     }
 
@@ -299,12 +303,16 @@ class OnboardingControllerTest {
     @TestSecurity(user = "userJwt")
     void deleteInvalidOnboardingIdOrOnboardingNotFound(){
         String onboardingId = "actual-onboarding-id";
+        ReasonRequest reasonRequest = new ReasonRequest();
+        reasonRequest.setReasonForReject("string");
 
-        when(onboardingService.rejectOnboarding(onboardingId))
+        when(onboardingService.rejectOnboarding(onboardingId, "string"))
                 .thenThrow(InvalidRequestException.class);
 
         given()
                 .when()
+                .body(reasonRequest)
+                .contentType(ContentType.JSON)
                 .pathParam("onboardingId", onboardingId)
                 .put("/{onboardingId}/reject")
                 .then()
@@ -312,7 +320,7 @@ class OnboardingControllerTest {
 
         ArgumentCaptor<String> expectedId = ArgumentCaptor.forClass(String.class);
         verify(onboardingService, times(1))
-                .rejectOnboarding(expectedId.capture());
+                .rejectOnboarding(expectedId.capture(), eq("string"));
         assertEquals(expectedId.getValue(), onboardingId);
     }
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -987,15 +987,15 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void testOnboardingUpdateStatusOK() {
-
+        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
-        mockUpdateOnboarding(onboarding.getId(), 1L);
+        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId())
+                .rejectOnboarding(onboarding.getId(), "string")
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -1004,15 +1004,16 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void rejectOnboarding_statusIsCOMPLETED() {
+        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         onboarding.setStatus(OnboardingStatus.COMPLETED);
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
-        mockUpdateOnboarding(onboarding.getId(), 1L);
+        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId())
+                .rejectOnboarding(onboarding.getId(), "string")
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
@@ -1021,25 +1022,25 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void testOnboardingDeleteOnboardingNotFoundOrAlreadyDeleted() {
-
+        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
-        mockUpdateOnboarding(onboarding.getId(), 0L);
+        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 0L);
 
         UniAssertSubscriber<Long> subscriber = onboardingService
-                .rejectOnboarding(onboarding.getId())
+                .rejectOnboarding(onboarding.getId(), "string")
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create());
 
         subscriber.assertFailedWith(InvalidRequestException.class);
     }
 
-    private void mockUpdateOnboarding(String onboardingId, Long updatedItemCount) {
+    private void mockUpdateOnboarding(String onboardingId, String reasonForReject, Long updatedItemCount) {
         ReactivePanacheUpdate query = mock(ReactivePanacheUpdate.class);
         PanacheMock.mock(Onboarding.class);
-        when(Onboarding.update(Onboarding.Fields.status.name(), OnboardingStatus.REJECTED)).thenReturn(query);
+        when(Onboarding.update(any(Document.class))).thenReturn(query);
         when(query.where("_id", onboardingId)).thenReturn(Uni.createFrom().item(updatedItemCount));
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added new ReasonRequest Object with reasonForReject attribute
- A new method has been added so that when the onboarding request is rejected by the PagoPA operator, in addition to changing the status, the new reasonForReject field is saved on the DB Entity

#### Motivation and Context

This change allows you to also inform via PEC the reason why your request was rejected by the PagoPA operator

#### How Has This Been Tested?

the API was invoked locally and it was verified that the status was updated from TOBEVALIDATE to REJECTED and it was also verified that the new reasonForReject attribute was saved.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.