### PR TITLE
[SELC - 5065] feat: Added API to save the onboarding request from an Aggregator

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -45,11 +45,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -131,11 +131,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -165,11 +165,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -201,11 +201,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -262,11 +262,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -298,11 +298,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -334,11 +334,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -370,11 +370,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -406,11 +406,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -441,11 +441,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -477,11 +477,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -513,11 +513,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -549,11 +549,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -584,11 +584,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -615,11 +615,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -662,11 +662,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -709,11 +709,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -756,11 +756,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -791,11 +791,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -831,11 +831,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -877,11 +877,11 @@
               "application/json" : { }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -912,11 +912,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -949,11 +949,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {
@@ -985,11 +985,11 @@
               }
             }
           },
-          "403" : {
-            "description" : "Not Allowed"
-          },
           "401" : {
             "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
           }
         },
         "security" : [ {

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -45,11 +45,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -131,11 +131,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -165,11 +165,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -201,11 +201,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -262,11 +262,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -298,11 +298,47 @@
               }
             }
           },
+          "403" : {
+            "description" : "Not Allowed"
+          },
           "401" : {
             "description" : "Not Authorized"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/pa/aggregation" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Perform onboarding aggregation request for PA institution type, it require billing.recipientCode in additition to default requestUsers data will be saved on personal data vault if it doesn't already exist.At the end, function triggers async activities related to onboarding aggregation that consist of create contract and sending mail to institution's digital address.",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingPaRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
           },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -334,11 +370,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -370,11 +406,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -405,11 +441,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -441,11 +477,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -477,11 +513,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -513,11 +549,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -548,11 +584,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -579,11 +615,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -626,11 +662,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -673,11 +709,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -720,11 +756,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -755,11 +791,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -795,11 +831,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -841,11 +877,11 @@
               "application/json" : { }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -876,11 +912,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -913,11 +949,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {
@@ -949,11 +985,11 @@
               }
             }
           },
