### PR TITLE
[SELC-5191] feat: added function to check if onboarding should send notification

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
@@ -2,21 +2,28 @@ package it.pagopa.selfcare.onboarding.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.dto.OnboardingAggregateOrchestratorInput;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
 import it.pagopa.selfcare.onboarding.exception.FunctionOrchestratedException;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 public class Utils {
 
     public static final BiFunction<String, String, String> CONTRACT_FILENAME_FUNC =
             (filename, productName) -> String.format(filename, StringUtils.stripAccents(productName.replaceAll("\\s+","_")));
 
-
+    private static final List<WorkflowType> ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS = List.of(
+            WorkflowType.CONFIRMATION,
+            WorkflowType.FOR_APPROVE,
+            WorkflowType.IMPORT,
+            WorkflowType.CONTRACT_REGISTRATION,
+            WorkflowType.FOR_APPROVE_PT
+    );
 
     public static Onboarding readOnboardingValue(ObjectMapper objectMapper, String onboardingString) {
         try {
@@ -62,5 +69,9 @@ public class Utils {
             throw new FunctionOrchestratedException(e);
         }
         return onboardingWorkflowString;
+    }
+
+    public static boolean isNotInstitutionOnboarding(Onboarding onboarding) {
+        return !ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.contains(onboarding.getWorkflowType());
     }
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -4,6 +4,7 @@ import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
+import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
 import it.pagopa.selfcare.onboarding.entity.Billing;
@@ -174,8 +175,24 @@ public class NotificationEventServiceDefaultTest {
         verifyNoInteractions(eventHubRestClient);
     }
 
+    @Test
+    void sendMessageWontProceedsWhenOnboardingIsNotReferredToInstitution() {
+        final Onboarding onboarding = createOnboarding();
+        onboarding.setWorkflowType(WorkflowType.USERS);
+
+        ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(Logger.getGlobal()).when(context).getLogger();
+
+        messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
+        verifyNoInteractions(productService);
+        verifyNoInteractions(tokenRepository);
+        verifyNoInteractions(institutionApi);
+        verifyNoInteractions(eventHubRestClient);
+    }
+
     private Onboarding createOnboarding() {
         Onboarding onboarding = new Onboarding();
+        onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION);
         onboarding.setId(onboarding.getId());
         String productId = "prod-io";
         onboarding.setProductId(productId);


### PR DESCRIPTION
#### List of Changes

Added function to check if onboarding should send notification, based on workflow type of onboarding

#### Motivation and Context

We need to send notifications only for onboarding of institution, ignoring onboarding of users and aggregates

#### How Has This Been Tested?
local env

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.