### PR TITLE
[SELC - 4393] fix: added updatedAt in query to update

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -796,7 +796,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     private static Uni<Long> updateReasonForRejectAndUpdateStatus(String onboardingId, String reasonForReject) {
-        Map<String, String> queryParameter = QueryUtils.createMapForOnboardingReject(reasonForReject, OnboardingStatus.REJECTED.name());
+        Map<String, Object> queryParameter = QueryUtils.createMapForOnboardingReject(reasonForReject, OnboardingStatus.REJECTED.name());
         Document query =  QueryUtils.buildUpdateDocument(queryParameter);
         return Onboarding.update(query)
                 .where("_id", onboardingId)

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/QueryUtils.java
@@ -16,11 +16,9 @@ import org.bson.codecs.DocumentCodec;
 import org.bson.conversions.Bson;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @RequiredArgsConstructor(access = AccessLevel.NONE)
 public class QueryUtils {
@@ -70,10 +68,11 @@ public class QueryUtils {
         return queryParameterMap;
     }
 
-    public static Map<String, String> createMapForOnboardingReject(String reasonForReject, String onboardingStatus) {
-        Map<String, String> queryParameterMap = new HashMap<>();
+    public static Map<String, Object> createMapForOnboardingReject(String reasonForReject, String onboardingStatus) {
+        Map<String, Object> queryParameterMap = new HashMap<>();
         Optional.ofNullable(reasonForReject).ifPresent(value -> queryParameterMap.put("reasonForReject", value));
         Optional.ofNullable(onboardingStatus).ifPresent(value -> queryParameterMap.put("status", value));
+        queryParameterMap.put("updatedAt", LocalDateTime.now());
         return queryParameterMap;
     }
 
@@ -85,7 +84,7 @@ public class QueryUtils {
         }
     }
 
-    public static Document buildUpdateDocument(Map<String, String> parameters) {
+    public static Document buildUpdateDocument(Map<String, Object> parameters) {
         if (!parameters.isEmpty()) {
             return bsonToDocument(Updates.combine(constructBsonUpdate(parameters)));
         } else {
@@ -93,7 +92,7 @@ public class QueryUtils {
         }
     }
 
-    private static List<Bson> constructBsonUpdate(Map<String, String> parameters) {
+    private static List<Bson> constructBsonUpdate(Map<String, Object> parameters) {
         return parameters.entrySet()
                 .stream()
                 .map(stringStringEntry -> Updates.set(stringStringEntry.getKey(), stringStringEntry.getValue()))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

added updatedAt in query to update

#### Motivation and Context

on the functions side this operation is not performed for reject. In a logical sense it is correct to modify the updatedAt when the request is rejected and not when the email is sent to the institution (function)

#### How Has This Been Tested?

The microservice was started locally and the Reject API was invoked

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.