### PR TITLE
[SELC-5214] feat: Added previousManagerId as attribute of Onboarding in order to detect email template

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/MailTemplatePlaceholdersConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/MailTemplatePlaceholdersConfig.java
@@ -7,6 +7,10 @@ public interface MailTemplatePlaceholdersConfig {
 
     String userName();
     String userSurname();
+    String managerName();
+    String managerSurname();
+    String previousManagerName();
+    String previousManagerSurname();
     String productName();
     String institutionDescription();
     String businessName();

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -35,8 +35,10 @@ public class Onboarding  {
     private String reasonForReject;
     private Boolean isAggregator;
     private Aggregator aggregator;
-
     private String delegationId;
+
+    //This field is used in case of workflowType USER
+    private String previousManagerId;
 
     public String getDelegationId() {
         return delegationId;
@@ -200,6 +202,14 @@ public class Onboarding  {
 
     public Aggregator getAggregator() {
         return aggregator;
+    }
+
+    public String getPreviousManagerId() {
+        return previousManagerId;
+    }
+
+    public void setPreviousManagerId(String previousManagerId) {
+        this.previousManagerId = previousManagerId;
     }
 
     @Override

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/OnboardingWorkflowUser.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/OnboardingWorkflowUser.java
@@ -1,9 +1,12 @@
 package it.pagopa.selfcare.onboarding.entity;
 
+import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.onboarding.common.TokenType;
 import it.pagopa.selfcare.onboarding.config.MailTemplatePathConfig;
 import it.pagopa.selfcare.onboarding.config.MailTemplatePlaceholdersConfig;
 import it.pagopa.selfcare.product.entity.Product;
+
+import java.util.Objects;
 
 public class OnboardingWorkflowUser extends OnboardingWorkflow {
 
@@ -22,7 +25,16 @@ public class OnboardingWorkflowUser extends OnboardingWorkflow {
 
     @Override
     public String emailRegistrationPath(MailTemplatePathConfig config) {
-        return config.registrationUserPath();
+        final String managerId =  this.onboarding.getUsers().stream()
+                .filter(user -> PartyRole.MANAGER == user.getRole())
+                .map(User::getId)
+                .findAny()
+                .orElse(null);
+        if (Objects.nonNull(this.onboarding.getPreviousManagerId())
+                && this.onboarding.getPreviousManagerId().equals(managerId)) {
+            return config.registrationUserPath();
+        }
+        return config.registrationUserNewManagerPath();
     }
 
     @Override

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationService.java
@@ -17,6 +17,8 @@ public interface NotificationService {
 
     void sendMailRegistrationForContract(String onboardingId, String destination, String name, String username, String productName, String institutionName, String templatePath, String confirmTokenUrl);
 
+    void sendMailRegistrationForContract(String onboardingId, String destination, OnboardingService.SendMailInput sendMailInput, String templatePath, String confirmTokenUrl);
+
     void sendMailRegistrationForContractAggregator(String onboardingId, String destination, String name, String username, String productName);
 
     void sendCompletedEmail(String institutionName, List<String> destinationMails, Product product, InstitutionType institutionType, OnboardingWorkflow onboardingWorkflow);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefault.java
@@ -115,6 +115,21 @@ public class NotificationServiceDefault implements NotificationService {
     }
 
     @Override
+    public void sendMailRegistrationForContract(String onboardingId, String destination, OnboardingService.SendMailInput sendMailInput, String templatePath, String confirmTokenUrl) {
+        // Prepare data for email
+        Map<String, String> mailParameters = new HashMap<>();
+        mailParameters.put(templatePlaceholdersConfig.productName(), sendMailInput.product.getTitle());
+        Optional.ofNullable(sendMailInput.userRequestName).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.userName(), value));
+        Optional.ofNullable(sendMailInput.userRequestSurname).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.userSurname(), value));
+        mailParameters.put(templatePlaceholdersConfig.rejectTokenName(), templatePlaceholdersConfig.rejectTokenPlaceholder() + onboardingId);
+        mailParameters.put(templatePlaceholdersConfig.confirmTokenName(), confirmTokenUrl + onboardingId);
+        mailParameters.put(templatePlaceholdersConfig.institutionDescription(), sendMailInput.institutionName);
+
+        sendMailWithFile(List.of(destination), templatePath, mailParameters, sendMailInput.product.getTitle(), null);
+
+    }
+
+    @Override
     public void sendMailRegistrationForContractAggregator(String onboardingId, String destination, String name, String username, String productName) {
 
         // Prepare data for email

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefault.java
@@ -124,6 +124,10 @@ public class NotificationServiceDefault implements NotificationService {
         mailParameters.put(templatePlaceholdersConfig.rejectTokenName(), templatePlaceholdersConfig.rejectTokenPlaceholder() + onboardingId);
         mailParameters.put(templatePlaceholdersConfig.confirmTokenName(), confirmTokenUrl + onboardingId);
         mailParameters.put(templatePlaceholdersConfig.institutionDescription(), sendMailInput.institutionName);
+        Optional.ofNullable(sendMailInput.managerName).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.managerName(), value));
+        Optional.ofNullable(sendMailInput.managerSurname).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.managerSurname(), value));
+        Optional.ofNullable(sendMailInput.previousManagerName).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.previousManagerName(), value));
+        Optional.ofNullable(sendMailInput.previousManagerSurname).ifPresent(value -> mailParameters.put(templatePlaceholdersConfig.previousManagerSurname(), value));
 
         sendMailWithFile(List.of(destination), templatePath, mailParameters, sendMailInput.product.getTitle(), null);
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -63,9 +63,6 @@ public class OnboardingService {
     ProductService productService;
 
     @Inject
-    OnboardingRepository onboardingRepository;
-
-    @Inject
     OnboardingRepository repository;
 
     @Inject
@@ -230,7 +227,7 @@ public class OnboardingService {
 
         // Set data of previousManager in case of workflowType USERS
         if (Objects.nonNull(onboarding.getPreviousManagerId())) {
-            setPreviousManager(onboarding, sendMailInput);
+            setManagerData(onboarding, sendMailInput);
         }
 
         // Retrieve user request name and surname
@@ -296,14 +293,16 @@ public class OnboardingService {
         Product product;
         String userRequestName;
         // Used in case of workflowType USER
-        String previousUserName;
+        String previousManagerName;
+        String managerName;
         String userRequestSurname;
         // Used in case of workflowType USER
-        String previousUserSurname;
+        String previousManagerSurname;
+        String managerSurname;
         String institutionName;
     }
 
-    private void setPreviousManager(Onboarding onboarding, SendMailInput sendMailInput) {
+    private void setManagerData(Onboarding onboarding, SendMailInput sendMailInput) {
         final String managerId =  onboarding.getUsers().stream()
                 .filter(user -> PartyRole.MANAGER == user.getRole())
                 .map(User::getId)
@@ -312,8 +311,11 @@ public class OnboardingService {
 
         if (!onboarding.getPreviousManagerId().equals(managerId)) {
             UserResource previousManager = userRegistryApi.findByIdUsingGET(USERS_WORKS_FIELD_LIST, onboarding.getPreviousManagerId());
-            sendMailInput.previousUserName = previousManager.getName().getValue();
-            sendMailInput.previousUserSurname = previousManager.getFamilyName().getValue();
+            sendMailInput.previousManagerName = previousManager.getName().getValue();
+            sendMailInput.previousManagerSurname = previousManager.getFamilyName().getValue();
+            UserResource currentManager = userRegistryApi.findByIdUsingGET(USERS_WORKS_FIELD_LIST, managerId);
+            sendMailInput.managerName = currentManager.getName().getValue();
+            sendMailInput.managerSurname = currentManager.getFamilyName().getValue();
         }
     }
 }

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -102,6 +102,10 @@ onboarding-functions.mail-template.path.onboarding.reject-path = ${MAIL_TEMPLATE
 ## MAIL PLACEHOLDERS
 onboarding-functions.mail-template.placeholders.onboarding.user-name = requesterName
 onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
+onboarding-functions.mail-template.placeholders.onboarding.previous-manager-name = previousManagerName
+onboarding-functions.mail-template.placeholders.onboarding.manager-name = managerName
+onboarding-functions.mail-template.placeholders.onboarding.manager-surname = managerSurname
+onboarding-functions.mail-template.placeholders.onboarding.previous-manager-surname = previousManagerSurname
 onboarding-functions.mail-template.placeholders.onboarding.product-name = productName
 onboarding-functions.mail-template.placeholders.onboarding.reason-for-reject = reasonForReject
 onboarding-functions.mail-template.placeholders.onboarding.institution-description = institutionName

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceTest.java
@@ -284,22 +284,27 @@ class OnboardingServiceTest {
                 .thenReturn(userResource);
 
         OnboardingWorkflow onboardingWorkflow = getOnboardingWorkflowInstitution(onboarding);
+        OnboardingService.SendMailInput sendMailInput = new OnboardingService.SendMailInput();
+        sendMailInput.userRequestName = userResource.getName().getValue();
+        sendMailInput.userRequestSurname = userResource.getFamilyName().getValue();
+        sendMailInput.product = product;
+        sendMailInput.institutionName = "description";
 
         doNothing().when(notificationService)
                 .sendMailRegistrationForContract(onboarding.getId(),
                         onboarding.getInstitution().getDigitalAddress(),
-                        userResource.getName().getValue(), userResource.getFamilyName().getValue(),
-                        product.getTitle(), "description",
+                        sendMailInput,
                         "default", "default");
 
         onboardingService.sendMailRegistrationForContract(onboardingWorkflow);
 
         Mockito.verify(notificationService, times(1))
-                .sendMailRegistrationForContract(onboarding.getId(),
-                        onboarding.getInstitution().getDigitalAddress(),
-                        userResource.getName().getValue(), userResource.getFamilyName().getValue(),
-                        product.getTitle(), "description",
-                        "default", "default");
+                .sendMailRegistrationForContract(any(),
+                        any(),
+                        any(),
+                        anyString(),
+                        anyString());
+        verifyNoMoreInteractions(notificationService);
     }
 
     @Test

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -28,6 +28,8 @@ onboarding-functions.mail-template.path.onboarding.reject-path = default
 ## MAIL PLACEHOLDERS
 onboarding-functions.mail-template.placeholders.onboarding.user-name = requesterName
 onboarding-functions.mail-template.placeholders.onboarding.previous-manager-name = previousManagerName
+onboarding-functions.mail-template.placeholders.onboarding.manager-name = managerName
+onboarding-functions.mail-template.placeholders.onboarding.manager-surname = managerSurname
 onboarding-functions.mail-template.placeholders.onboarding.previous-manager-surname = previousManagerSurname
 onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
 onboarding-functions.mail-template.placeholders.onboarding.product-name = productName

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -27,11 +27,11 @@ onboarding-functions.mail-template.path.onboarding.reject-path = default
 
 ## MAIL PLACEHOLDERS
 onboarding-functions.mail-template.placeholders.onboarding.user-name = requesterName
+onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
 onboarding-functions.mail-template.placeholders.onboarding.previous-manager-name = previousManagerName
 onboarding-functions.mail-template.placeholders.onboarding.manager-name = managerName
 onboarding-functions.mail-template.placeholders.onboarding.manager-surname = managerSurname
 onboarding-functions.mail-template.placeholders.onboarding.previous-manager-surname = previousManagerSurname
-onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
 onboarding-functions.mail-template.placeholders.onboarding.product-name = productName
 onboarding-functions.mail-template.placeholders.onboarding.institution-description = institutionName
 onboarding-functions.mail-template.placeholders.onboarding.admin-link = default

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -27,6 +27,8 @@ onboarding-functions.mail-template.path.onboarding.reject-path = default
 
 ## MAIL PLACEHOLDERS
 onboarding-functions.mail-template.placeholders.onboarding.user-name = requesterName
+onboarding-functions.mail-template.placeholders.onboarding.previous-manager-name = previousManagerName
+onboarding-functions.mail-template.placeholders.onboarding.previous-manager-surname = previousManagerSurname
 onboarding-functions.mail-template.placeholders.onboarding.user-surname = requesterSurname
 onboarding-functions.mail-template.placeholders.onboarding.product-name = productName
 onboarding-functions.mail-template.placeholders.onboarding.institution-description = institutionName

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -42,4 +42,5 @@ public class Onboarding extends ReactivePanacheMongoEntityBase {
     private Boolean isAggregator;
 
     private String referenceOnboardingId;
+    private String previousManagerId;
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -297,16 +297,23 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     private Uni<Onboarding> addReferencedOnboardingId(Onboarding onboarding) {
-        String taxCode = onboarding.getInstitution().getTaxCode();
-        String origin = onboarding.getInstitution().getOrigin().name();
-        String originId = onboarding.getInstitution().getOriginId();
-        String productId = onboarding.getProductId();
-        String subunitCode = onboarding.getInstitution().getSubunitCode();
-        return  getOnboardingByFilters(taxCode, subunitCode, origin, originId, productId)
-                .filter(item -> Objects.isNull(item.getReferenceOnboardingId()))
+        final String taxCode = onboarding.getInstitution().getTaxCode();
+        final String origin = onboarding.getInstitution().getOrigin().name();
+        final String originId = onboarding.getInstitution().getOriginId();
+        final String productId = onboarding.getProductId();
+        final String subunitCode = onboarding.getInstitution().getSubunitCode();
+        Multi<Onboarding> onboardings = getOnboardingByFilters(taxCode, subunitCode, origin, originId, productId);
+        Uni<Onboarding> current = onboardings.filter(item -> Objects.isNull(item.getReferenceOnboardingId()))
                 .toUni().onItem().ifNull().failWith(() -> new ResourceNotFoundException(String.format("Onboarding for taxCode %s, origin %s, originId %s, productId %s, subunitCode %s not found",
                         taxCode, origin, originId, productId, subunitCode)))
-                .invoke(previousOnboarding -> onboarding.setReferenceOnboardingId(previousOnboarding.getId()))
+                .invoke(previousOnboarding -> onboarding.setReferenceOnboardingId(previousOnboarding.getId()));
+        return current.onItem()
+                .invoke(() ->
+                    onboarding.setPreviousManagerId(onboardings.collect().first()
+                            .map(previousOnboarding -> previousOnboarding.getUsers().stream()
+                                    .filter(user -> user.getRole().equals(PartyRole.MANAGER))
+                                    .map(User::getId).findFirst().orElse(null))
+                            .toString()))
                 .replaceWith(onboarding);
     }
 
@@ -317,8 +324,9 @@ public class OnboardingServiceDefault implements OnboardingService {
                 originId, OnboardingStatus.COMPLETED,
                 productId
         );
+        Document sort = QueryUtils.buildSortDocument(Onboarding.Fields.createdAt.name(), SortEnum.DESC);
         Document query = QueryUtils.buildQuery(queryParameter);
-        return Onboarding.find(query).stream();
+        return Onboarding.find(query, sort).stream();
     }
 
     public Uni<Onboarding> persistAndStartOrchestrationOnboarding(Onboarding onboarding, Uni<OrchestrationResponse> orchestration) {

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1452,7 +1452,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
         when(query.stream()).thenReturn(Multi.createFrom().item(new Onboarding()));
-        when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
 
         asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
@@ -1485,7 +1485,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
         when(query.firstResult()).thenReturn(Uni.createFrom().nullItem());
-        when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
 
         asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))
                 .thenReturn(Uni.createFrom().item(Response.noContent().build())));
@@ -1744,7 +1744,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
         when(query.stream()).thenReturn(Multi.createFrom().items(onboarding));
-        when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
         UserResource userResource = new UserResource();
         userResource.setId(UUID.randomUUID());
         when(userRegistryApi.searchUsingPOST(any(), any()))
@@ -1768,7 +1768,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
         when(query.stream()).thenReturn(Multi.createFrom().items(onboarding));
-        when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
         UserResource userResource = new UserResource();
         userResource.setId(uuid);
         when(userRegistryApi.searchUsingPOST(any(), any()))
@@ -1798,7 +1798,7 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
         when(query.stream()).thenReturn(Multi.createFrom().empty());
-        when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
         UserResource userResource = new UserResource();
         userResource.setId(UUID.randomUUID());
         when(userRegistryApi.searchUsingPOST(any(), any()))

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -138,11 +138,11 @@ class OnboardingServiceDefaultTest {
             .role(PartyRole.MANAGER)
             .build();
 
-    final static UserResource managerResource;
-    final static UserResource managerResourceWk;
-    final static UserResource managerResourceWkSpid;
+    static final UserResource managerResource;
+    static final UserResource managerResourceWk;
+    static final UserResource managerResourceWkSpid;
 
-    final static File testFile = new File("src/test/resources/application.properties");
+    static final File testFile = new File("src/test/resources/application.properties");
 
     static {
         managerResource = new UserResource();

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1449,9 +1449,10 @@ class OnboardingServiceDefaultTest {
         mockSimpleSearchPOSTAndPersist(asserter);
         mockSimpleProductValidAssert(request.getProductId(), false, asserter);
 
+        Onboarding onboarding = createDummyOnboarding();
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
-        when(query.stream()).thenReturn(Multi.createFrom().item(new Onboarding()));
+        when(query.stream()).thenReturn(Multi.createFrom().item(onboarding));
         when(Onboarding.find((Document) any(), any())).thenReturn(query);
 
         asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))


### PR DESCRIPTION
#### List of Changes

- Added previousManagerId as attribute of Onboarding in order to detect email template
- Added previous manager name and previous manager surname into registration email in case of workflow USERS

#### Motivation and Context

In order to display name and surname of previous manager in case of addition administration flow, a new attribute has been added into Onboarding class. This attribute stores the previous manager identifier and it's used to compare current manager id with old one

#### How Has This Been Tested?

I have deployed the feature branch in dev and tested the entire process of onboarding for workflowType USERS

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.