### PR TITLE
[SELC-4697] feat: added feature flag for persist user function

### DIFF
--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -23,6 +23,8 @@ onboarding-functions.purge.completed-from = 60
 onboarding-functions.purge.completed-to = 30
 onboarding-functions.purge.all-from = 150
 onboarding-functions.purge.all-to = 120
+#property to invoke or not the user microservice
+onboarding-functions.persist-users.active = ${USER_MS_ACTIVE:false}
 
 ## REST CLIENT #
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -466,6 +466,23 @@ public class CompletionServiceDefaultTest {
                 .usersUserIdPost(any(), any());
     }
 
+    @Test
+    void persistUsersWithException() {
+
+        Onboarding onboarding = createOnboarding();
+
+        User user = new User();
+        user.setRole(PartyRole.MANAGER);
+        user.setId("user-id");
+        onboarding.setUsers(List.of(user));
+
+        Response response = new ServerResponse(null, 500, null);
+        when(userControllerApi.usersUserIdPost(any(), any())).thenReturn(response);
+
+        assertThrows(RuntimeException.class, () -> completionServiceDefault.persistUsers(onboarding));
+
+    }
+
     private InstitutionResponse dummyInstitutionResponse() {
         InstitutionResponse response = new InstitutionResponse();
         response.setId("response-id");

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -3,6 +3,8 @@ package it.pagopa.selfcare.onboarding.service;
 import io.quarkus.mongodb.panache.common.PanacheUpdate;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
@@ -47,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
+@TestProfile(CompletionServiceDefaultTest.UserMSProfile.class)
 public class CompletionServiceDefaultTest {
 
     public static final String MANAGER_WORKCONTRACT_MAIL = "mail@mail.it";
@@ -82,6 +85,13 @@ public class CompletionServiceDefaultTest {
     org.openapi.quarkus.party_registry_proxy_json.api.InstitutionApi institutionRegistryProxyApi;
 
     final String productId = "productId";
+
+    public static class UserMSProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("onboarding-functions.persist-users.active", "true");
+        }
+    }
 
     @Test
     void createInstitutionAndPersistInstitutionId_shouldThrowExceptionIfMoreInstitutions() {


### PR DESCRIPTION
#### List of Changes

Added feature flag for persist user function

#### Motivation and Context

In order to distribute onboarding-ms indipendently from other microservices invoked, a feature flag has been added to invoke user-ms and persist user during onboarding phase. The default value has been set false.

#### How Has This Been Tested?

I have run the CREATE_USERS function locally and checked the scenario.
