### PR TITLE
[SELC-5034] feature: added logic to discriminate event type in cdc module

### DIFF
--- a/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/NotificationService.java
+++ b/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/NotificationService.java
@@ -1,0 +1,61 @@
+package it.pagopa.selfcare.onboarding.event;
+
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.onboarding.event.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.event.entity.util.QueueEvent;
+import it.pagopa.selfcare.onboarding.event.mapper.OnboardingMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.openapi.quarkus.onboarding_functions_json.api.NotificationsApi;
+import org.openapi.quarkus.onboarding_functions_json.model.OrchestrationResponse;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@ApplicationScoped
+public class NotificationService {
+    @Inject
+    @RestClient
+    NotificationsApi notificationsApi;
+    private final OnboardingMapper onboardingMapper;
+    private final Integer retryMinBackOff;
+    private final Integer retryMaxBackOff;
+    private final Integer maxRetry;
+    private final Integer minutesThresholdForUpdateNotification;
+
+    public NotificationService(OnboardingMapper onboardingMapper,
+                               @ConfigProperty(name = "onboarding-cdc.retry.min-backoff") Integer retryMinBackOff,
+                               @ConfigProperty(name = "onboarding-cdc.retry.max-backoff") Integer retryMaxBackOff,
+                               @ConfigProperty(name = "onboarding-cdc.retry") Integer maxRetry,
+                               @ConfigProperty(name = "onboarding-cdc.minutes-threshold-for-update-notification") Integer minutesThresholdForUpdateNotification) {
+        this.onboardingMapper = onboardingMapper;
+        this.retryMinBackOff = retryMinBackOff;
+        this.retryMaxBackOff = retryMaxBackOff;
+        this.maxRetry = maxRetry;
+        this.minutesThresholdForUpdateNotification = minutesThresholdForUpdateNotification;
+    }
+
+    public Uni<OrchestrationResponse> invokeNotificationApi(Onboarding onboarding) {
+        assert onboarding != null;
+        QueueEvent queueEvent = determineEventType(onboarding);
+        return notificationsApi.apiNotificationPost(queueEvent.name(), onboardingMapper.toEntity(onboarding))
+                .onFailure().retry().withBackOff(Duration.ofSeconds(retryMinBackOff), Duration.ofHours(retryMaxBackOff)).atMost(maxRetry);
+    }
+
+    private QueueEvent determineEventType(Onboarding onboarding) {
+        return switch (onboarding.getStatus()) {
+            case COMPLETED -> (isOverUpdateThreshold(onboarding.getUpdatedAt(), onboarding.getActivatedAt())) ? QueueEvent.UPDATE : QueueEvent.ADD;
+            case DELETED -> QueueEvent.UPDATE;
+            default -> throw new IllegalArgumentException("Onboarding status not supported");
+        };
+    }
+
+    private boolean isOverUpdateThreshold(LocalDateTime updatedAt, LocalDateTime activatedAt) {
+        return Objects.nonNull(updatedAt)
+                && Objects.nonNull(activatedAt)
+                && updatedAt.isAfter(activatedAt.plusMinutes(minutesThresholdForUpdateNotification));
+    }
+}