-          "401" : {
-            "description" : "Not Authorized"
-          },
           "403" : {
             "description" : "Not Allowed"
+          },
+          "401" : {
+            "description" : "Not Authorized"
           }
         },
         "security" : [ {

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -32,10 +32,10 @@ paths:
             application/json:
               schema:
                 type: string
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding:
@@ -92,10 +92,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingGetResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
     post:
@@ -117,10 +117,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/completion:
@@ -141,10 +141,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/institutionOnboardings:
@@ -183,10 +183,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/pa:
@@ -210,10 +210,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
+      security:
+      - SecurityScheme: []
+  /v1/onboarding/pa/aggregation:
+    post:
+      tags:
+      - Onboarding Controller
+      summary: "Perform onboarding aggregation request for PA institution type, it\
+        \ require billing.recipientCode in additition to default requestUsers data\
+        \ will be saved on personal data vault if it doesn't already exist.At the\
+        \ end, function triggers async activities related to onboarding aggregation\
+        \ that consist of create contract and sending mail to institution's digital\
+        \ address."
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OnboardingPaRequest'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OnboardingResponse'
+        "403":
+          description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/pa/completion:
@@ -234,10 +262,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/pa/import:
@@ -258,10 +286,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/pg/completion:
@@ -280,10 +308,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/psp:
@@ -306,10 +334,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/psp/completion:
@@ -330,10 +358,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/users:
@@ -356,10 +384,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}:
@@ -380,10 +408,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingGet'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/approve:
@@ -404,10 +432,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/complete:
@@ -441,10 +469,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/completeOnboardingUsers:
@@ -479,10 +507,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/consume:
@@ -514,10 +542,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/pending:
@@ -540,10 +568,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingGet'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/reject:
@@ -569,10 +597,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/update:
@@ -601,10 +629,10 @@ paths:
           description: OK
           content:
             application/json: {}
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/onboarding/{onboardingId}/withUserInfo:
@@ -626,10 +654,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OnboardingGet'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/tokens:
@@ -651,10 +679,10 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/TokenResponse'
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
   /v1/tokens/{onboardingId}/contract:
@@ -676,10 +704,10 @@ paths:
               schema:
                 format: binary
                 type: string
-        "401":
-          description: Not Authorized
         "403":
           description: Not Allowed
+        "401":
+          description: Not Authorized
       security:
       - SecurityScheme: []
 components:

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -216,6 +216,34 @@ paths:
           description: Not Allowed
       security:
       - SecurityScheme: []
+  /v1/onboarding/pa/aggregation:
+    post:
+      tags:
+      - Onboarding Controller
+      summary: "Perform onboarding aggregation request for PA institution type, it\
+        \ require billing.recipientCode in additition to default requestUsers data\
+        \ will be saved on personal data vault if it doesn't already exist.At the\
+        \ end, function triggers async activities related to onboarding aggregation\
+        \ that consist of create contract and sending mail to institution's digital\
+        \ address."
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OnboardingPaRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OnboardingResponse"
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+      - SecurityScheme: []
   /v1/onboarding/pa/completion:
     post:
       tags:

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -79,6 +79,19 @@ public class OnboardingController {
                         .onboarding(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
     }
 
+    @Operation(summary = "Perform onboarding aggregation request for PA institution type, it require billing.recipientCode in additition to default request" +
+            "Users data will be saved on personal data vault if it doesn't already exist." +
+            "At the end, function triggers async activities related to onboarding aggregation that consist of create contract and sending mail to institution's digital address.")
+    @POST
+    @Path("/pa/aggregation")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<OnboardingResponse> onboardingPaAggregation(@Valid OnboardingPaRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(userId -> onboardingService
+                        .onboarding(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
+    }
+
     @Operation(summary = "Perform onboarding request for PSP institution type." +
             "Users data will be saved on personal data vault if it doesn't already exist." +
             "At the end, function triggers async activities related to onboarding that consist of sending mail to Selfcare admin for approve request.")

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -351,7 +351,7 @@ public class OnboardingServiceDefault implements OnboardingService {
             return WorkflowType.FOR_APPROVE_PT;
         }
 
-        if (onboarding.getIsAggregator().equals(Boolean.TRUE)) {
+        if (Objects.nonNull(onboarding.getIsAggregator()) && onboarding.getIsAggregator().equals(Boolean.TRUE)) {
             return WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR;
         }
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -351,6 +351,10 @@ public class OnboardingServiceDefault implements OnboardingService {
             return WorkflowType.FOR_APPROVE_PT;
         }
 
+        if (onboarding.getIsAggregator().equals(Boolean.TRUE)) {
+            return WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR;
+        }
+
         if (InstitutionType.PA.equals(institutionType)
                 || isGspAndProdInterop(institutionType, onboarding.getProductId())
                 || InstitutionType.SA.equals(institutionType)

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -164,6 +164,33 @@ class OnboardingControllerTest {
 
     @Test
     @TestSecurity(user = "userJwt")
+    void onboardingPaAggregator() {
+        OnboardingPaRequest onboardingPaValid = dummyOnboardingPa();
+        onboardingPaValid.setIsAggregator(Boolean.TRUE);
+        List<InstitutionBaseRequest> institutionBaseRequests = new ArrayList<>();
+        institutionBaseRequests.add(institution);
+        onboardingPaValid.setAggregates(institutionBaseRequests);
+
+        Mockito.when(onboardingService.onboarding(any(), any()))
+                .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
+
+        given()
+                .when()
+                .body(onboardingPaValid)
+                .contentType(ContentType.JSON)
+                .post("/pa/aggregation")
+                .then()
+                .statusCode(200);
+
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1))
+                .onboarding(captor.capture(), any());
+        assertEquals(captor.getValue().getBilling().getRecipientCode(), onboardingPaValid.getBilling().getRecipientCode().toUpperCase());
+
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
     void onboardingUsers() {
         OnboardingUserRequest onboardingUserRequest = dummyOnboardingUser();
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
+import static io.smallrye.common.constraint.Assert.assertFalse;
+import static io.smallrye.common.constraint.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -186,7 +188,8 @@ class OnboardingControllerTest {
         Mockito.verify(onboardingService, times(1))
                 .onboarding(captor.capture(), any());
         assertEquals(captor.getValue().getBilling().getRecipientCode(), onboardingPaValid.getBilling().getRecipientCode().toUpperCase());
-
+        assertTrue(captor.getValue().getIsAggregator());
+        assertFalse(captor.getValue().getAggregates().isEmpty());
     }
 
     @Test

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -34,10 +34,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static io.smallrye.common.constraint.Assert.assertFalse;
-import static io.smallrye.common.constraint.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -18,7 +18,6 @@ import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
-import it.pagopa.selfcare.onboarding.controller.request.InstitutionBaseRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingImportContract;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingUserRequest;
 import it.pagopa.selfcare.onboarding.controller.request.UserRequest;
@@ -130,7 +129,7 @@ class OnboardingServiceDefaultTest {
     @Spy
     OnboardingMapper onboardingMapper = new OnboardingMapperImpl();
 
-    final static UserRequest managerUser = UserRequest.builder()
+    final static UserRequest manager = UserRequest.builder()
             .name("name")
             .surname("surname")
             .taxCode("taxCode")
@@ -147,19 +146,19 @@ class OnboardingServiceDefaultTest {
         managerResource = new UserResource();
         managerResource.setId(UUID.randomUUID());
         managerResource.setName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getName())
+                .value(manager.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
         managerResource.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getSurname())
+                .value(manager.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
 
         managerResourceWk = new UserResource();
         managerResourceWk.setId(UUID.randomUUID());
         managerResourceWk.setName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getName())
+                .value(manager.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
         managerResourceWk.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getSurname())
+                .value(manager.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
 
         Map<String, WorkContactResource> map = new HashMap<>();
@@ -173,10 +172,10 @@ class OnboardingServiceDefaultTest {
         managerResourceWkSpid = new UserResource();
         managerResourceWkSpid.setId(UUID.randomUUID());
         managerResourceWkSpid.setName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getName())
+                .value(manager.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.SPID));
         managerResourceWkSpid.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(managerUser.getSurname())
+                .value(manager.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.SPID));
         managerResourceWkSpid.setWorkContacts(map);
     }
@@ -185,7 +184,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductThrowException(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();onboardingRequest.setIsAggregator(Boolean.FALSE);
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -200,7 +199,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -214,7 +213,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductAlreadyOnboarded(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -239,7 +238,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotDelegable(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PT);
@@ -259,7 +258,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PG);
@@ -283,7 +282,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -619,7 +618,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingSa_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.SA);
@@ -656,14 +655,14 @@ class OnboardingServiceDefaultTest {
         productRole.setCode("admin");
         ProductRoleInfo productRoleInfo = new ProductRoleInfo();
         productRoleInfo.setRoles(List.of(productRole));
-        roleMapping.put(managerUser.getRole(), productRoleInfo);
+        roleMapping.put(manager.getRole(), productRoleInfo);
         productResource.setRoleMappings(roleMapping);
 
         if (hasParent) {
             Product parent = new Product();
             parent.setId("productParentId");
             Map<PartyRole, ProductRoleInfo> roleParentMapping = new HashMap<>();
-            roleParentMapping.put(managerUser.getRole(), productRoleInfo);
+            roleParentMapping.put(manager.getRole(), productRoleInfo);
             parent.setRoleMappings(roleParentMapping);
 
             productResource.setParentId(parent.getId());
@@ -678,7 +677,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.PSP);
@@ -704,7 +703,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdateAndProductHasParent(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productParentId");
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.PSP);
@@ -737,7 +736,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         onboardingDefaultRequest.setProductId("productId");
         onboardingDefaultRequest.setInstitution(new Institution());
 
@@ -890,7 +889,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserNotFoundedAndWillSave(UniAsserter asserter) {
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         request.setProductId("productId");
         request.setInstitution(new Institution());
         final UUID createUserId = UUID.randomUUID();
@@ -932,7 +931,7 @@ class OnboardingServiceDefaultTest {
         Onboarding onboardingDefaultRequest = new Onboarding();
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
 
         mockPersistOnboarding(asserter);
 
@@ -1491,7 +1490,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingUsers(UniAsserter asserter) {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         request.setUsers(users);
         mockPersistOnboarding(asserter);
@@ -1528,7 +1527,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingUsersWithNullOnboardingReeferenceId(UniAsserter asserter) {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         request.setUsers(users);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
@@ -1556,7 +1555,7 @@ class OnboardingServiceDefaultTest {
     @Test
     void onboardingUsersWithInstitutionNotFound() {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(managerUser);
+        List<UserRequest> users = List.of(manager);
         request.setTaxCode("taxCode");
         request.setSubunitCode("subunitCode");
         request.setProductId(PROD_INTEROP.getValue());

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -201,7 +201,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -216,7 +216,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductAlreadyOnboarded(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -242,7 +242,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotDelegable(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -263,7 +263,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -288,7 +288,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -315,7 +315,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfRoleNotValid(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
+        
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
 
@@ -344,7 +344,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -389,7 +389,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -425,7 +425,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -461,7 +461,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -505,7 +505,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -543,7 +543,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -634,7 +634,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingSa_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -694,7 +694,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionPspRequest = new Institution();
@@ -721,7 +721,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdateAndProductHasParent(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productParentId");
         Institution institutionPspRequest = new Institution();
@@ -755,7 +755,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         onboardingDefaultRequest.setProductId("productId");
         onboardingDefaultRequest.setInstitution(new Institution());
@@ -785,7 +785,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -831,7 +831,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -872,7 +872,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -912,7 +912,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserNotFoundedAndWillSave(UniAsserter asserter) {
         Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.FALSE);
+        
         List<UserRequest> users = List.of(manager);
         request.setProductId("productId");
         request.setInstitution(new Institution());
@@ -953,7 +953,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfUserRegistryFails(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
+        
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
         List<UserRequest> users = List.of(manager);
@@ -1194,7 +1194,7 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyOnboarding() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setIsAggregator(Boolean.FALSE);
+        
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
 
@@ -1212,7 +1212,7 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyUsersOnboarding() {
         Onboarding onboarding = new Onboarding();
-        onboarding.setIsAggregator(Boolean.FALSE);
+        
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
         onboarding.setReferenceOnboardingId("referenceOnboardinId");

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -18,6 +18,7 @@ import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.onboarding.controller.request.InstitutionBaseRequest;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingImportContract;
 import it.pagopa.selfcare.onboarding.controller.request.OnboardingUserRequest;
 import it.pagopa.selfcare.onboarding.controller.request.UserRequest;
@@ -184,6 +185,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductThrowException(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -199,6 +201,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -213,6 +216,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductAlreadyOnboarded(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -238,6 +242,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotDelegable(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -258,6 +263,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -282,6 +288,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -308,6 +315,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfRoleNotValid(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
+        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
 
@@ -336,6 +344,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -380,6 +389,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -415,6 +425,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -450,6 +461,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -493,6 +505,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -530,6 +543,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -576,8 +590,51 @@ class OnboardingServiceDefaultTest {
 
     @Test
     @RunOnVertxContext
+    void onboarding_Onboarding_Aggregator(UniAsserter asserter) {
+        UserRequest manager = UserRequest.builder()
+                .name("name")
+                .taxCode(managerResource.getFiscalCode())
+                .role(PartyRole.MANAGER)
+                .build();
+
+        Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.TRUE);
+        List<UserRequest> users = List.of(manager);
+        request.setProductId(PROD_INTEROP.getValue());
+        Institution institutionBaseRequest = new Institution();
+        institutionBaseRequest.setInstitutionType(InstitutionType.PA);
+        institutionBaseRequest.setTaxCode("taxCode");
+        request.setInstitution(institutionBaseRequest);
+        List<Institution> aggregates = new ArrayList<>();
+        Institution institution = new Institution();
+        aggregates.add(institution);
+        request.setAggregates(aggregates);
+
+        mockPersistOnboarding(asserter);
+
+        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))
+                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+
+        mockSimpleSearchPOSTAndPersist(asserter);
+        mockSimpleProductValidAssert(request.getProductId(), false, asserter);
+        mockVerifyOnboardingNotFound(asserter);
+        mockVerifyAllowedMap(request.getInstitution().getTaxCode(), request.getProductId(), asserter);
+
+
+        asserter.assertThat(() -> onboardingService.onboarding(request, users), Assertions::assertNotNull);
+
+        asserter.execute(() -> {
+            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
+            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
+            PanacheMock.verifyNoMoreInteractions(Onboarding.class);
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
     void onboardingSa_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -637,6 +694,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionPspRequest = new Institution();
@@ -663,6 +721,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdateAndProductHasParent(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
+        onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productParentId");
         Institution institutionPspRequest = new Institution();
@@ -696,6 +755,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
+        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingDefaultRequest.setProductId("productId");
         onboardingDefaultRequest.setInstitution(new Institution());
@@ -725,6 +785,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -770,6 +831,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -810,6 +872,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -849,6 +912,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserNotFoundedAndWillSave(UniAsserter asserter) {
         Onboarding request = new Onboarding();
+        request.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         request.setProductId("productId");
         request.setInstitution(new Institution());
@@ -889,6 +953,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfUserRegistryFails(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
+        onboardingDefaultRequest.setIsAggregator(Boolean.FALSE);
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
         List<UserRequest> users = List.of(manager);
@@ -1129,6 +1194,7 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyOnboarding() {
         Onboarding onboarding = new Onboarding();
+        onboarding.setIsAggregator(Boolean.FALSE);
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
 
@@ -1146,6 +1212,7 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyUsersOnboarding() {
         Onboarding onboarding = new Onboarding();
+        onboarding.setIsAggregator(Boolean.FALSE);
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
         onboarding.setReferenceOnboardingId("referenceOnboardinId");

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1205,7 +1205,6 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void testOnboardingUpdateStatusOK() {
-        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))
@@ -1222,7 +1221,6 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void rejectOnboarding_statusIsCOMPLETED() {
-        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         onboarding.setStatus(OnboardingStatus.COMPLETED);
         PanacheMock.mock(Onboarding.class);
@@ -1240,7 +1238,6 @@ class OnboardingServiceDefaultTest {
 
     @Test
     void testOnboardingDeleteOnboardingNotFoundOrAlreadyDeleted() {
-        String reasonForReject = "string";
         Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -130,7 +130,7 @@ class OnboardingServiceDefaultTest {
     @Spy
     OnboardingMapper onboardingMapper = new OnboardingMapperImpl();
 
-    final static UserRequest manager = UserRequest.builder()
+    final static UserRequest managerUser = UserRequest.builder()
             .name("name")
             .surname("surname")
             .taxCode("taxCode")
@@ -147,19 +147,19 @@ class OnboardingServiceDefaultTest {
         managerResource = new UserResource();
         managerResource.setId(UUID.randomUUID());
         managerResource.setName(new CertifiableFieldResourceOfstring()
-                .value(manager.getName())
+                .value(managerUser.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
         managerResource.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(manager.getSurname())
+                .value(managerUser.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
 
         managerResourceWk = new UserResource();
         managerResourceWk.setId(UUID.randomUUID());
         managerResourceWk.setName(new CertifiableFieldResourceOfstring()
-                .value(manager.getName())
+                .value(managerUser.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
         managerResourceWk.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(manager.getSurname())
+                .value(managerUser.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE));
 
         Map<String, WorkContactResource> map = new HashMap<>();
@@ -173,10 +173,10 @@ class OnboardingServiceDefaultTest {
         managerResourceWkSpid = new UserResource();
         managerResourceWkSpid.setId(UUID.randomUUID());
         managerResourceWkSpid.setName(new CertifiableFieldResourceOfstring()
-                .value(manager.getName())
+                .value(managerUser.getName())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.SPID));
         managerResourceWkSpid.setFamilyName(new CertifiableFieldResourceOfstring()
-                .value(manager.getSurname())
+                .value(managerUser.getSurname())
                 .certification(CertifiableFieldResourceOfstring.CertificationEnum.SPID));
         managerResourceWkSpid.setWorkContacts(map);
     }
@@ -185,7 +185,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductThrowException(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();onboardingRequest.setIsAggregator(Boolean.FALSE);
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -200,7 +200,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -214,7 +214,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductAlreadyOnboarded(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -239,7 +239,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotDelegable(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PT);
@@ -259,7 +259,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PG);
@@ -283,7 +283,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
@@ -330,14 +330,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_Aoo(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser = UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -374,14 +374,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_AooNotFound(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -409,14 +409,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_AooException(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -444,14 +444,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_Uo(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -487,14 +487,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_UoNotFound(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -524,14 +524,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_addParentDescriptionForAooOrUo_UoException(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -578,14 +578,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_Aggregator(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();request.setIsAggregator(Boolean.TRUE);
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
@@ -606,7 +606,6 @@ class OnboardingServiceDefaultTest {
         mockVerifyOnboardingNotFound(asserter);
         mockVerifyAllowedMap(request.getInstitution().getTaxCode(), request.getProductId(), asserter);
 
-
         asserter.assertThat(() -> onboardingService.onboarding(request, users), Assertions::assertNotNull);
 
         asserter.execute(() -> {
@@ -620,7 +619,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingSa_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.SA);
@@ -657,14 +656,14 @@ class OnboardingServiceDefaultTest {
         productRole.setCode("admin");
         ProductRoleInfo productRoleInfo = new ProductRoleInfo();
         productRoleInfo.setRoles(List.of(productRole));
-        roleMapping.put(manager.getRole(), productRoleInfo);
+        roleMapping.put(managerUser.getRole(), productRoleInfo);
         productResource.setRoleMappings(roleMapping);
 
         if (hasParent) {
             Product parent = new Product();
             parent.setId("productParentId");
             Map<PartyRole, ProductRoleInfo> roleParentMapping = new HashMap<>();
-            roleParentMapping.put(manager.getRole(), productRoleInfo);
+            roleParentMapping.put(managerUser.getRole(), productRoleInfo);
             parent.setRoleMappings(roleParentMapping);
 
             productResource.setParentId(parent.getId());
@@ -679,7 +678,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productId");
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.PSP);
@@ -705,7 +704,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdateAndProductHasParent(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingRequest.setProductId("productParentId");
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.PSP);
@@ -738,7 +737,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         onboardingDefaultRequest.setProductId("productId");
         onboardingDefaultRequest.setInstitution(new Institution());
 
@@ -760,14 +759,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillUpdate(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResourceWk.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.GSP);
@@ -805,14 +804,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_whenUserFoundAndWillNotUpdate(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("wrong_name")
                 .taxCode(managerResourceWkSpid.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.GSP);
@@ -844,7 +843,7 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillUpdateMailUuid(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResourceWk.getFiscalCode())
                 .role(PartyRole.MANAGER)
@@ -852,7 +851,7 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.GSP);
@@ -891,7 +890,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserNotFoundedAndWillSave(UniAsserter asserter) {
         Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId("productId");
         request.setInstitution(new Institution());
         final UUID createUserId = UUID.randomUUID();
@@ -933,7 +932,7 @@ class OnboardingServiceDefaultTest {
         Onboarding onboardingDefaultRequest = new Onboarding();
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
 
         mockPersistOnboarding(asserter);
 
@@ -998,7 +997,7 @@ class OnboardingServiceDefaultTest {
 
         mockFindToken(asserter, onboarding.getId());
 
-        //Mock find manager fiscal code
+        //Mock find managerUserfiscal code
         String actualUseUid = onboarding.getUsers().get(0).getId();
         UserResource actualUserResource = new UserResource();
         actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
@@ -1033,7 +1032,7 @@ class OnboardingServiceDefaultTest {
 
         mockFindToken(asserter, onboarding.getId());
 
-        //Mock find manager fiscal code
+        //Mock find managerUserfiscal code
         String actualUseUid = onboarding.getUsers().get(0).getId();
         UserResource actualUserResource = new UserResource();
         actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
@@ -1213,7 +1212,7 @@ class OnboardingServiceDefaultTest {
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
-        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 1L);
+        mockUpdateOnboarding(onboarding.getId(), 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
                 .rejectOnboarding(onboarding.getId(), "string")
                 .subscribe()
@@ -1231,7 +1230,7 @@ class OnboardingServiceDefaultTest {
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
 
-        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 1L);
+        mockUpdateOnboarding(onboarding.getId(), 1L);
         UniAssertSubscriber<Long> subscriber = onboardingService
                 .rejectOnboarding(onboarding.getId(), "string")
                 .subscribe()
@@ -1247,7 +1246,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.findById(onboarding.getId()))
                 .thenReturn(Uni.createFrom().item(onboarding));
-        mockUpdateOnboarding(onboarding.getId(), reasonForReject, 0L);
+        mockUpdateOnboarding(onboarding.getId(), 0L);
 
         UniAssertSubscriber<Long> subscriber = onboardingService
                 .rejectOnboarding(onboarding.getId(), "string")
@@ -1257,7 +1256,7 @@ class OnboardingServiceDefaultTest {
         subscriber.assertFailedWith(InvalidRequestException.class);
     }
 
-    private void mockUpdateOnboarding(String onboardingId, String reasonForReject, Long updatedItemCount) {
+    private void mockUpdateOnboarding(String onboardingId, Long updatedItemCount) {
         ReactivePanacheUpdate query = mock(ReactivePanacheUpdate.class);
         PanacheMock.mock(Onboarding.class);
         when(Onboarding.update(any(Document.class))).thenReturn(query);
@@ -1445,13 +1444,14 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboarding_Onboarding_importPA(UniAsserter asserter) {
-        UserRequest manager = UserRequest.builder()
+        UserRequest managerUser= UserRequest.builder()
                 .name("name")
                 .taxCode(managerResource.getFiscalCode())
                 .role(PartyRole.MANAGER)
                 .build();
 
-        Onboarding request = new Onboarding();List<UserRequest> users = List.of(manager);
+        Onboarding request = new Onboarding();
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setTaxCode("taxCode");
@@ -1491,7 +1491,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingUsers(UniAsserter asserter) {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         request.setUsers(users);
         mockPersistOnboarding(asserter);
@@ -1528,7 +1528,7 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingUsersWithNullOnboardingReeferenceId(UniAsserter asserter) {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setProductId(PROD_INTEROP.getValue());
         request.setUsers(users);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
@@ -1556,7 +1556,7 @@ class OnboardingServiceDefaultTest {
     @Test
     void onboardingUsersWithInstitutionNotFound() {
         OnboardingUserRequest request = new OnboardingUserRequest();
-        List<UserRequest> users = List.of(manager);
+        List<UserRequest> users = List.of(managerUser);
         request.setTaxCode("taxCode");
         request.setSubunitCode("subunitCode");
         request.setProductId(PROD_INTEROP.getValue());
@@ -1611,7 +1611,7 @@ class OnboardingServiceDefaultTest {
 
             mockFindToken(asserter, onboarding.getId());
 
-            //Mock find manager fiscal code
+            //Mock find managerUserfiscal code
             String actualUseUid = onboarding.getUsers().get(0).getId();
             UserResource actualUserResource = new UserResource();
             actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
@@ -1637,7 +1637,7 @@ class OnboardingServiceDefaultTest {
 
             mockFindToken(asserter, onboarding.getId());
 
-            //Mock find manager fiscal code
+            //Mock find managerUserfiscal code
             String actualUseUid = onboarding.getUsers().get(0).getId();
             UserResource actualUserResource = new UserResource();
             actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
@@ -1664,7 +1664,7 @@ class OnboardingServiceDefaultTest {
 
             mockFindToken(asserter, onboarding.getId());
 
-            //Mock find manager fiscal code
+            //Mock find managerUserfiscal code
             String actualUseUid = onboarding.getUsers().get(0).getId();
             UserResource actualUserResource = new UserResource();
             actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");
@@ -1698,7 +1698,7 @@ class OnboardingServiceDefaultTest {
 
             mockFindToken(asserter, onboarding.getId());
 
-            //Mock find manager fiscal code
+            //Mock find managerUserfiscal code
             String actualUseUid = onboarding.getUsers().get(0).getId();
             UserResource actualUserResource = new UserResource();
             actualUserResource.setFiscalCode("ACTUAL-FISCAL-CODE");

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -184,8 +184,7 @@ class OnboardingServiceDefaultTest {
     @Test
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductThrowException(UniAsserter asserter) {
-        Onboarding onboardingRequest = new Onboarding();
-        onboardingRequest.setIsAggregator(Boolean.FALSE);
+        Onboarding onboardingRequest = new Onboarding();onboardingRequest.setIsAggregator(Boolean.FALSE);
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -201,7 +200,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -216,7 +214,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductAlreadyOnboarded(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -242,7 +239,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductIsNotDelegable(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -263,7 +259,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -288,7 +283,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPa_throwExceptionIfProductParentRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
@@ -315,7 +309,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfRoleNotValid(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
 
@@ -344,7 +337,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -389,7 +381,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -425,7 +416,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -461,7 +451,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -505,7 +494,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -543,7 +531,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -597,8 +584,7 @@ class OnboardingServiceDefaultTest {
                 .role(PartyRole.MANAGER)
                 .build();
 
-        Onboarding request = new Onboarding();
-        request.setIsAggregator(Boolean.TRUE);
+        Onboarding request = new Onboarding();request.setIsAggregator(Boolean.TRUE);
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
@@ -634,7 +620,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingSa_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionBaseRequest = new Institution();
@@ -694,7 +679,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productId");
         Institution institutionPspRequest = new Institution();
@@ -721,7 +705,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingPsp_whenUserFoundedAndWillNotUpdateAndProductHasParent(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingRequest.setProductId("productParentId");
         Institution institutionPspRequest = new Institution();
@@ -755,7 +738,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserFoundedAndWillNotUpdate(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         onboardingDefaultRequest.setProductId("productId");
         onboardingDefaultRequest.setInstitution(new Institution());
@@ -785,7 +767,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -831,7 +812,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -872,7 +852,6 @@ class OnboardingServiceDefaultTest {
                 .build();
 
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionPspRequest = new Institution();
@@ -912,7 +891,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_whenUserNotFoundedAndWillSave(UniAsserter asserter) {
         Onboarding request = new Onboarding();
-        
         List<UserRequest> users = List.of(manager);
         request.setProductId("productId");
         request.setInstitution(new Institution());
@@ -953,7 +931,6 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfUserRegistryFails(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        
         onboardingDefaultRequest.setInstitution(new Institution());
         onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
         List<UserRequest> users = List.of(manager);
@@ -1194,7 +1171,6 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyOnboarding() {
         Onboarding onboarding = new Onboarding();
-        
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
 
@@ -1212,7 +1188,6 @@ class OnboardingServiceDefaultTest {
 
     private Onboarding createDummyUsersOnboarding() {
         Onboarding onboarding = new Onboarding();
-        
         onboarding.setId(UUID.randomUUID().toString());
         onboarding.setProductId("prod-id");
         onboarding.setReferenceOnboardingId("referenceOnboardinId");
@@ -1476,8 +1451,7 @@ class OnboardingServiceDefaultTest {
                 .role(PartyRole.MANAGER)
                 .build();
 
-        Onboarding request = new Onboarding();
-        List<UserRequest> users = List.of(manager);
+        Onboarding request = new Onboarding();List<UserRequest> users = List.of(manager);
         request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setTaxCode("taxCode");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added API to save the onboarding request from an Aggregator
- added check if isAggregator is TRUE to set workflowType to CONTRACT_REGISTRATION_AGGREGATOR

#### Motivation and Context

The endpoint dedicated to aggregation will take care of:

- Validate the product and verify that the aggregator does not already have an active membership for that product. The same check is NOT done for all the aggregated entities as in the case of membership already present this is not modified.
- Validate the data referring to the institution as already foreseen for classic onboarding
- Persist onboarding and launch Request to Join orchestration

#### How Has This Been Tested?

The new API was invoked and it was verified that the data was correctly saved in the DB

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.