### PR TITLE
[SELC-4899] feature: added http function to find notification by filter

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/NotificationConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/NotificationConfig.java
@@ -8,6 +8,7 @@ import java.util.Map;
 @ConfigMapping(prefix = "notification")
 public interface NotificationConfig {
     Map<String, Consumer> consumers();
+    Integer minutesThresholdForUpdateNotification();
     interface Consumer {
         String topic();
         String name();

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/FindNotificationToSendResponse.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/FindNotificationToSendResponse.java
@@ -1,0 +1,32 @@
+package it.pagopa.selfcare.onboarding.dto;
+
+import java.util.List;
+
+public class FindNotificationToSendResponse {
+    private List<NotificationToSend> notifications;
+    private Long count;
+
+    public FindNotificationToSendResponse() {
+    }
+
+    public FindNotificationToSendResponse(List<NotificationToSend> notifications, Long count) {
+        this.notifications = notifications;
+        this.count = count;
+    }
+
+    public List<NotificationToSend> getNotifications() {
+        return notifications;
+    }
+
+    public void setNotifications(List<NotificationToSend> notifications) {
+        this.notifications = notifications;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
@@ -11,21 +11,7 @@ public class NotificationToSendFilters {
     private Integer page;
     private Integer size;
 
-    public NotificationToSendFilters() {
-    }
-
-    public NotificationToSendFilters(String productId, String institutionId, String onboardingId, String taxCode, String status, String from, String to, Integer page, Integer size) {
-        this.productId = productId;
-        this.institutionId = institutionId;
-        this.onboardingId = onboardingId;
-        this.taxCode = taxCode;
-        this.status = status;
-        this.from = from;
-        this.to = to;
-        this.page = page;
-        this.size = size;
-    }
-
+    public NotificationToSendFilters() {}
     public String getProductId() {
         return productId;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
@@ -1,0 +1,100 @@
+package it.pagopa.selfcare.onboarding.dto;
+
+public class NotificationToSendFilters {
+    private String productId;
+    private String institutionId;
+    private String onboardingId;
+    private String taxCode;
+    private String status;
+    private String from;
+    private String to;
+    private Integer page;
+    private Integer size;
+
+    public NotificationToSendFilters() {
+    }
+
+    public NotificationToSendFilters(String productId, String institutionId, String onboardingId, String taxCode, String status, String from, String to, Integer page, Integer size) {
+        this.productId = productId;
+        this.institutionId = institutionId;
+        this.onboardingId = onboardingId;
+        this.taxCode = taxCode;
+        this.status = status;
+        this.from = from;
+        this.to = to;
+        this.page = page;
+        this.size = size;
+    }
+
+    public String getProductId() {
+        return productId;
+    }
+
+    public void setProductId(String productId) {
+        this.productId = productId;
+    }
+
+    public String getInstitutionId() {
+        return institutionId;
+    }
+
+    public void setInstitutionId(String institutionId) {
+        this.institutionId = institutionId;
+    }
+
+    public String getOnboardingId() {
+        return onboardingId;
+    }
+
+    public void setOnboardingId(String onboardingId) {
+        this.onboardingId = onboardingId;
+    }
+
+    public String getTaxCode() {
+        return taxCode;
+    }
+
+    public void setTaxCode(String taxCode) {
+        this.taxCode = taxCode;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public Integer getPage() {
+        return page;
+    }
+
+    public void setPage(Integer page) {
+        this.page = page;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/dto/NotificationToSendFilters.java
@@ -11,7 +11,6 @@ public class NotificationToSendFilters {
     private Integer page;
     private Integer size;
 
-    public NotificationToSendFilters() {}
     public String getProductId() {
         return productId;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -3,12 +3,13 @@ package it.pagopa.selfcare.onboarding.entity;
 import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
+import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.List;
 
 public class Institution {
-
-    private String id;
+    @BsonProperty("id")
+    public String id;
     private InstitutionType institutionType;
     private String taxCode;
     private String subunitCode;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -2,19 +2,21 @@ package it.pagopa.selfcare.onboarding.entity;
 
 
 import io.quarkus.mongodb.panache.common.MongoEntity;
+import io.quarkus.mongodb.panache.reactive.ReactivePanacheMongoEntityBase;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import org.bson.codecs.pojo.annotations.BsonId;
+import org.openapi.quarkus.core_json.model.AdditionalInformations;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-
 @MongoEntity(collection="onboardings")
-public class Onboarding  {
+public class Onboarding extends ReactivePanacheMongoEntityBase {
 
     @BsonId
-    private String id;
+    public String id;
+
     private String productId;
     private List<String> testEnvProductIds;
     private WorkflowType workflowType;
@@ -23,14 +25,16 @@ public class Onboarding  {
     private String pricingPlan;
     private Billing billing;
     private Boolean signContract;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime activatedAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
     private LocalDateTime expiringDate;
     private OnboardingStatus status;
     private String userRequestUid;
     private String workflowInstanceId;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private LocalDateTime activatedAt;
-    private LocalDateTime deletedAt;
+    private AdditionalInformations additionalInformations;
     private String reasonForReject;
 
     public String getId() {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -176,6 +176,14 @@ public class Onboarding extends ReactivePanacheMongoEntityBase {
         this.deletedAt = deletedAt;
     }
 
+    public AdditionalInformations getAdditionalInformations() {
+        return additionalInformations;
+    }
+
+    public void setAdditionalInformations(AdditionalInformations additionalInformations) {
+        this.additionalInformations = additionalInformations;
+    }
+
     @Override
     public String toString() {
         return "Onboarding{" +

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -61,7 +61,7 @@ public class NotificationFunctions {
         final String onboardingString = request.getBody().get();
         try {
             onboarding = readOnboardingValue(objectMapper, onboardingString);
-            context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, SEND_ONBOARDING_NOTIFICATION, onboardingString));
+            context.getLogger().info(() -> String.format(FORMAT_LOGGER_ONBOARDING_STRING, SEND_ONBOARDING_NOTIFICATION, onboardingString));
         } catch (Exception ex) {
             context.getLogger().warning("Error during sendNotifications execution, msg: " + ex.getMessage());
             return request.createResponseBuilder(HttpStatus.BAD_REQUEST)

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -110,17 +110,7 @@ public class NotificationFunctions {
             final ExecutionContext context) throws JsonProcessingException {
         context.getLogger().info("findNotificationsToSend trigger processed a request");
 
-        final String productId = request.getQueryParameters().get("productId");
-        final String institutionId = request.getQueryParameters().get("institutionId");
-        final String onboardingId = request.getQueryParameters().get("onboardingId");
-        final String taxCode = request.getQueryParameters().get("taxCode");
-        final String from = request.getQueryParameters().get("from");
-        final String to = request.getQueryParameters().get("to");
-        final String status = request.getQueryParameters().get("status");
-        final Integer page = Integer.parseInt(request.getQueryParameters().getOrDefault("page", "0"));
-        final Integer size = Integer.parseInt(request.getQueryParameters().getOrDefault("size", "20"));
-
-        NotificationToSendFilters filters = new NotificationToSendFilters(productId, institutionId, onboardingId, taxCode, status, from, to, page, size);
+        NotificationToSendFilters filters = getNotificationToSendFilters(request);
         FindNotificationToSendResponse response;
         try {
             response = notificationEventService.findNotificationToSend(context, filters);
@@ -140,5 +130,29 @@ public class NotificationFunctions {
                 .body(objectMapper.writeValueAsString(response))
                 .header("Content-Type", MediaType.APPLICATION_JSON)
                 .build();
+    }
+
+    private static NotificationToSendFilters getNotificationToSendFilters(HttpRequestMessage<Optional<String>> request) {
+        final String productId = request.getQueryParameters().get("productId");
+        final String institutionId = request.getQueryParameters().get("institutionId");
+        final String onboardingId = request.getQueryParameters().get("onboardingId");
+        final String taxCode = request.getQueryParameters().get("taxCode");
+        final String from = request.getQueryParameters().get("from");
+        final String to = request.getQueryParameters().get("to");
+        final String status = request.getQueryParameters().get("status");
+        final Integer page = Integer.parseInt(request.getQueryParameters().getOrDefault("page", "0"));
+        final Integer size = Integer.parseInt(request.getQueryParameters().getOrDefault("size", "20"));
+
+        NotificationToSendFilters filters = new NotificationToSendFilters();
+        filters.setProductId(productId);
+        filters.setInstitutionId(institutionId);
+        filters.setOnboardingId(onboardingId);
+        filters.setTaxCode(taxCode);
+        filters.setStatus(status);
+        filters.setFrom(from);
+        filters.setTo(to);
+        filters.setPage(page);
+        filters.setSize(size);
+        return filters;
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventService.java
@@ -2,9 +2,12 @@ package it.pagopa.selfcare.onboarding.service;
 
 import com.microsoft.azure.functions.ExecutionContext;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.dto.FindNotificationToSendResponse;
+import it.pagopa.selfcare.onboarding.dto.NotificationToSendFilters;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
 
 public interface NotificationEventService {
 
     void send(ExecutionContext context, Onboarding onboarding, QueueEvent queueEvent);
+    FindNotificationToSendResponse findNotificationToSend(ExecutionContext context, NotificationToSendFilters notificationToSendFilters);
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -15,12 +15,9 @@ import it.pagopa.selfcare.onboarding.dto.QueueEvent;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.Token;
 import it.pagopa.selfcare.onboarding.exception.NotificationException;
-import it.pagopa.selfcare.onboarding.utils.NotificationBuilder;
+import it.pagopa.selfcare.onboarding.utils.*;
 import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import it.pagopa.selfcare.onboarding.repository.TokenRepository;
-import it.pagopa.selfcare.onboarding.utils.NotificationBuilderFactory;
-import it.pagopa.selfcare.onboarding.utils.QueryUtils;
-import it.pagopa.selfcare.onboarding.utils.SortEnum;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -33,12 +30,15 @@ import org.openapi.quarkus.core_json.model.InstitutionResponse;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class NotificationEventServiceDefault implements NotificationEventService {
 
     private static final String STANDARD_CONSUMER = "standard";
+    private static final Integer MAX_SIZE = 100;
+
     @RestClient
     @Inject
     EventHubRestClient eventHubRestClient;
@@ -53,17 +53,20 @@ public class NotificationEventServiceDefault implements NotificationEventService
     private final TokenRepository tokenRepository;
     private final ObjectMapper mapper;
     private final OnboardingRepository onboardingRepository;
+    private final QueueEventExaminer queueEventExaminer;
 
     public NotificationEventServiceDefault(ProductService productService,
                                            NotificationConfig notificationConfig,
                                            NotificationBuilderFactory notificationBuilderFactory,
                                            TokenRepository tokenRepository,
-                                           OnboardingRepository onboardingRepository) {
+                                           OnboardingRepository onboardingRepository,
+                                           QueueEventExaminer queueEventExaminer) {
         this.productService = productService;
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
         this.tokenRepository = tokenRepository;
         this.onboardingRepository = onboardingRepository;
+        this.queueEventExaminer = queueEventExaminer;
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
     }
@@ -121,6 +124,29 @@ public class NotificationEventServiceDefault implements NotificationEventService
     @Override
     public FindNotificationToSendResponse findNotificationToSend(ExecutionContext context, NotificationToSendFilters filters) {
         context.getLogger().info(String.format("Finding notifications to send with filters: %s", filters));
+        validateFilters(filters);
+
+        Document sort = QueryUtils.buildSortDocument("createdAt", SortEnum.DESC);
+        Map<String, List<String>> queryParameter = QueryUtils.createMapForOnboardingQueryParameter(filters);
+        Document query = QueryUtils.buildQuery(queryParameter);
+
+        List<Onboarding> onboardings = onboardingRepository.find(query, sort).page(filters.getPage(), filters.getSize()).list();
+        long count = onboardingRepository.find(query, sort).count();
+        context.getLogger().info(String.format("Found %s onboardings to send with filters", onboardings.size()));
+
+        Map<String, InstitutionResponse> institutions = getInstitutions(onboardings);
+
+        List<NotificationToSend> notifications = onboardings.stream()
+                .map(onboarding -> buildNotificationToSend(onboarding, institutions))
+                .toList();
+
+        return new FindNotificationToSendResponse(notifications, count);
+    }
+
+    private static void validateFilters(NotificationToSendFilters filters) {
+        if (filters.getSize() > MAX_SIZE) {
+            throw new IllegalArgumentException(String.format("Size cannot be greater than %s.", MAX_SIZE));
+        }
 
         if (filters.getStatus() != null) {
             OnboardingStatus statusEnum = OnboardingStatus.valueOf(filters.getStatus());
@@ -129,35 +155,26 @@ public class NotificationEventServiceDefault implements NotificationEventService
                 throw new IllegalArgumentException("For the status field only COMPLETED and DELETED values are valid.");
             }
         }
+    }
 
-        Document sort = QueryUtils.buildSortDocument("createdAt", SortEnum.DESC);
-        Map<String, List<String>> queryParameter = QueryUtils.createMapForOnboardingQueryParameter(filters);
-        Document query = QueryUtils.buildQuery(queryParameter);
-
-        List<Onboarding> onboardings = onboardingRepository.find(query, sort).page(filters.getPage(), filters.getSize()).list();
-        long count = onboardingRepository.find(query, sort).count();
-        context.getLogger().info(String.format("Found %s onboardings", onboardings.size()));
-
+    private Map<String, InstitutionResponse> getInstitutions(List<Onboarding> onboardings) {
         Set<String> institutionsId = onboardings.stream()
                 .map(onboarding -> onboarding.getInstitution().getId())
                 .collect(Collectors.toSet());
 
-        // TODO : Testare caso di eccezione
-        Map<String, org.openapi.quarkus.core_json.model.InstitutionResponse> institutions = institutionsId.stream()
+        return institutionsId.stream()
                 .map(id -> institutionApi.retrieveInstitutionByIdUsingGET(id))
-                .collect(Collectors.toMap(InstitutionResponse::getId, institutionResponse -> institutionResponse));
-
-        NotificationConfig.Consumer consumerConfig = notificationConfig.consumers().get(STANDARD_CONSUMER);
-        NotificationBuilder notificationBuilder = notificationBuilderFactory.create(consumerConfig);
-        List<NotificationToSend> notificationToSends = onboardings.stream()
-                .map(onboarding -> {
-                    org.openapi.quarkus.core_json.model.InstitutionResponse institution = institutions.get(onboarding.getInstitution().getId());
-                    Token token = tokenRepository.findByOnboardingId(onboarding.getId()).orElseThrow();
-                    // TODO : è giusto considerare UPDATE?
-                    return notificationBuilder.buildNotificationToSend(onboarding, token, institution, QueueEvent.UPDATE);
-                }).toList();
-
-        return new FindNotificationToSendResponse(notificationToSends, count);
+                .collect(Collectors.toMap(InstitutionResponse::getId, Function.identity()));
     }
+
+    private NotificationToSend buildNotificationToSend(Onboarding onboarding, Map<String, InstitutionResponse> institutions) {
+        NotificationBuilder notificationBuilder = notificationBuilderFactory.create(notificationConfig.consumers().get(STANDARD_CONSUMER));
+        Token token = tokenRepository.findByOnboardingId(onboarding.getId()).orElse(null);
+
+        QueueEvent queueEvent = queueEventExaminer.determineEventType(onboarding);
+        return notificationBuilder.buildNotificationToSend(onboarding, token, institutions.get(onboarding.getInstitution().getId()), queueEvent);
+    }
+
+
 
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -6,29 +6,39 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.microsoft.azure.functions.ExecutionContext;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.config.NotificationConfig;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
+import it.pagopa.selfcare.onboarding.dto.FindNotificationToSendResponse;
+import it.pagopa.selfcare.onboarding.dto.NotificationToSendFilters;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.Token;
 import it.pagopa.selfcare.onboarding.exception.NotificationException;
 import it.pagopa.selfcare.onboarding.utils.NotificationBuilder;
+import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import it.pagopa.selfcare.onboarding.repository.TokenRepository;
 import it.pagopa.selfcare.onboarding.utils.NotificationBuilderFactory;
+import it.pagopa.selfcare.onboarding.utils.QueryUtils;
+import it.pagopa.selfcare.onboarding.utils.SortEnum;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.bson.Document;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.openapi.quarkus.core_json.api.InstitutionApi;
 import org.openapi.quarkus.core_json.model.InstitutionResponse;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class NotificationEventServiceDefault implements NotificationEventService {
 
+    private static final String STANDARD_CONSUMER = "standard";
     @RestClient
     @Inject
     EventHubRestClient eventHubRestClient;
@@ -42,15 +52,18 @@ public class NotificationEventServiceDefault implements NotificationEventService
     private final NotificationBuilderFactory notificationBuilderFactory;
     private final TokenRepository tokenRepository;
     private final ObjectMapper mapper;
+    private final OnboardingRepository onboardingRepository;
 
     public NotificationEventServiceDefault(ProductService productService,
                                            NotificationConfig notificationConfig,
                                            NotificationBuilderFactory notificationBuilderFactory,
-                                           TokenRepository tokenRepository) {
+                                           TokenRepository tokenRepository,
+                                           OnboardingRepository onboardingRepository) {
         this.productService = productService;
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
         this.tokenRepository = tokenRepository;
+        this.onboardingRepository = onboardingRepository;
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
     }
@@ -103,6 +116,48 @@ public class NotificationEventServiceDefault implements NotificationEventService
                 sendNotification(context, topic, notificationToSend);
             }
         }
+    }
+
+    @Override
+    public FindNotificationToSendResponse findNotificationToSend(ExecutionContext context, NotificationToSendFilters filters) {
+        context.getLogger().info(String.format("Finding notifications to send with filters: %s", filters));
+
+        if (filters.getStatus() != null) {
+            OnboardingStatus statusEnum = OnboardingStatus.valueOf(filters.getStatus());
+            var allowedStates = List.of(OnboardingStatus.COMPLETED, OnboardingStatus.DELETED);
+            if (!allowedStates.contains(statusEnum)) {
+                throw new IllegalArgumentException("For the status field only COMPLETED and DELETED values are valid.");
+            }
+        }
+
+        Document sort = QueryUtils.buildSortDocument("createdAt", SortEnum.DESC);
+        Map<String, List<String>> queryParameter = QueryUtils.createMapForOnboardingQueryParameter(filters);
+        Document query = QueryUtils.buildQuery(queryParameter);
+
+        List<Onboarding> onboardings = onboardingRepository.find(query, sort).page(filters.getPage(), filters.getSize()).list();
+        long count = onboardingRepository.find(query, sort).count();
+        context.getLogger().info(String.format("Found %s onboardings", onboardings.size()));
+
+        Set<String> institutionsId = onboardings.stream()
+                .map(onboarding -> onboarding.getInstitution().getId())
+                .collect(Collectors.toSet());
+
+        // TODO : Testare caso di eccezione
+        Map<String, org.openapi.quarkus.core_json.model.InstitutionResponse> institutions = institutionsId.stream()
+                .map(id -> institutionApi.retrieveInstitutionByIdUsingGET(id))
+                .collect(Collectors.toMap(InstitutionResponse::getId, institutionResponse -> institutionResponse));
+
+        NotificationConfig.Consumer consumerConfig = notificationConfig.consumers().get(STANDARD_CONSUMER);
+        NotificationBuilder notificationBuilder = notificationBuilderFactory.create(consumerConfig);
+        List<NotificationToSend> notificationToSends = onboardings.stream()
+                .map(onboarding -> {
+                    org.openapi.quarkus.core_json.model.InstitutionResponse institution = institutions.get(onboarding.getInstitution().getId());
+                    Token token = tokenRepository.findByOnboardingId(onboarding.getId()).orElseThrow();
+                    // TODO : è giusto considerare UPDATE?
+                    return notificationBuilder.buildNotificationToSend(onboarding, token, institution, QueueEvent.UPDATE);
+                }).toList();
+
+        return new FindNotificationToSendResponse(notificationToSends, count);
     }
 
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -74,7 +74,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
     public void send(ExecutionContext context, Onboarding onboarding, QueueEvent queueEvent) {
         Product product = productService.getProduct(onboarding.getProductId());
         if (product.getConsumers() == null || product.getConsumers().isEmpty()) {
-            context.getLogger().warning(String.format("Node consumers is null or empty for product with ID %s", onboarding.getProductId()));
+            context.getLogger().warning(() -> String.format("Node consumers is null or empty for product with ID %s", onboarding.getProductId()));
             return;
         }
 
@@ -87,7 +87,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
                 prepareAndSendNotification(context, product, consumerConfig, onboarding, token.orElse(null), institution, queueEvent);
             }
         } catch (Exception e) {
-            context.getLogger().warning(String.format("Error during send notification for onboarding with ID %s. Error: %s", onboarding.getId(), e.getMessage()));
+            context.getLogger().warning(() -> String.format("Error during send notification for onboarding with ID %s. Error: %s", onboarding.getId(), e.getMessage()));
             throw new NotificationException(String.format("Impossible to send notification for onboarding %s", onboarding));
         }
     }
@@ -100,20 +100,20 @@ public class NotificationEventServiceDefault implements NotificationEventService
             sendNotification(context, consumer.topic(), notificationToSend);
             sendTestEnvProductsNotification(context, product, consumer.topic(), notificationToSend);
         } else {
-            context.getLogger().info(String.format("Notification not sent for onboarding %s on topic %s", onboarding.getId(), consumer.topic()));
+            context.getLogger().info(() -> String.format("Notification not sent for onboarding %s on topic %s", onboarding.getId(), consumer.topic()));
         }
     }
 
     private void sendNotification(ExecutionContext context, String topic, NotificationToSend notificationToSend) throws JsonProcessingException {
         String message = mapper.writeValueAsString(notificationToSend);
-        context.getLogger().info(String.format("Sending notification on topic: %s with message: %s", topic, message));
+        context.getLogger().info(() -> String.format("Sending notification on topic: %s with message: %s", topic, message));
         eventHubRestClient.sendMessage(topic, message);
     }
 
     private void sendTestEnvProductsNotification(ExecutionContext context, Product product, String topic, NotificationToSend notificationToSend) throws JsonProcessingException {
         if (product.getTestEnvProductIds() != null) {
             for (String testEnvProductId : product.getTestEnvProductIds()) {
-                context.getLogger().info(String.format("Notification for onboarding with id: %s should be sent on topic: %s for envProduct : %s", notificationToSend.getOnboardingTokenId(), topic, testEnvProductId));
+                context.getLogger().info(() -> String.format("Notification for onboarding with id: %s should be sent on topic: %s for envProduct : %s", notificationToSend.getOnboardingTokenId(), topic, testEnvProductId));
                 notificationToSend.setId(UUID.randomUUID().toString());
                 notificationToSend.setProduct(testEnvProductId);
                 sendNotification(context, topic, notificationToSend);
@@ -123,7 +123,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
 
     @Override
     public FindNotificationToSendResponse findNotificationToSend(ExecutionContext context, NotificationToSendFilters filters) {
-        context.getLogger().info(String.format("Finding notifications to send with filters: %s", filters));
+        context.getLogger().info(() -> String.format("Finding notifications to send with filters: %s", filters));
         validateFilters(filters);
 
         Document sort = QueryUtils.buildSortDocument("createdAt", SortEnum.DESC);
@@ -132,7 +132,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
 
         List<Onboarding> onboardings = onboardingRepository.find(query, sort).page(filters.getPage(), filters.getSize()).list();
         long count = onboardingRepository.find(query, sort).count();
-        context.getLogger().info(String.format("Found %s onboardings to send with filters", onboardings.size()));
+        context.getLogger().info(() -> String.format("Found %s onboardings to send with filters", onboardings.size()));
 
         Map<String, InstitutionResponse> institutions = getInstitutions(onboardings);
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
@@ -1,0 +1,92 @@
+package it.pagopa.selfcare.onboarding.utils;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.dto.NotificationToSendFilters;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.Document;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodec;
+import org.bson.conversions.Bson;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class QueryUtils {
+
+    public static Document buildQuery(Map<String, List<String>> parameters) {
+        if (!parameters.isEmpty()) {
+            return bsonToDocument(Filters.and(constructBsonFilter(parameters)));
+        } else {
+            return new Document();
+        }
+    }
+
+    /**
+     * The constructBsonFilter function takes a Map of parameters and returns a List of Bson objects.
+     * The function iterates over the entries in the parameter map, and for each entry it creates
+     * either an equality filter or a range filter depending on whether the key is &quot;from&quot; or &quot;to&quot;.
+     */
+    private static List<Bson> constructBsonFilter(Map<String, List<String>> parameters) {
+        return parameters.entrySet().stream()
+                .map(entry -> {
+                    List<String> values = entry.getValue();
+                    if ( values.size() == 1 ) {
+                        if (StringUtils.equalsIgnoreCase(entry.getKey(), "from")) {
+                            return Filters.gte("createdAt", LocalDate.parse(entry.getValue().get(0), DateTimeFormatter.ISO_LOCAL_DATE));
+                        } else if (StringUtils.equalsIgnoreCase(entry.getKey(), "to")) {
+                            return Filters.lt("createdAt", LocalDate.parse(entry.getValue().get(0), DateTimeFormatter.ISO_LOCAL_DATE).plusDays(1));
+                        }
+                        return Filters.eq(entry.getKey(), entry.getValue().get(0));
+                    } else {
+                        return Filters.or(
+                                values.stream()
+                                        .map( value -> Filters.eq(entry.getKey(), value))
+                                        .toList()
+                        );
+                    }
+                }).toList();
+    }
+
+    private static Document bsonToDocument(Bson bson) {
+        BsonDocument bsonDocument = bson.toBsonDocument(BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+        DocumentCodec codec = new DocumentCodec();
+        DecoderContext decoderContext = DecoderContext.builder().build();
+        return codec.decode(new BsonDocumentReader(bsonDocument), decoderContext);
+    }
+
+    /**
+     * The createMapForOnboardingQueryParameter function creates a map of query parameters for the Onboarding Collection.
+     */
+    public static Map<String, List<String>> createMapForOnboardingQueryParameter(NotificationToSendFilters filters) {
+        Map<String, List<String>> queryParameterMap = new HashMap<>();
+
+
+        Optional.ofNullable(filters.getProductId()).ifPresent(value -> queryParameterMap.put("productId", List.of(value)));
+        Optional.ofNullable(filters.getInstitutionId()).ifPresent(value -> queryParameterMap.put("institution.id", List.of(value)));
+        Optional.ofNullable(filters.getOnboardingId()).ifPresent(value -> queryParameterMap.put("id", List.of(value)));
+        Optional.ofNullable(filters.getTaxCode()).ifPresent(value -> queryParameterMap.put("institution.taxCode", List.of(value)));
+        Optional.ofNullable(filters.getStatus()).ifPresentOrElse(value -> queryParameterMap.put("status", List.of(value)),
+                () -> queryParameterMap.put("status", List.of(OnboardingStatus.COMPLETED.name(), OnboardingStatus.DELETED.name())));
+        Optional.ofNullable(filters.getFrom()).ifPresent(value -> queryParameterMap.put("from", List.of(value)));
+        Optional.ofNullable(filters.getTo()).ifPresent(value -> queryParameterMap.put("to", List.of(value)));
+        return queryParameterMap;
+    }
+
+    public static Document buildSortDocument(String field, SortEnum order) {
+        if(SortEnum.ASC == order) {
+            return bsonToDocument(Sorts.ascending(field));
+        }else{
+            return bsonToDocument(Sorts.descending(field));
+        }
+    }
+
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
@@ -72,7 +72,7 @@ public class QueryUtils {
 
         Optional.ofNullable(filters.getProductId()).ifPresent(value -> queryParameterMap.put("productId", List.of(value)));
         Optional.ofNullable(filters.getInstitutionId()).ifPresent(value -> queryParameterMap.put("institution.id", List.of(value)));
-        Optional.ofNullable(filters.getOnboardingId()).ifPresent(value -> queryParameterMap.put("id", List.of(value)));
+        Optional.ofNullable(filters.getOnboardingId()).ifPresent(value -> queryParameterMap.put("_id", List.of(value)));
         Optional.ofNullable(filters.getTaxCode()).ifPresent(value -> queryParameterMap.put("institution.taxCode", List.of(value)));
         Optional.ofNullable(filters.getStatus()).ifPresentOrElse(value -> queryParameterMap.put("status", List.of(value)),
                 () -> queryParameterMap.put("status", List.of(OnboardingStatus.COMPLETED.name(), OnboardingStatus.DELETED.name())));

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueryUtils.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 public class QueryUtils {
 
+    private QueryUtils() { }
+
     public static Document buildQuery(Map<String, List<String>> parameters) {
         if (!parameters.isEmpty()) {
             return bsonToDocument(Filters.and(constructBsonFilter(parameters)));

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueueEventExaminer.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/QueueEventExaminer.java
@@ -1,0 +1,33 @@
+package it.pagopa.selfcare.onboarding.utils;
+
+import it.pagopa.selfcare.onboarding.config.NotificationConfig;
+import it.pagopa.selfcare.onboarding.dto.QueueEvent;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@ApplicationScoped
+public class QueueEventExaminer {
+
+    private final Integer minutesThresholdForUpdateNotification;
+
+    public QueueEventExaminer(NotificationConfig notificationConfig) {
+        this.minutesThresholdForUpdateNotification = notificationConfig.minutesThresholdForUpdateNotification();
+    }
+
+    public QueueEvent determineEventType(Onboarding onboarding) {
+        return switch (onboarding.getStatus()) {
+            case COMPLETED -> (isOverUpdateThreshold(onboarding.getUpdatedAt(), onboarding.getActivatedAt())) ? QueueEvent.UPDATE : QueueEvent.ADD;
+            case DELETED -> QueueEvent.UPDATE;
+            default -> throw new IllegalArgumentException("Onboarding status not supported");
+        };
+    }
+
+    private boolean isOverUpdateThreshold(LocalDateTime updatedAt, LocalDateTime activatedAt) {
+        return Objects.nonNull(updatedAt)
+                && Objects.nonNull(activatedAt)
+                && updatedAt.isAfter(activatedAt.plusMinutes(minutesThresholdForUpdateNotification));
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/SortEnum.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/SortEnum.java
@@ -1,0 +1,6 @@
+package it.pagopa.selfcare.onboarding.utils;
+
+public enum SortEnum {
+    ASC,
+    DESC
+}

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -161,3 +161,4 @@ notification.consumers.fd.name=${FD_SHARED_ACCESS_KEY_NAME:test}
 notification.consumers.fd.key=${EVENTHUB_SC_CONTRACTS_FD_SELFCARE_WO_KEY_LC:test}
 notification.consumers.fd.allowed-institution-types=null
 notification.consumers.fd.allowed-origins=null
+notification.minutes-threshold-for-update-notification=${MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION:5}

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/QueueEventExaminerTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/utils/QueueEventExaminerTest.java
@@ -1,0 +1,77 @@
+package it.pagopa.selfcare.onboarding.utils;
+
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.config.NotificationConfig;
+import it.pagopa.selfcare.onboarding.dto.QueueEvent;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class QueueEventExaminerTest {
+    @Inject
+    private QueueEventExaminer queueEventExaminer;
+
+    @BeforeEach
+    public void setup() {
+        NotificationConfig notificationConfig = mock(NotificationConfig.class);
+        when(notificationConfig.minutesThresholdForUpdateNotification()).thenReturn(5);
+        queueEventExaminer = new QueueEventExaminer(notificationConfig);
+    }
+
+    @Test
+    @DisplayName("Should return ADD event for COMPLETED status and update within threshold")
+    public void shouldReturnAddEventForCompletedStatusAndUpdateWithinThreshold() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.COMPLETED);
+        onboarding.setUpdatedAt(LocalDateTime.now());
+        onboarding.setActivatedAt(LocalDateTime.now().minusMinutes(4));
+
+        QueueEvent result = queueEventExaminer.determineEventType(onboarding);
+
+        assertEquals(QueueEvent.ADD, result);
+    }
+
+    @Test
+    @DisplayName("Should return UPDATE event for COMPLETED status and update over threshold")
+    public void shouldReturnUpdateEventForCompletedStatusAndUpdateOverThreshold() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.COMPLETED);
+        onboarding.setUpdatedAt(LocalDateTime.now());
+        onboarding.setActivatedAt(LocalDateTime.now().minusMinutes(10));
+
+        QueueEvent result = queueEventExaminer.determineEventType(onboarding);
+
+        assertEquals(QueueEvent.UPDATE, result);
+    }
+
+    @Test
+    @DisplayName("Should return UPDATE event for DELETED status")
+    public void shouldReturnUpdateEventForDeletedStatus() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.DELETED);
+
+        QueueEvent result = queueEventExaminer.determineEventType(onboarding);
+
+        assertEquals(QueueEvent.UPDATE, result);
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException for unsupported status")
+    public void shouldThrowIllegalArgumentExceptionForUnsupportedStatus() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(OnboardingStatus.PENDING);
+
+        assertThrows(IllegalArgumentException.class, () -> queueEventExaminer.determineEventType(onboarding));
+    }
+}

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -47,3 +47,4 @@ onboarding-functions.mail-template.placeholders.onboarding.notification-requeste
 onboarding-functions.mail-template.placeholders.onboarding.reject-product-name=productName
 onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-placeholder=onboardingUrl
 onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-value=default
+notification.minutes-threshold-for-update-notification=5

--- a/infra/functions/onboarding-functions/env/dev-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev-pnpg/terraform.tfvars
@@ -87,4 +87,5 @@ app_settings = {
   "FD_TOPIC_NAME"                                      = "Selfcare-FD"
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 }

--- a/infra/functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev/terraform.tfvars
@@ -83,5 +83,6 @@ app_settings = {
   "EVENTHUB_SC_CONTRACTS_FD_SELFCARE_WO_KEY_LC"        = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/eventhub-selfcare-fd-external-interceptor-wo-key-lc/)"
   "FD_TOPIC_NAME"                                      = "Selfcare-FD",
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP",
-  "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC",
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 }

--- a/infra/functions/onboarding-functions/env/prod-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/prod-pnpg/terraform.tfvars
@@ -78,6 +78,7 @@ app_settings = {
   "FD_TOPIC_NAME"                                      = "Selfcare-FD"
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 
   ## IGNORE VALUES
 

--- a/infra/functions/onboarding-functions/env/prod/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/prod/terraform.tfvars
@@ -85,6 +85,7 @@ app_settings = {
   "FD_TOPIC_NAME"                                      = "Selfcare-FD"
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 
   ##ARUBA SIGNATURE
   "PAGOPA_SIGNATURE_SOURCE"                        = "aruba",

--- a/infra/functions/onboarding-functions/env/uat-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/uat-pnpg/terraform.tfvars
@@ -77,6 +77,7 @@ app_settings = {
   "FD_TOPIC_NAME"                                      = "Selfcare-FD"
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 
   ## IGNORE VALUES
 

--- a/infra/functions/onboarding-functions/env/uat/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/uat/terraform.tfvars
@@ -84,6 +84,7 @@ app_settings = {
   "FD_TOPIC_NAME"                                      = "Selfcare-FD"
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
 
   ##ARUBA SIGNATURE
   "PAGOPA_SIGNATURE_SOURCE"                        = "disabled",


### PR DESCRIPTION
#### List of Changes

Added http function to find notification by filter.

#### Motivation and Context

This http function retrieves paginated onboarding by filters (only with states COMPLETED,DELETED), build and returns the same model of sc-contracts for each onboarding.

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.