--- a/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/OnboardingCdcService.java
+++ b/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/OnboardingCdcService.java
@@ -154,23 +154,17 @@ public class OnboardingCdcService {
     }
 
     private QueueEvent determineEventType(Onboarding onboarding) {
-        if (onboarding.getStatus() == COMPLETED) {
-            if (Objects.nonNull(onboarding.getActivatedAt()) && isOverUpdateThreshold(onboarding.getUpdatedAt(), onboarding.getActivatedAt())) {
-                return QueueEvent.UPDATE;
-            }
-
-            return QueueEvent.ADD;
-        }
-
-        if (onboarding.getStatus() == DELETED) {
-            return QueueEvent.UPDATE;
-        }
-
-        throw new IllegalArgumentException("Onboarding status not supported");
+        return switch (onboarding.getStatus()) {
+            case COMPLETED -> (isOverUpdateThreshold(onboarding.getUpdatedAt(), onboarding.getActivatedAt())) ? QueueEvent.UPDATE : QueueEvent.ADD;
+            case DELETED -> QueueEvent.UPDATE;
+            default -> throw new IllegalArgumentException("Onboarding status not supported");
+        };
     }
 
     private boolean isOverUpdateThreshold(LocalDateTime updatedAt, LocalDateTime activatedAt) {
-        return updatedAt.isAfter(activatedAt.plusMinutes(minutesThresholdForUpdateNotification));
+        return Objects.nonNull(updatedAt)
+                && Objects.nonNull(activatedAt)
+                && updatedAt.isAfter(activatedAt.plusMinutes(minutesThresholdForUpdateNotification));
     }
 
     private void updateLastResumeToken(BsonDocument resumeToken) {

--- a/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/entity/util/QueueEvent.java
+++ b/apps/onboarding-cdc/src/main/java/it/pagopa/selfcare/onboarding/event/entity/util/QueueEvent.java
@@ -1,0 +1,6 @@
+package it.pagopa.selfcare.onboarding.event.entity.util;
+
+public enum QueueEvent {
+    ADD,
+    UPDATE
+}

--- a/apps/onboarding-cdc/src/main/openapi/onboarding_functions.json
+++ b/apps/onboarding-cdc/src/main/openapi/onboarding_functions.json
@@ -85,6 +85,17 @@
         ],
         "summary": "",
         "description": "",
+        "parameters": [
+          {
+            "name": "queueEvent",
+            "in": "query",
+            "description": "Query Event type",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {

--- a/apps/onboarding-cdc/src/main/resources/application.properties
+++ b/apps/onboarding-cdc/src/main/resources/application.properties
@@ -15,6 +15,7 @@ onboarding-cdc.storage.connection-string=${STORAGE_CONNECTION_STRING:UseDevelopm
 onboarding-cdc.retry.min-backoff=${ONBOARDING-CDC-RETRY-MIN-BACKOFF:1}
 onboarding-cdc.retry.max-backoff=${ONBOARDING-CDC-RETRY-MAX-BACKOFF:2}
 onboarding-cdc.retry=${ONBOARDING-CDC-RETRY:3}
+onboarding-cdc.minutes-threshold-for-update-notification=${ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION:5}
 
 quarkus.openapi-generator.codegen.spec.onboarding_functions_json.mutiny=true
 quarkus.openapi-generator.codegen.spec.onboarding_functions_json.type-mappings.DateTime=java.time.LocalDateTime

--- a/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/NotificationServiceTest.java
+++ b/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/NotificationServiceTest.java
@@ -1,0 +1,92 @@
+package it.pagopa.selfcare.onboarding.event;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.event.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.event.entity.util.QueueEvent;
+import it.pagopa.selfcare.onboarding.event.mapper.OnboardingMapper;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.openapi.quarkus.onboarding_functions_json.api.NotificationsApi;
+import org.openapi.quarkus.onboarding_functions_json.model.OrchestrationResponse;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.*;
+
+@QuarkusTest
+public class NotificationServiceTest {
+    @Mock
+    private OnboardingMapper onboardingMapper;
+    @InjectMock
+    @RestClient
+    private NotificationsApi notificationsApi;
+    @Inject
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("Should handle Invoke Notification API Success passing event ADD")
+    public void shouldHandleInvokeNotificationApiSuccessForQueueEventAdd() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.COMPLETED);
+        onboarding.setUpdatedAt(LocalDateTime.now());
+        onboarding.setActivatedAt(LocalDateTime.now());
+
+        when(notificationsApi.apiNotificationPost(any(), any()))
+                .thenReturn(Uni.createFrom().item(new OrchestrationResponse()));
+
+        UniAssertSubscriber<OrchestrationResponse> subscriber = notificationService
+                .invokeNotificationApi(onboarding)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompleted().awaitItem();
+
+        verify(notificationsApi, times(1)).apiNotificationPost(eq(QueueEvent.ADD.name()), any());
+    }
+
+    @Test
+    @DisplayName("Should handle Invoke Notification API Success passing event UPDATE")
+    public void shouldHandleInvokeNotificationApiSuccessForQueueEventUpdate() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.COMPLETED);
+        onboarding.setUpdatedAt(LocalDateTime.now().plusMinutes(10)); // 5 minutes should be the threshold
+        onboarding.setActivatedAt(LocalDateTime.now());
+
+        when(notificationsApi.apiNotificationPost(any(), any()))
+                .thenReturn(Uni.createFrom().item(new OrchestrationResponse()));
+
+        UniAssertSubscriber<OrchestrationResponse> subscriber = notificationService
+                .invokeNotificationApi(onboarding)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompleted().awaitItem();
+
+        verify(notificationsApi, times(1)).apiNotificationPost(eq(QueueEvent.UPDATE.name()), any());
+    }
+
+    @Test
+    @DisplayName("Should handle Invoke Notification API Success passing event UPDATE with status DELETED")
+    public void shouldHandleInvokeNotificationApiSuccessForQueueEventUpdateWithStatusDeleted() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.DELETED);
+        onboarding.setUpdatedAt(LocalDateTime.now()); // 5 minutes should be the threshold
+        onboarding.setActivatedAt(LocalDateTime.now());
+
+        when(notificationsApi.apiNotificationPost(any(), any()))
+                .thenReturn(Uni.createFrom().item(new OrchestrationResponse()));
+
+        UniAssertSubscriber<OrchestrationResponse> subscriber = notificationService
+                .invokeNotificationApi(onboarding)
+                .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertCompleted().awaitItem();
+
+        verify(notificationsApi, times(1)).apiNotificationPost(eq(QueueEvent.UPDATE.name()), any());
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -85,13 +85,17 @@ public class NotificationFunctions {
                     .build();
         }
 
