### PR TITLE
SELC-5119 feat: added watch config to prevent azure function invocation on demand

### DIFF
--- a/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/NotificationServiceTest.java
+++ b/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/NotificationServiceTest.java
@@ -2,16 +2,20 @@ package it.pagopa.selfcare.onboarding.event;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.helpers.test.UniAssertSubscriber;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.event.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.event.entity.util.QueueEvent;
 import it.pagopa.selfcare.onboarding.event.mapper.OnboardingMapper;
+import it.pagopa.selfcare.onboarding.event.profile.NotificationTestProfile;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
 import org.openapi.quarkus.onboarding_functions_json.api.NotificationsApi;
 import org.openapi.quarkus.onboarding_functions_json.model.OrchestrationResponse;
@@ -88,5 +92,28 @@ public class NotificationServiceTest {
         subscriber.assertCompleted().awaitItem();
 
         verify(notificationsApi, times(1)).apiNotificationPost(eq(QueueEvent.UPDATE.name()), any());
+    }
+
+    @Nested
+    @TestProfile(NotificationTestProfile.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class NotificationServiceTestWithDisabledWatcherTest {
+        @Test
+        @DisplayName("Should not invoke Notification API when watcher is disabled")
+        public void shouldNotInvokeNotificationApiWhenWatcheIsDisabled() {
+            Onboarding onboarding = new Onboarding();
+            onboarding.setStatus(OnboardingStatus.DELETED);
+            onboarding.setUpdatedAt(LocalDateTime.now()); // 5 minutes should be the threshold
+            onboarding.setActivatedAt(LocalDateTime.now());
+
+
+            UniAssertSubscriber<OrchestrationResponse> subscriber = notificationService
+                    .invokeNotificationApi(onboarding)
+                    .subscribe().withSubscriber(UniAssertSubscriber.create());
+
+            subscriber.assertCompleted().awaitItem();
+
+            verify(notificationsApi, times(0)).apiNotificationPost(any(), any());
+        }
     }
 }

--- a/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/profile/NotificationTestProfile.java
+++ b/apps/onboarding-cdc/src/test/java/it/pagopa/selfcare/onboarding/event/profile/NotificationTestProfile.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.onboarding.event.profile;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class NotificationTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("onboarding-cdc.mongodb.watch.enabled", "false");
+    }
+}

--- a/apps/onboarding-cdc/src/test/resources/application.properties
+++ b/apps/onboarding-cdc/src/test/resources/application.properties
@@ -1,1 +1,2 @@
+onboarding-cdc.mongodb.watch.enabled=true
 

--- a/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
@@ -28,7 +28,7 @@ app_settings = [
   },
   {
     name  = "ONBOARDING-CDC-MONGODB-WATCH-ENABLED"
-    value = "false"
+    value = "true"
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"

--- a/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
@@ -30,7 +30,7 @@ app_settings = [
   },
   {
     name  = "ONBOARDING-CDC-MONGODB-WATCH-ENABLED"
-    value = "false"
+    value = "true"
   },
   {
     name  = "ONBOARDING_FUNCTIONS_URL"


### PR DESCRIPTION
#### List of Changes

Added watch config to prevent azure function invocation on demand

#### Motivation and Context

With this feature we can disable the invocation of azure function.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.