### PR TITLE
SELC-4709 fix: added originId in Institution in onboarding-functions

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -175,6 +175,14 @@ public class Institution {
         this.origin = origin;
     }
 
+    public String getOriginId() {
+        return originId;
+    }
+
+    public void setOriginId(String originId) {
+        this.originId = originId;
+    }
+
     public InstitutionPaSubunitType getSubunitType() {
         return subunitType;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -15,6 +15,7 @@ public class Institution {
     private InstitutionPaSubunitType subunitType;
 
     private Origin origin;
+    private String originId;
     private String city;
     private String country;
     private String county;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
@@ -56,7 +56,7 @@ public class PdfMapper {
         map.put("zipCode", institution.getZipCode());
         map.put("managerName", getStringValue(manager.getName()));
         map.put("managerSurname", getStringValue(manager.getFamilyName()));
-        map.put("originId", Optional.ofNullable(institution.getOrigin()).map(Origin::name).orElse(""));
+        map.put("originId", Optional.ofNullable(institution.getTaxCode()).map(taxCode -> Optional.ofNullable(institution.getOrigin()).map(Origin::name).orElse("")).orElse(""));
         map.put("institutionMail", institution.getDigitalAddress());
         map.put("managerTaxCode", manager.getFiscalCode());
         map.put("managerEmail", mailManager);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
@@ -56,7 +56,7 @@ public class PdfMapper {
         map.put("zipCode", institution.getZipCode());
         map.put("managerName", getStringValue(manager.getName()));
         map.put("managerSurname", getStringValue(manager.getFamilyName()));
-        map.put("originId", Optional.ofNullable(institution.getTaxCode()).map(taxCode -> Optional.ofNullable(institution.getOrigin()).map(Origin::name).orElse("")).orElse(""));
+        map.put("originId", Optional.ofNullable(institution.getTaxCode()).map(taxCode -> UNDERSCORE).orElse(Optional.ofNullable(institution.getOriginId()).orElse(UNDERSCORE)));
         map.put("institutionMail", institution.getDigitalAddress());
         map.put("managerTaxCode", manager.getFiscalCode());
         map.put("managerEmail", mailManager);


### PR DESCRIPTION
#### List of Changes

added originId in Institution in onboarding-functions, and a check in PdfMapper to assign a value to originId depending on taxCode presence

#### Motivation and Context

It is necessary to add the originId field and map it to the ivassCode for onboarding foreign insurance in the objects used by the onboarding API

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.