+        final String queueEventString = request.getQueryParameters().get("queueEvent");
+        final QueueEvent queueEvent = Objects.isNull(queueEventString) ? QueueEvent.UPDATE : QueueEvent.valueOf(queueEventString);
+
+
         final Optional<Onboarding> onboarding = onboardingService.getOnboarding(onboardingId);
         if(onboarding.isEmpty()) {
             return request.createResponseBuilder(HttpStatus.NOT_FOUND)
                     .body("Onboarding with ID: " + onboardingId + " not found")
                     .build();
         }
-        notificationEventService.send(context, onboarding.get(), QueueEvent.UPDATE);
+        notificationEventService.send(context, onboarding.get(), queueEvent);
         return request.createResponseBuilder(HttpStatus.OK).build();
     }
 }

--- a/infra/container_apps/onboarding-cdc/env/dev/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/dev/terraform.tfvars
@@ -46,6 +46,10 @@ app_settings = [
   {
     name  = "ONBOARDING-CDC-MONGODB-WATCH-ENABLED"
     value = "true"
+  },
+  {
+    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    value = "5"
   }
 ]
 

--- a/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
@@ -33,6 +33,10 @@ app_settings = [
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-d-onboarding-fn.azurewebsites.net"
+  },
+  {
+    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    value = "5"
   }
 ]
 

--- a/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
@@ -35,6 +35,10 @@ app_settings = [
   {
     name  = "ONBOARDING_FUNCTIONS_URL"
     value = "https://selc-d-onboarding-fn.azurewebsites.net"
+  },
+  {
+    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    value = "5"
   }
 ]
 


### PR DESCRIPTION
#### List of Changes

Added logic to discriminate event type in cdc module before invoking function to send notifications

#### Motivation and Context
With this feature we have the ability to understand if the result of a change in an onboarding document we need to send an event on ADD or UPDATE on queues

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.