### PR TITLE
[SELC-4719] feat: Modified invocation to getInstitutions API to work with origin and originId when taxCode is not present

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -112,10 +112,10 @@ public class CompletionServiceDefault implements CompletionService {
 
     private InstitutionsResponse getInstitutionsByFilters(Institution institution) {
         InstitutionsResponse institutionsResponse;
-        if(!Objects.isNull(institution.getTaxCode())) {
+        if(Objects.nonNull(institution.getTaxCode())) {
             institutionsResponse = institutionApi.getInstitutionsUsingGET(institution.getTaxCode(), institution.getSubunitCode(), null, null);
         } else {
-            String origin = !Objects.isNull(institution.getOrigin()) ? institution.getOrigin().getValue() : null;
+            String origin = Objects.nonNull(institution.getOrigin()) ? institution.getOrigin().getValue() : null;
             institutionsResponse = institutionApi.getInstitutionsUsingGET(null, null, origin, institution.getOriginId());
         }
         return institutionsResponse;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -93,8 +93,7 @@ public class CompletionServiceDefault implements CompletionService {
     public String createInstitutionAndPersistInstitutionId(Onboarding onboarding) {
 
         Institution institution = onboarding.getInstitution();
-
-        InstitutionsResponse institutionsResponse = institutionApi.getInstitutionsUsingGET(institution.getTaxCode(), institution.getSubunitCode(), null, null);
+        InstitutionsResponse institutionsResponse = getInstitutionsByFilters(institution);
         if(Objects.nonNull(institutionsResponse.getInstitutions()) && institutionsResponse.getInstitutions().size() > 1){
             throw new GenericOnboardingException("List of institutions is ambiguous, it is empty or has more than one element!!");
         }
@@ -109,6 +108,17 @@ public class CompletionServiceDefault implements CompletionService {
                 .where("_id", onboarding.getId());
 
         return institutionResponse.getId();
+    }
+
+    private InstitutionsResponse getInstitutionsByFilters(Institution institution) {
+        InstitutionsResponse institutionsResponse;
+        if(!Objects.isNull(institution.getTaxCode())) {
+            institutionsResponse = institutionApi.getInstitutionsUsingGET(institution.getTaxCode(), institution.getSubunitCode(), null, null);
+        } else {
+            String origin = !Objects.isNull(institution.getOrigin()) ? institution.getOrigin().getValue() : null;
+            institutionsResponse = institutionApi.getInstitutionsUsingGET(null, null, origin, institution.getOriginId());
+        }
+        return institutionsResponse;
     }
 
     /**

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -139,6 +139,7 @@ public class CompletionServiceDefaultTest {
         Onboarding onboarding = createOnboarding();
 
         Institution institutionSa = new Institution();
+        institutionSa.setTaxCode("taxCode");
         institutionSa.setInstitutionType(InstitutionType.SA);
         institutionSa.setOrigin(Origin.ANAC);
         onboarding.setInstitution(institutionSa);
@@ -155,10 +156,11 @@ public class CompletionServiceDefaultTest {
     }
 
     @Test
-    void createInstitutionAndPersistInstitutionId_notFoundInstitutionAndCreateAsIvass() {
+    void createInstitutionAndPersistInstitutionId_notFoundInstitutionAndCreateAsIvassWithTaxCode() {
         Onboarding onboarding = createOnboarding();
 
         Institution institution = new Institution();
+        institution.setTaxCode("taxCode");
         institution.setInstitutionType(InstitutionType.AS);
         institution.setOrigin(Origin.IVASS);
         onboarding.setInstitution(institution);
@@ -173,11 +175,32 @@ public class CompletionServiceDefaultTest {
 
         mockOnboardingUpdateAndExecuteCreateInstitution(onboarding, institutionResponse);
     }
+
+    @Test
+    void createInstitutionAndPersistInstitutionId_notFoundInstitutionAndCreateAsIvassWithOrigin() {
+        Onboarding onboarding = createOnboarding();
+
+        Institution institution = new Institution();
+        institution.setInstitutionType(InstitutionType.AS);
+        institution.setOrigin(Origin.IVASS);
+        institution.setOriginId("originId");
+        onboarding.setInstitution(institution);
+
+        InstitutionsResponse response = new InstitutionsResponse();
+        when(institutionApi.getInstitutionsUsingGET(null, null, Origin.IVASS.getValue(), "originId"))
+                .thenReturn(response);
+
+        InstitutionResponse institutionResponse = dummyInstitutionResponse();
+        when(institutionApi.createInstitutionFromIvassUsingPOST(any())).thenReturn(institutionResponse);
+
+        mockOnboardingUpdateAndExecuteCreateInstitution(onboarding, institutionResponse);
+    }
     @Test
     void createInstitutionAndPersistInstitutionId_notFoundInstitutionAndCreatePgAde() {
         Onboarding onboarding = createOnboarding();
 
         Institution institution = new Institution();
+        institution.setTaxCode("taxCode");
         institution.setInstitutionType(InstitutionType.PG);
         institution.setOrigin(Origin.ADE);
         onboarding.setInstitution(institution);
@@ -197,6 +220,7 @@ public class CompletionServiceDefaultTest {
         Onboarding onboarding = createOnboarding();
 
         Institution institution = new Institution();
+        institution.setTaxCode("taxCode");
         institution.setInstitutionType(InstitutionType.PA);
         institution.setSubunitType(InstitutionPaSubunitType.AOO);
         institution.setSubunitCode("code");
@@ -232,6 +256,7 @@ public class CompletionServiceDefaultTest {
         Onboarding onboarding = createOnboarding();
 
         Institution institution = new Institution();
+        institution.setTaxCode("taxCode");
         institution.setInstitutionType(InstitutionType.PA);
         institution.setSubunitType(InstitutionPaSubunitType.UO);
         institution.setSubunitCode("code");


### PR DESCRIPTION
#### List of Changes

modified invocation to getInstitutions API to work with origin and originId when taxCode is not present

#### Motivation and Context

When creating an institution in the onboarding finalization phase there is a verification of the institution's existence by invoking a core api using taxCode and subunitCode. With this modification, the origin and originId can also be sent to the api to perform the verification in the absence of taxCode

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.