### PR TITLE
chore: Use Container App name as url when calling a container app

### DIFF
--- a/infra/container_apps/onboarding-ms/env/dev-pnpg/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/dev-pnpg/terraform.tfvars
@@ -58,11 +58,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-d-pnpg-ms-core-ca.victoriousfield-e39534b8.westeurope.azurecontainerapps.io"
+    value = "http://selc-d-pnpg-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-d-pnpg-party-reg-proxy-ca.victoriousfield-e39534b8.westeurope.azurecontainerapps.io"
+    value = "http://selc-d-pnpg-party-reg-proxy-ca"
   },
   {
     name  = "SIGNATURE_VALIDATION_ENABLED"

--- a/infra/container_apps/onboarding-ms/env/dev/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/dev/terraform.tfvars
@@ -57,11 +57,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-d-ms-core-ca.politewater-9af33050.westeurope.azurecontainerapps.io"
+    value = "http://selc-d-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-d-party-reg-proxy-ca.politewater-9af33050.westeurope.azurecontainerapps.io"
+    value = "http://selc-d-party-reg-proxy-ca"
   },
   {
     name  = "SIGNATURE_VALIDATION_ENABLED"

--- a/infra/container_apps/onboarding-ms/env/prod-pnpg/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/prod-pnpg/terraform.tfvars
@@ -58,11 +58,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-p-pnpg-ms-core-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io"
+    value = "http://selc-p-pnpg-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-p-pnpg-party-reg-proxy-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io"
+    value = "http://selc-p-pnpg-party-reg-proxy-ca"
   },
   {
     name  = "SIGNATURE_VALIDATION_ENABLED"

--- a/infra/container_apps/onboarding-ms/env/prod/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/prod/terraform.tfvars
@@ -57,11 +57,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-p-ms-core-ca.greensand-62fc96da.westeurope.azurecontainerapps.io"
+    value = "http://selc-p-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-p-party-reg-proxy-ca.greensand-62fc96da.westeurope.azurecontainerapps.io"
+    value = "http://selc-p-party-reg-proxy-ca"
   },
   {
     name  = "STORAGE_CONTAINER_CONTRACT"

--- a/infra/container_apps/onboarding-ms/env/uat-pnpg/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/uat-pnpg/terraform.tfvars
@@ -47,11 +47,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-u-pnpg-ms-core-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io"
+    value = "http://selc-u-pnpg-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-u-pnpg-party-reg-proxy-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io"
+    value = "http://selc-u-pnpg-party-reg-proxy-ca"
   },
   {
     name  = "SIGNATURE_VALIDATION_ENABLED"

--- a/infra/container_apps/onboarding-ms/env/uat/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/uat/terraform.tfvars
@@ -46,11 +46,11 @@ app_settings = [
   },
   {
     name  = "MS_CORE_URL"
-    value = "https://selc-u-ms-core-ca.proudglacier-20652b81.westeurope.azurecontainerapps.io"
+    value = "http://selc-u-ms-core-ca"
   },
   {
     name  = "MS_PARTY_REGISTRY_URL"
-    value = "https://selc-u-party-reg-proxy-ca.proudglacier-20652b81.westeurope.azurecontainerapps.io"
+    value = "http://selc-u-party-reg-proxy-ca"
   },
   {
     name  = "SIGNATURE_VALIDATION_ENABLED"


### PR DESCRIPTION
… url

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Remove https to container app url
* Remove suffix {env}.westeurope.azurecontainerapps.io to container app url

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
You can call other container apps in the same environment from your application code using the container app name, for instance http://<APP_NAME> for internal requests. It is the best method for internal requests inside a Container App environment

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.