### PR TITLE
SELC-4901: added function for checkOrganization

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/FDConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/FDConfig.java
@@ -1,0 +1,8 @@
+package it.pagopa.selfcare.onboarding.config;
+
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "fd")
+public interface FDConfig {
+    boolean byPassCheckOrganization();
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -2,12 +2,10 @@ package it.pagopa.selfcare.onboarding.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.functions.*;
-import com.microsoft.azure.functions.annotation.AuthorizationLevel;
-import com.microsoft.azure.functions.annotation.FixedDelayRetry;
-import com.microsoft.azure.functions.annotation.FunctionName;
-import com.microsoft.azure.functions.annotation.HttpTrigger;
+import com.microsoft.azure.functions.annotation.*;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
+import it.pagopa.selfcare.onboarding.service.CheckOrganizationService;
 import it.pagopa.selfcare.onboarding.service.NotificationEventService;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 
@@ -22,14 +20,16 @@ public class NotificationFunctions {
 
     private final NotificationEventService notificationEventService;
     private final OnboardingService onboardingService;
+    private final CheckOrganizationService checkOrganizationService;
     private final ObjectMapper objectMapper;
 
     public NotificationFunctions(ObjectMapper objectMapper,
                                  NotificationEventService notificationEventService,
-                                 OnboardingService onboardingService) {
+                                 OnboardingService onboardingService, CheckOrganizationService checkOrganizationService) {
         this.objectMapper = objectMapper;
         this.notificationEventService = notificationEventService;
         this.onboardingService = onboardingService;
+        this.checkOrganizationService = checkOrganizationService;
     }
 
     /**
@@ -91,5 +91,31 @@ public class NotificationFunctions {
         }
         notificationEventService.send(context, onboarding.get(), queueEvent);
         return request.createResponseBuilder(HttpStatus.OK).build();
+    }
+
+    @FunctionName("CheckOrganization")
+    public HttpResponseMessage checkOrganization(
+            @HttpTrigger(name = "req", methods = {HttpMethod.HEAD}, route = "organizations", authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+
+        context.getLogger().info("checkOrganization trigger processed a request");
+
+        String fiscalCode = request.getQueryParameters().get("fiscalCode");
+        String vatNumber = request.getQueryParameters().get("vatNumber");
+
+        if (fiscalCode == null || vatNumber == null) {
+            context.getLogger().warning("fiscalCode, vatNumber are required.");
+            return request.createResponseBuilder(HttpStatus.BAD_REQUEST)
+                    .body("fiscalCode, vatNumber are required.")
+                    .build();
+        }
+
+        boolean alreadyRegistered =  checkOrganizationService.checkOrganization(context, fiscalCode, vatNumber);
+
+        if (alreadyRegistered) {
+            return request.createResponseBuilder(HttpStatus.OK).build();
+        } else {
+            return request.createResponseBuilder(HttpStatus.NOT_FOUND).build();
+        }
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationService.java
@@ -1,0 +1,7 @@
+package it.pagopa.selfcare.onboarding.service;
+
+import com.microsoft.azure.functions.ExecutionContext;
+
+public interface CheckOrganizationService {
+    boolean checkOrganization(ExecutionContext context, String fiscalCode, String vatNumber);
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationServiceDefault.java
@@ -1,0 +1,29 @@
+package it.pagopa.selfcare.onboarding.service;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import it.pagopa.selfcare.onboarding.config.FDConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CheckOrganizationServiceDefault implements CheckOrganizationService {
+
+    private final FDConfig fdConfig;
+
+    public CheckOrganizationServiceDefault(FDConfig fdConfig) {
+        this.fdConfig = fdConfig;
+    }
+
+    @Override
+    public boolean checkOrganization(ExecutionContext context, String fiscalCode, String vatNumber) {
+        context.getLogger().info("checkOrganization start");
+        context.getLogger().info(() -> String.format("checkOrganization fiscalCode = %s, vatNumber = %s", fiscalCode, vatNumber));
+
+        if (fdConfig.byPassCheckOrganization()) {
+            context.getLogger().info("byPassCheckOrganization is true, skipping check");
+            return false;
+        } else {
+            // TODO: implement the check via API
+            return true;
+        }
+    }
+}

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -164,3 +164,4 @@ notification.consumers.fd.key=${EVENTHUB_SC_CONTRACTS_FD_SELFCARE_WO_KEY_LC:test
 notification.consumers.fd.allowed-institution-types=null
 notification.consumers.fd.allowed-origins=null
 notification.minutes-threshold-for-update-notification=${MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION:5}
+fd.by-pass-check-organization=${BYPASS_CHECK_ORGANIZATION:false}

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/TestUtils.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/TestUtils.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.onboarding;
+
+import com.microsoft.azure.functions.ExecutionContext;
+
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class TestUtils {
+    public static ExecutionContext getMockedContext() {
+        ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+        return context;
+    }
+}

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctionsTest.java
@@ -8,6 +8,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.HttpResponseMessageMock;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.service.CheckOrganizationService;
 import it.pagopa.selfcare.onboarding.service.NotificationEventService;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
 import jakarta.inject.Inject;
@@ -39,6 +40,9 @@ public class NotificationFunctionsTest {
 
     @InjectMock
     NotificationEventService notificationEventService;
+
+    @InjectMock
+    CheckOrganizationService checkOrganizationService;
 
     final String onboardinString = "{\"onboardingId\":\"onboardingId\"}";
 
@@ -173,6 +177,82 @@ public class NotificationFunctionsTest {
         HttpResponseMessage responseMessage = function.sendNotification(req, context);
         assertEquals(HttpStatus.BAD_REQUEST.value(), responseMessage.getStatusCode());
 
+    }
+
+    @Test
+    public void checkOrganizationTest() {
+        @SuppressWarnings("unchecked") final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fiscalCode", "someFiscalCode");
+        queryParams.put("vatNumber", "someVatNumber");
+        queryParams.put("Authorization", "someToken");
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+        when(checkOrganizationService.checkOrganization(any(), any(), any())).thenReturn(true);
+        HttpResponseMessage responseMessage = function.checkOrganization(req, context);
+        assertEquals(HttpStatus.OK.value(), responseMessage.getStatusCode());
+    }
+
+    @Test
+    public void checkOrganizationFiscalCodeNullTest() {
+        @SuppressWarnings("unchecked") final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("vatNumber", "vatNumber");
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        HttpResponseMessage responseMessage = function.checkOrganization(req, context);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), responseMessage.getStatusCode());
+    }
+
+    @Test
+    public void checkOrganizationVatNumberNullTest() {
+        @SuppressWarnings("unchecked") final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fiscalCode", "fiscalCode");
+        doReturn(queryParams).when(req).getQueryParameters();
+
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        HttpResponseMessage responseMessage = function.checkOrganization(req, context);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), responseMessage.getStatusCode());
+    }
+
+    @Test
+    public void checkOrganizationAlreadyRegisteredNullTest() {
+        @SuppressWarnings("unchecked") final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("fiscalCode", "fiscalCode");
+        queryParams.put("vatNumber", "vatNumber");
+        doReturn(queryParams).when(req).getQueryParameters();
+        doAnswer((Answer<HttpResponseMessage.Builder>) invocation -> {
+            HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+            return new HttpResponseMessageMock.HttpResponseMessageBuilderMock().status(status);
+        }).when(req).createResponseBuilder(any(HttpStatus.class));
+        final ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+        when(checkOrganizationService.checkOrganization(any(), any(), any())).thenReturn(false);
+        HttpResponseMessage responseMessage = function.checkOrganization(req, context);
+        assertEquals(HttpStatus.NOT_FOUND.value(), responseMessage.getStatusCode());
     }
 
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CheckOrganizationServiceDefaultTest.java
@@ -1,0 +1,36 @@
+package it.pagopa.selfcare.onboarding.service;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import it.pagopa.selfcare.onboarding.service.profile.CheckOrganizationByPassTestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static it.pagopa.selfcare.onboarding.TestUtils.getMockedContext;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class CheckOrganizationServiceDefaultTest {
+    @Inject
+    CheckOrganizationService checkOrganizationService;
+
+    @Test
+    void checkOrganizationWhenByPassCheckOrganizationIsFalse() {
+        assertTrue(checkOrganizationService.checkOrganization(getMockedContext(), null, null));
+    }
+
+    @Nested
+    @TestProfile(CheckOrganizationByPassTestProfile.class)
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CheckOrganizationWhenByPassCheckOrganizationIsTrue {
+        @Test
+        void checkOrganizationWhenByPassCheckOrganizationIsTrue() {
+            assertFalse(checkOrganizationService.checkOrganization(getMockedContext(), null, null));
+        }
+    }
+
+
+}

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/profile/CheckOrganizationByPassTestProfile.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/profile/CheckOrganizationByPassTestProfile.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.onboarding.service.profile;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class CheckOrganizationByPassTestProfile implements QuarkusTestProfile {
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of("fd.by-pass-check-organization", "true");
+    }
+
+}

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -47,3 +47,4 @@ onboarding-functions.mail-template.placeholders.onboarding.notification-requeste
 onboarding-functions.mail-template.placeholders.onboarding.reject-product-name=productName
 onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-placeholder=onboardingUrl
 onboarding-functions.mail-template.placeholders.onboarding.reject-onboarding-url-value=default
+fd.by-pass-check-organization=false

--- a/infra/functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev/terraform.tfvars
@@ -86,4 +86,5 @@ app_settings = {
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP",
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
   "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
+  "BYPASS_CHECK_ORGANIZATION"                          = "false"
 }

--- a/infra/functions/onboarding-functions/env/prod/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/prod/terraform.tfvars
@@ -87,6 +87,7 @@ app_settings = {
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
   "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
+  "BYPASS_CHECK_ORGANIZATION"                          = "false"
 
   ##ARUBA SIGNATURE
   "PAGOPA_SIGNATURE_SOURCE"                        = "aruba",

--- a/infra/functions/onboarding-functions/env/uat/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/uat/terraform.tfvars
@@ -86,6 +86,7 @@ app_settings = {
   "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
   "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
   "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
+  "BYPASS_CHECK_ORGANIZATION"                          = "false"
 
   ##ARUBA SIGNATURE
   "PAGOPA_SIGNATURE_SOURCE"                        = "disabled",


### PR DESCRIPTION
#### List of Changes

added function for checkOrganization

#### Motivation and Context

Moving checkOrganization from selfcare-ms-external-interceptor in dedicated http function.
At the moment the function returns true, because we need to add the invocation to FD service.

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.