### PR TITLE
[SELC-4773] fix: removed condition on the field originId for IVASS contract

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
@@ -61,7 +61,7 @@ public class PdfMapper {
         map.put("zipCode", Optional.ofNullable(institution.getZipCode()).orElse(""));
         map.put("managerName", getStringValue(manager.getName()));
         map.put("managerSurname", getStringValue(manager.getFamilyName()));
-        map.put("originId", Optional.ofNullable(institution.getTaxCode()).map(taxCode -> UNDERSCORE).orElse(Optional.ofNullable(institution.getOriginId()).orElse(UNDERSCORE)));
+        map.put("originId", Optional.ofNullable(institution.getOriginId()).orElse(UNDERSCORE));
         map.put("institutionMail", institution.getDigitalAddress());
         map.put("managerTaxCode", manager.getFiscalCode());
         map.put("managerEmail", mailManager);


### PR DESCRIPTION
#### List of Changes

Removed condition on field originId for IVASS contract

#### Motivation and Context

With this development, the field originId will be filled indipendently from the fiscal code.

#### How Has This Been Tested?

I have deployed the bugfix directly in the DEV environment and tested the specific scenario.
