### PR TITLE
fix: added check on null values of Token in BaseNotificationBuilder

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/BaseNotificationBuilder.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/BaseNotificationBuilder.java
@@ -184,7 +184,7 @@ public class BaseNotificationBuilder implements NotificationBuilder {
 
     @Override
     public void setTokenData(NotificationToSend notificationToSend, Token token) {
-        if (Objects.nonNull(token)) {
+        if (Objects.nonNull(token) && Objects.nonNull(token.getContractSigned())) {
             notificationToSend.setFileName(Paths.get(token.getContractSigned()).getFileName().toString());
             notificationToSend.setContentType(token.getContractSigned());
         }


### PR DESCRIPTION
#### List of Changes

added check on null values of Token in BaseNotificationBuilder

#### Motivation and Context

There was a problem when building notification when the token entity didn't have contractSigned field

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.