### PR TITLE
[SELC-5126] feat: Added placeholders into contract for previous Manager

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -34,6 +34,7 @@ public class Onboarding  {
     private LocalDateTime deletedAt;
     private String reasonForReject;
     private Boolean isAggregator;
+    private String referenceOnboardingId;
 
     public String getId() {
         return id;
@@ -183,6 +184,14 @@ public class Onboarding  {
 
     public void setIsAggregator(Boolean isAggregator) { this.isAggregator = isAggregator; }
 
+    public String getReferenceOnboardingId() {
+        return referenceOnboardingId;
+    }
+
+    public void setReferenceOnboardingId(String referenceOnboardingId) {
+        this.referenceOnboardingId = referenceOnboardingId;
+    }
+
     @Override
     public String toString() {
         return "Onboarding{" +
@@ -192,6 +201,7 @@ public class Onboarding  {
                 ", workflowType=" + workflowType +
                 ", institution=" + institution +
                 ", users=" + users +
+                ", aggregates=" + aggregates +
                 ", pricingPlan='" + pricingPlan + '\'' +
                 ", billing=" + billing +
                 ", signContract=" + signContract +
@@ -199,11 +209,13 @@ public class Onboarding  {
                 ", status=" + status +
                 ", userRequestUid='" + userRequestUid + '\'' +
                 ", workflowInstanceId='" + workflowInstanceId + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
                 ", activatedAt=" + activatedAt +
                 ", deletedAt=" + deletedAt +
                 ", reasonForReject='" + reasonForReject + '\'' +
-                ", aggregates=" + aggregates +
-                ", isAggregator='" + isAggregator + '\'' +
+                ", isAggregator=" + isAggregator +
+                ", referenceOnboardingId='" + referenceOnboardingId + '\'' +
                 '}';
     }
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
@@ -2,19 +2,25 @@ package it.pagopa.selfcare.onboarding.service;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectSpy;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.config.AzureStorageConfig;
 import it.pagopa.selfcare.onboarding.config.PagoPaSignatureConfig;
 import it.pagopa.selfcare.onboarding.crypto.PadesSignService;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.User;
+import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.openapi.quarkus.user_registry_json.api.UserApi;
 import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
 import org.openapi.quarkus.user_registry_json.model.UserResource;
 import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
@@ -31,26 +37,24 @@ class ContractServiceDefaultTest {
 
     @Inject
     AzureStorageConfig azureStorageConfig;
-
     @InjectMock
     AzureBlobClient azureBlobClient;
+    @InjectMock
     PadesSignService padesSignService;
-
     @Inject
     ContractService contractService;
-
+    @InjectMock
+    @RestClient
+    UserApi userRegistryApi;
+    @InjectMock
+    OnboardingRepository onboardingRepository;
     @Inject
     PagoPaSignatureConfig pagoPaSignatureConfig;
 
-
     final static String productNameExample = "product-name";
 
-    @BeforeEach
-    void setup(){
-        padesSignService = mock(PadesSignService.class);
-        contractService = new ContractServiceDefault(azureStorageConfig, azureBlobClient, padesSignService, pagoPaSignatureConfig, "logo- path", true);
-    }
-
+    private final static String contractFilepath = "contract";
+    private final static String contractHtml = "contract";
 
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
@@ -90,8 +94,6 @@ class ContractServiceDefaultTest {
 
     @Test
     void createContractPDF() {
-        final String contractFilepath = "contract";
-        final String contractHtml = "contract";
         final String productNameAccent = "Interoperabilità";
 
         Onboarding onboarding = createOnboarding();
@@ -114,9 +116,6 @@ class ContractServiceDefaultTest {
 
     @Test
     void createContractPDFSA() {
-        final String contractFilepath = "contract";
-        final String contractHtml = "contract";
-
         Onboarding onboarding = createOnboarding();
         User userManager = onboarding.getUsers().get(0);
         UserResource manager = createDummyUserResource(userManager.getId(), userManager.getUserMailUuid());
@@ -148,17 +147,42 @@ class ContractServiceDefaultTest {
     }
 
     @Test
-    void createContractPDFAndSigned() {
-        final String contractFilepath = "contract";
-        final String contractHtml = "contract";
+    void createContractPDFWithPreviousManagerData() {
+        Onboarding onboarding = createOnboarding();
+        onboarding.setReferenceOnboardingId("previousOnboardingId");
+        Onboarding previousOnboarding = createOnboarding();
+        previousOnboarding.getUsers().get(0).setRole(PartyRole.MANAGER);
+        User userManager = onboarding.getUsers().get(0);
+        userManager.setRole(PartyRole.MANAGER);
+        User previousUserManager = previousOnboarding.getUsers().get(0);
+        UserResource manager = createDummyUserResource(userManager.getId(), userManager.getUserMailUuid());
+        UserResource previousManager = createDummyUserResource(previousUserManager.getId(), previousUserManager.getUserMailUuid());
+        CertifiableFieldResourceOfstring certifiedField = new CertifiableFieldResourceOfstring();
+        certifiedField.setValue("name");
+        previousManager.setName(certifiedField);
+        previousManager.setFamilyName(certifiedField);
+        onboarding.getInstitution().setInstitutionType(InstitutionType.PA);
+        onboarding.setProductId("prod-pagopa");
 
+        Mockito.when(onboardingRepository.findByIdOptional(anyString())).thenReturn(Optional.of(previousOnboarding));
+
+        Mockito.when(userRegistryApi.findByIdUsingGET(any(), anyString())).thenReturn(previousManager);
+
+        Mockito.when(azureBlobClient.getFileAsText(contractFilepath)).thenReturn(contractHtml);
+
+        Mockito.when(azureBlobClient.uploadFile(any(),any(),any())).thenReturn(contractHtml);
+
+        assertNotNull(contractService.createContractPDF(contractFilepath, onboarding, manager, List.of(), productNameExample));
+    }
+
+    @Test
+    void createContractPDFAndSigned() {
         Onboarding onboarding = createOnboarding();
         User userManager = onboarding.getUsers().get(0);
         UserResource manager = createDummyUserResource(userManager.getId(), userManager.getUserMailUuid());
 
         PagoPaSignatureConfig pagoPaSignatureConfig = Mockito.spy(this.pagoPaSignatureConfig);
         when(pagoPaSignatureConfig.source()).thenReturn("local");
-        contractService = new ContractServiceDefault(azureStorageConfig, azureBlobClient, padesSignService, pagoPaSignatureConfig, "logo-path", true);
 
         Mockito.when(azureBlobClient.getFileAsText(contractFilepath)).thenReturn(contractHtml);
 
@@ -173,9 +197,6 @@ class ContractServiceDefaultTest {
 
     @Test
     void loadContractPDF() {
-        final String contractFilepath = "contract";
-        final String contractHtml = "contract";
-
         Onboarding onboarding = createOnboarding();
 
         File pdf = new File(Objects.requireNonNull(getClass().getClassLoader().getResource("application.properties")).getFile());
@@ -203,7 +224,6 @@ class ContractServiceDefaultTest {
         assertTrue(filepathActual.getValue().contains(onboarding.getId()));
         assertTrue(filepathActual.getValue().contains(productNameExample));
     }
-
 
     @Test
     void getLogoFile() {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
@@ -2,7 +2,6 @@ package it.pagopa.selfcare.onboarding.service;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.junit.mockito.InjectSpy;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
@@ -14,9 +13,7 @@ import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.User;
 import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import jakarta.inject.Inject;
-import jakarta.inject.Qualifier;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;


### PR DESCRIPTION
#### List of Changes

Added placeholders ( and relative logic) into contract for previous Manager fields

#### Motivation and Context

In the addition administrator flow, in case of diversity between the new manager and the old one, the contract should include two new values:

1. previous manager name
2. previous manager surname

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.