### PR TITLE
[SELC-4894] fix: removed filePath from base builder and added only in standard builder

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/BaseNotificationBuilder.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/BaseNotificationBuilder.java
@@ -58,9 +58,9 @@ public class BaseNotificationBuilder implements NotificationBuilder {
             notificationToSend.setId(UUID.randomUUID().toString());
         }
         notificationToSend.setState(convertOnboardingStatusToNotificationStatus(onboarding.getStatus()));
-        mapDataFromToken(token, notificationToSend);
         mapDataFromOnboarding(onboarding, notificationToSend, queueEvent);
         notificationToSend.setInstitution(retrieveInstitution(institution));
+        setTokenData(notificationToSend, token);
 
         return notificationToSend;
     }
@@ -84,17 +84,6 @@ public class BaseNotificationBuilder implements NotificationBuilder {
                 notificationToSend.setUpdatedAt(OffsetDateTime.of(Optional.ofNullable(onboarding.getUpdatedAt()).orElse(onboarding.getCreatedAt()), ZoneOffset.UTC));
             }
         }
-    }
-
-    private void mapDataFromToken(Token token, NotificationToSend notificationToSend) {
-        if(Objects.isNull(token)) {
-            return;
-        }
-
-        notificationToSend.setProduct(token.getProductId());
-        notificationToSend.setFilePath(token.getContractSigned());
-        notificationToSend.setFileName(Objects.isNull(token.getContractSigned()) ? "" : Paths.get(token.getContractSigned()).getFileName().toString());
-        notificationToSend.setContentType(token.getContractSigned());
     }
 
     private String convertOnboardingStatusToNotificationStatus(OnboardingStatus status) {
@@ -188,5 +177,16 @@ public class BaseNotificationBuilder implements NotificationBuilder {
         billingToSend.setVatNumber(billing.getVatNumber());
         billingToSend.setRecipientCode(billing.getRecipientCode());
         return billingToSend;
+    }
+
+    @Override
+    public void setTokenData(NotificationToSend notificationToSend, Token token) {
+        if(Objects.isNull(token)) {
+            return;
+        }
+
+        notificationToSend.setProduct(token.getProductId());
+        notificationToSend.setFileName(Objects.isNull(token.getContractSigned()) ? "" : Paths.get(token.getContractSigned()).getFileName().toString());
+        notificationToSend.setContentType(token.getContractSigned());
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/NotificationBuilder.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/NotificationBuilder.java
@@ -14,6 +14,7 @@ public interface NotificationBuilder {
         return true;
     }
     InstitutionToNotify retrieveInstitution(InstitutionResponse institution);
+    void setTokenData(NotificationToSend notificationToSend, Token token);
     void retrieveAndSetGeographicData(InstitutionToNotify institution);
     BillingToSend retrieveBilling(Onboarding onboarding);
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/StandardNotificationBuilder.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/StandardNotificationBuilder.java
@@ -41,4 +41,10 @@ public class StandardNotificationBuilder extends BaseNotificationBuilder {
         billing.setTaxCodeInvoicing(onboarding.getBilling().getTaxCodeInvoicing());
         return billing;
     }
+
+    @Override
+    public void setTokenData(NotificationToSend notificationToSend, Token token) {
+        super.setTokenData(notificationToSend, token);
+        notificationToSend.setFilePath(token.getContractSigned());
+    }
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/FdNotificationBuilderTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/FdNotificationBuilderTest.java
@@ -86,5 +86,6 @@ class FdNotificationBuilderTest {
         assertNull(notification.getBilling().getTaxCodeInvoicing());
         assertNull(notification.getBilling().isPublicServices());
         assertEquals(onboarding.getBilling().isPublicServices(), notification.getBilling().isPublicService());
+        assertNull(notification.getFilePath());
     }
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/SapNotificationBuilderTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/SapNotificationBuilderTest.java
@@ -115,6 +115,7 @@ class SapNotificationBuilderTest {
         assertEquals("provinceAbbreviation", notification.getInstitution().getCounty());
         assertEquals("countryAbbreviation", notification.getInstitution().getCountry());
         assertEquals("desc", notification.getInstitution().getCity());
+        assertNull(notification.getFilePath());
     }
 
     @Test

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/StandardNotificationBuilderTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/StandardNotificationBuilderTest.java
@@ -75,6 +75,7 @@ class StandardNotificationBuilderTest {
         assertEquals(tokenId, notification.getOnboardingTokenId());
         assertEquals(onboarding.getActivatedAt(), notification.getCreatedAt().toLocalDateTime());
         assertEquals(onboarding.getActivatedAt(), notification.getUpdatedAt().toLocalDateTime());
+        assertEquals(token.getContractSigned(), notification.getFilePath());
         assertEquals(QueueEvent.ADD, notification.getNotificationType());
     }
 


### PR DESCRIPTION
#### List of Changes
Removed filePath from base builder and added only in standard builder

#### Motivation and Context
the node "filePath" in root model NotificationToSend should not have value for SAP and FD model

#### How Has This Been Tested?
dev env

#### Screenshots (if appropriate):

#### Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.