### PR TITLE
[SELC-5290] Add monitoring for notification events

### DIFF
--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -192,17 +192,17 @@
       <artifactId>quarkus-jacoco</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-collections4</artifactId>
-          <version>4.4</version>
-          <scope>compile</scope>
-      </dependency>
-      <dependency>
-          <groupId>com.microsoft.azure</groupId>
-          <artifactId>applicationinsights-web</artifactId>
-          <version>2.6.4</version>
-      </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.4</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>applicationinsights-core</artifactId>
+        <version>2.6.4</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -200,7 +200,7 @@
     </dependency>
     <dependency>
         <groupId>com.microsoft.azure</groupId>
-        <artifactId>applicationinsights-core</artifactId>
+        <artifactId>applicationinsights-web</artifactId>
         <version>2.6.4</version>
     </dependency>
   </dependencies>

--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -198,6 +198,11 @@
           <version>4.4</version>
           <scope>compile</scope>
       </dependency>
+      <dependency>
+          <groupId>com.microsoft.azure</groupId>
+          <artifactId>applicationinsights-web</artifactId>
+          <version>2.6.4</version>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/EventhubSasTokenAuthorization.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/EventhubSasTokenAuthorization.java
@@ -35,8 +35,9 @@ public class EventhubSasTokenAuthorization implements ClientRequestFilter {
         NotificationConfig.Consumer consumerConfiguration = notificationConfig.consumers().values().stream()
                 .filter(consumer -> consumer.topic().equals(topic))
                 .findFirst().orElse(null);
-        if(Objects.nonNull(consumerConfiguration))
+        if (Objects.nonNull(consumerConfiguration)) {
             clientRequestContext.getHeaders().add("Authorization", getSASToken(resourceUri.toString(), consumerConfiguration.name(), consumerConfiguration.key()));
+        }
     }
 
     private static String getSASToken(String resourceUri, String keyName, String key) {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/eventhub/EventHubRestClient.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/eventhub/EventHubRestClient.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.client.eventhub;
 
+import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.client.auth.EventhubSasTokenAuthorization;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.POST;
@@ -16,7 +17,7 @@ public interface EventHubRestClient {
 
     @POST
     @Path("{hubName}/messages")
-    void sendMessage(@PathParam("hubName") String topicName, String notification);
+    Uni<Void> sendMessage(@PathParam("hubName") String topicName, String notification);
 
 }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/eventhub/EventHubRestClient.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/eventhub/EventHubRestClient.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.onboarding.client.eventhub;
 
-import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.client.auth.EventhubSasTokenAuthorization;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.POST;
@@ -8,6 +7,8 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import java.util.concurrent.CompletionStage;
 
 @RegisterRestClient(configKey = "event-hub")
 @ApplicationScoped
@@ -17,7 +18,7 @@ public interface EventHubRestClient {
 
     @POST
     @Path("{hubName}/messages")
-    Uni<Void> sendMessage(@PathParam("hubName") String topicName, String notification);
+    Void sendMessage(@PathParam("hubName") String topicName, String notification);
 
 }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.TelemetryConfiguration;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.json.jackson.DatabindCodec;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
@@ -85,12 +83,5 @@ public class OnboardingFunctionConfig {
             case SIGNATURE_SOURCE_DISABLED -> new PadesSignServiceImpl(disabledPkcs7HashSignService());
             default -> new PadesSignServiceImpl(pkcs7HashSignService());
         };
-    }
-
-    @ApplicationScoped
-    public TelemetryClient telemetryClient(@ConfigProperty(name = "onboarding-functions.appinsights.connection-string") String appInsightsConnectionString) {
-        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
-        telemetryConfiguration.setConnectionString(appInsightsConnectionString);
-        return new TelemetryClient(telemetryConfiguration);
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/config/OnboardingFunctionConfig.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.json.jackson.DatabindCodec;
 import it.pagopa.selfcare.azurestorage.AzureBlobClient;
@@ -85,4 +87,10 @@ public class OnboardingFunctionConfig {
         };
     }
 
+    @ApplicationScoped
+    public TelemetryClient telemetryClient(@ConfigProperty(name = "onboarding-functions.appinsights.connection-string") String appInsightsConnectionString) {
+        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
+        telemetryConfiguration.setConnectionString(appInsightsConnectionString);
+        return new TelemetryClient(telemetryConfiguration);
+    }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -232,4 +232,16 @@ public class Institution {
     public void setParentDescription(String parentDescription) {
         this.parentDescription = parentDescription;
     }
+
+    @Override
+    public String toString() {
+        return "Institution{" +
+                "id='" + id + '\'' +
+                ", taxCode='" + taxCode + '\'' +
+                ", description=" + description +
+                ", digitalAddress=" + digitalAddress +
+                ", origin=" + origin +
+                ", originId=" + originId +
+                '}';
+    }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.onboarding.functions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.*;
 import com.microsoft.azure.functions.annotation.*;
 import com.microsoft.durabletask.DurableTaskClient;
@@ -37,9 +38,11 @@ public class NotificationFunctions {
     private final NotificationEventResenderService notificationEventResenderService;
     private final ObjectMapper objectMapper;
 
+
     public NotificationFunctions(ObjectMapper objectMapper,
                                  NotificationEventService notificationEventService,
-                                 OnboardingService onboardingService, NotificationEventResenderService notificationEventResenderService) {
+                                 OnboardingService onboardingService,
+                                 NotificationEventResenderService notificationEventResenderService) {
         this.objectMapper = objectMapper;
         this.notificationEventService = notificationEventService;
         this.onboardingService = onboardingService;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/NotificationFunctions.java
@@ -2,7 +2,6 @@ package it.pagopa.selfcare.onboarding.functions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.*;
 import com.microsoft.azure.functions.annotation.*;
 import com.microsoft.durabletask.DurableTaskClient;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -34,7 +34,6 @@ import static it.pagopa.selfcare.onboarding.utils.Utils.*;
 public class OnboardingFunctions {
 
     public static final String CREATED_NEW_ONBOARDING_ORCHESTRATION_WITH_INSTANCE_ID_MSG = "Created new Onboarding orchestration with instance ID = ";
-
     private final OnboardingService service;
     private final CompletionService completionService;
     private final ObjectMapper objectMapper;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -1,5 +1,7 @@
 package it.pagopa.selfcare.onboarding.service;
 
+import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
 import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
@@ -335,5 +337,12 @@ public class CompletionServiceDefault implements CompletionService {
         onboardingToUpdate.setStatus(OnboardingStatus.PENDING);
         onboardingRepository.persistOrUpdate(onboardingToUpdate);
         return onboardingToUpdate.getId();
+    }
+
+    @ApplicationScoped
+    public TelemetryClient telemetryClient(@ConfigProperty(name = "onboarding-function.appinsights.connection-string") String appInsightsConnectionString) {
+        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
+        telemetryConfiguration.setConnectionString(appInsightsConnectionString);
+        return new TelemetryClient(telemetryConfiguration);
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -1,7 +1,5 @@
 package it.pagopa.selfcare.onboarding.service;
 
-import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.TelemetryConfiguration;
 import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
@@ -96,7 +94,7 @@ public class CompletionServiceDefault implements CompletionService {
     @ConfigProperty(name = "onboarding-functions.persist-users.send-mail")
     private boolean hasToSendEmail;
 
-    @ConfigProperty(name = "onboarding-function.force-institution-persist")
+    @ConfigProperty(name = "onboarding-functions.force-institution-persist")
     private boolean forceInstitutionCreation;
 
     @Override
@@ -337,12 +335,5 @@ public class CompletionServiceDefault implements CompletionService {
         onboardingToUpdate.setStatus(OnboardingStatus.PENDING);
         onboardingRepository.persistOrUpdate(onboardingToUpdate);
         return onboardingToUpdate.getId();
-    }
-
-    @ApplicationScoped
-    public TelemetryClient telemetryClient(@ConfigProperty(name = "onboarding-function.appinsights.connection-string") String appInsightsConnectionString) {
-        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
-        telemetryConfiguration.setConnectionString(appInsightsConnectionString);
-        return new TelemetryClient(telemetryConfiguration);
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.microsoft.applicationinsights.TelemetryClient;
-import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.azure.functions.ExecutionContext;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.config.NotificationConfig;
@@ -53,21 +52,23 @@ public class NotificationEventServiceDefault implements NotificationEventService
     private final TokenRepository tokenRepository;
     private final ObjectMapper mapper;
     private final QueueEventExaminer queueEventExaminer;
-
+    @ConfigProperty(name = "onboarding-functions.appinsights.connection-string")
+    private String appInsightsConnectionString;
 
     public NotificationEventServiceDefault(ProductService productService,
                                            NotificationConfig notificationConfig,
                                            NotificationBuilderFactory notificationBuilderFactory,
                                            TokenRepository tokenRepository,
-                                           QueueEventExaminer queueEventExaminer,
-                                           TelemetryClient telemetryClient) {
+                                           QueueEventExaminer queueEventExaminer
+            , TelemetryClient telemetryClient
+    ) {
         this.productService = productService;
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
         this.tokenRepository = tokenRepository;
         this.queueEventExaminer = queueEventExaminer;
         this.telemetryClient = telemetryClient;
-        telemetryClient.getContext().getOperation().setName(OPERATION_NAME);
+        this.telemetryClient.getContext().getOperation().setName(OPERATION_NAME);
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.microsoft.applicationinsights.TelemetryClient;
+import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.azure.functions.ExecutionContext;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.config.NotificationConfig;
@@ -21,6 +22,7 @@ import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.service.ProductService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.openapi.quarkus.core_json.api.InstitutionApi;
 import org.openapi.quarkus.core_json.model.InstitutionResponse;
@@ -52,6 +54,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
     private final ObjectMapper mapper;
     private final QueueEventExaminer queueEventExaminer;
 
+
     public NotificationEventServiceDefault(ProductService productService,
                                            NotificationConfig notificationConfig,
                                            NotificationBuilderFactory notificationBuilderFactory,
@@ -62,7 +65,8 @@ public class NotificationEventServiceDefault implements NotificationEventService
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
         this.tokenRepository = tokenRepository;
-        this.queueEventExaminer = queueEventExaminer;this.telemetryClient = telemetryClient;
+        this.queueEventExaminer = queueEventExaminer;
+        this.telemetryClient = telemetryClient;
         telemetryClient.getContext().getOperation().setName(OPERATION_NAME);
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -35,7 +35,7 @@ import static it.pagopa.selfcare.onboarding.utils.Utils.isNotInstitutionOnboardi
 @ApplicationScoped
 public class NotificationEventServiceDefault implements NotificationEventService {
 
-    public static final String EVENT_ONBOARDING_FN_NAME = "ONBOARDING_FN";
+    public static final String EVENT_ONBOARDING_FN_NAME = "ONBOARDING-FN";
     public static final String EVENT_ONBOARDING_INSTTITUTION_FN_FAILURE = "EventsOnboardingInstitution_failures";
     public static final String EVENT_ONBOARDING_INSTTITUTION_FN_SUCCESS = "EventsOnboardingInstitution_success";
     private static final String OPERATION_NAME = "ONBOARDING-FN";
@@ -60,9 +60,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
                                            NotificationBuilderFactory notificationBuilderFactory,
                                            TokenRepository tokenRepository,
                                            QueueEventExaminer queueEventExaminer,
-                                           @Context @ConfigProperty(name = "onboarding-functions.appinsights.connection-string") String appInsightsConnectionString
-//            , TelemetryClient telemetryClient
-    ) {
+                                           @Context @ConfigProperty(name = "onboarding-functions.appinsights.connection-string") String appInsightsConnectionString) {
         this.productService = productService;
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
@@ -93,9 +91,8 @@ public class NotificationEventServiceDefault implements NotificationEventService
                 queueEvent = queueEventExaminer.determineEventType(onboarding);
             }
 
-            Optional<Token> token = tokenRepository.findByOnboardingId(onboarding.getId());
             InstitutionResponse institution = institutionApi.retrieveInstitutionByIdUsingGET(onboarding.getInstitution().getId());
-
+            Optional<Token> token = tokenRepository.findByOnboardingId(onboarding.getId());
             for (String consumer : product.getConsumers()) {
                 NotificationConfig.Consumer consumerConfig = notificationConfig.consumers().get(consumer.toLowerCase());
                 prepareAndSendNotification(context, product, consumerConfig, onboarding, token.orElse(null), institution, queueEvent);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -4,6 +4,7 @@ package it.pagopa.selfcare.onboarding.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.ExecutionContext;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.config.NotificationConfig;
@@ -24,15 +25,18 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.openapi.quarkus.core_json.api.InstitutionApi;
 import org.openapi.quarkus.core_json.model.InstitutionResponse;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static it.pagopa.selfcare.onboarding.utils.Utils.isNotInstitutionOnboarding;
 
 @ApplicationScoped
 public class NotificationEventServiceDefault implements NotificationEventService {
 
+    public static final String EVENT_ONBOARDING_FN_NAME = "ONBOARDINF_FN";
+    public static final String EVENT_ONBOARDING_INSTTITUTION_FN_FAILURE = "EventsOnboardingInstitution_failures";
+    public static final String EVENT_ONBOARDING_INSTTITUTION_FN_SUCCESS = "EventsOnboardingInstitution_success";
+    private static final String OPERATION_NAME = "ONBOARDING-FN";
+    private final TelemetryClient telemetryClient;
     @RestClient
     @Inject
     EventHubRestClient eventHubRestClient;
@@ -52,12 +56,14 @@ public class NotificationEventServiceDefault implements NotificationEventService
                                            NotificationConfig notificationConfig,
                                            NotificationBuilderFactory notificationBuilderFactory,
                                            TokenRepository tokenRepository,
-                                           QueueEventExaminer queueEventExaminer) {
+                                           QueueEventExaminer queueEventExaminer,
+                                           TelemetryClient telemetryClient) {
         this.productService = productService;
         this.notificationConfig = notificationConfig;
         this.notificationBuilderFactory = notificationBuilderFactory;
         this.tokenRepository = tokenRepository;
-        this.queueEventExaminer = queueEventExaminer;
+        this.queueEventExaminer = queueEventExaminer;this.telemetryClient = telemetryClient;
+        telemetryClient.getContext().getOperation().setName(OPERATION_NAME);
         mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
     }
@@ -105,7 +111,10 @@ public class NotificationEventServiceDefault implements NotificationEventService
     private void sendNotification(ExecutionContext context, String topic, NotificationToSend notificationToSend) throws JsonProcessingException {
         String message = mapper.writeValueAsString(notificationToSend);
         context.getLogger().info(() -> String.format("Sending notification on topic: %s with message: %s", topic, message));
-        eventHubRestClient.sendMessage(topic, message);
+
+        eventHubRestClient.sendMessage(topic, message)
+                .onItem().invoke(() -> telemetryClient.trackEvent(EVENT_ONBOARDING_FN_NAME, notificationEventMap(notificationToSend),  Map.of(EVENT_ONBOARDING_INSTTITUTION_FN_SUCCESS, 1D)))
+                .onFailure().invoke(() -> telemetryClient.trackEvent(EVENT_ONBOARDING_FN_NAME, notificationEventMap(notificationToSend),  Map.of(EVENT_ONBOARDING_INSTTITUTION_FN_FAILURE, 1D)));
     }
 
     private void sendTestEnvProductsNotification(ExecutionContext context, Product product, String topic, NotificationToSend notificationToSend) throws JsonProcessingException {
@@ -119,4 +128,48 @@ public class NotificationEventServiceDefault implements NotificationEventService
         }
     }
 
+    public static Map<String, String> notificationEventMap(NotificationToSend notificationToSend) {
+        Map<String, String> propertiesMap = new HashMap<>();
+        Optional.ofNullable(notificationToSend.getId()).ifPresent(value -> propertiesMap.put("id", value));
+        Optional.ofNullable(notificationToSend.getInternalIstitutionID()).ifPresent(value -> propertiesMap.put("internalIstitutionID", value));
+        Optional.ofNullable(notificationToSend.getInstitutionId()).ifPresent(value -> propertiesMap.put("institutionId", value));
+        Optional.ofNullable(notificationToSend.getProduct()).ifPresent(value -> propertiesMap.put("product", value));
+        Optional.ofNullable(notificationToSend.getState()).ifPresent(value -> propertiesMap.put("state", value));
+        Optional.ofNullable(notificationToSend.getFilePath()).ifPresent(value -> propertiesMap.put("filePath", value));
+        Optional.ofNullable(notificationToSend.getFileName()).ifPresent(value -> propertiesMap.put("fileName", value));
+        Optional.ofNullable(notificationToSend.getContentType()).ifPresent(value -> propertiesMap.put("contentType", value));
+        Optional.ofNullable(notificationToSend.getOnboardingTokenId()).ifPresent(value -> propertiesMap.put("onboardingTokenId", value));
+        Optional.ofNullable(notificationToSend.getPricingPlan()).ifPresent(value -> propertiesMap.put("pricingPlan", value));
+
+        if (Optional.ofNullable(notificationToSend.getInstitution()).isPresent()) {
+            Optional.ofNullable(notificationToSend.getInstitution().getDescription()).ifPresent(value -> propertiesMap.put("description", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getInstitutionType()).ifPresent(value -> propertiesMap.put("institutionType", value.name()));
+            Optional.ofNullable(notificationToSend.getInstitution().getDigitalAddress()).ifPresent(value -> propertiesMap.put("digitalAddress", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getAddress()).ifPresent(value -> propertiesMap.put("address", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getTaxCode()).ifPresent(value -> propertiesMap.put("taxCode", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getOrigin()).ifPresent(value -> propertiesMap.put("origin", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getOriginId()).ifPresent(value -> propertiesMap.put("originId", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getIstatCode()).ifPresent(value -> propertiesMap.put("istatCode", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getCity()).ifPresent(value -> propertiesMap.put("city", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getCountry()).ifPresent(value -> propertiesMap.put("country", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getCounty()).ifPresent(value -> propertiesMap.put("county", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getSubUnitCode()).ifPresent(value -> propertiesMap.put("subUnitCode", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getCategory()).ifPresent(value -> propertiesMap.put("category", value));
+            Optional.ofNullable(notificationToSend.getInstitution().getSubUnitType()).ifPresent(value -> propertiesMap.put("subUnitType", value));
+            if (Optional.ofNullable(notificationToSend.getInstitution().getRootParent()).isPresent()) {
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getId()).ifPresent(value -> propertiesMap.put("RootParentId", value));
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getDescription()).ifPresent(value -> propertiesMap.put("RootParentDescription", value));
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getOriginId()).ifPresent(value -> propertiesMap.put("RootParentOriginId", value));
+            }
+        }
+
+        if (Optional.ofNullable(notificationToSend.getBilling()).isPresent()) {
+            Optional.ofNullable(notificationToSend.getBilling().getRecipientCode()).ifPresent(value -> propertiesMap.put("billing.recipientCode", value));
+            Optional.ofNullable(notificationToSend.getBilling().getTaxCodeInvoicing()).ifPresent(value -> propertiesMap.put("billing.TaxCodeInvoicing()", value));
+            Optional.ofNullable(notificationToSend.getBilling().getVatNumber()).ifPresent(value -> propertiesMap.put("billing.VatNumber", value));
+            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "si" : "no"));
+        }
+
+        return propertiesMap;
+    }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -166,17 +166,17 @@ public class NotificationEventServiceDefault implements NotificationEventService
             Optional.ofNullable(notificationToSend.getInstitution().getCategory()).ifPresent(value -> propertiesMap.put("category", value));
             Optional.ofNullable(notificationToSend.getInstitution().getSubUnitType()).ifPresent(value -> propertiesMap.put("subUnitType", value));
             if (Optional.ofNullable(notificationToSend.getInstitution().getRootParent()).isPresent()) {
-                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getId()).ifPresent(value -> propertiesMap.put("RootParentId", value));
-                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getDescription()).ifPresent(value -> propertiesMap.put("RootParentDescription", value));
-                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getOriginId()).ifPresent(value -> propertiesMap.put("RootParentOriginId", value));
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getId()).ifPresent(value -> propertiesMap.put("root.parentId", value));
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getDescription()).ifPresent(value -> propertiesMap.put("root.parentDescription", value));
+                Optional.ofNullable(notificationToSend.getInstitution().getRootParent().getOriginId()).ifPresent(value -> propertiesMap.put("root.parentOriginId", value));
             }
         }
 
         if (Optional.ofNullable(notificationToSend.getBilling()).isPresent()) {
             Optional.ofNullable(notificationToSend.getBilling().getRecipientCode()).ifPresent(value -> propertiesMap.put("billing.recipientCode", value));
-            Optional.ofNullable(notificationToSend.getBilling().getTaxCodeInvoicing()).ifPresent(value -> propertiesMap.put("billing.TaxCodeInvoicing()", value));
+            Optional.ofNullable(notificationToSend.getBilling().getTaxCodeInvoicing()).ifPresent(value -> propertiesMap.put("billing.TaxCodeInvoicing", value));
             Optional.ofNullable(notificationToSend.getBilling().getVatNumber()).ifPresent(value -> propertiesMap.put("billing.VatNumber", value));
-            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "yes" : "false"));
+            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "true" : "false"));
         }
 
         return propertiesMap;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -176,7 +176,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
             Optional.ofNullable(notificationToSend.getBilling().getRecipientCode()).ifPresent(value -> propertiesMap.put("billing.recipientCode", value));
             Optional.ofNullable(notificationToSend.getBilling().getTaxCodeInvoicing()).ifPresent(value -> propertiesMap.put("billing.TaxCodeInvoicing()", value));
             Optional.ofNullable(notificationToSend.getBilling().getVatNumber()).ifPresent(value -> propertiesMap.put("billing.VatNumber", value));
-            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "si" : "no"));
+            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "yes" : "false"));
         }
 
         return propertiesMap;

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -27,6 +27,8 @@ onboarding-functions.purge.all-to = 120
 onboarding-functions.persist-users.send-mail = ${USER_MS_SEND_MAIL:true}
 #property to force the institution creation when a new onboarding to pnpg is performed only in pnpg environment
 onboarding-function.force-institution-persist= ${FORCE_INSTITUTION_PERSIST:false}
+onboarding-function.appinsights.connection-string=${APPLICATIONINSIGHTS_CONNECTION_STRING:InstrumentationKey=00000000-0000-0000-0000-000000000000}
+
 ## REST CLIENT #
 
 quarkus.openapi-generator.user_registry_json.auth.api_key.api-key = ${USER_REGISTRY_API_KEY:example-api-key}

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -25,9 +25,11 @@ onboarding-functions.purge.all-from = 150
 onboarding-functions.purge.all-to = 120
 #property to invoke or not the user microservice
 onboarding-functions.persist-users.send-mail = ${USER_MS_SEND_MAIL:true}
+onboarding-functions.appinsights.connection-string=${APPLICATIONINSIGHTS_CONNECTION_STRING:InstrumentationKey=00000000-0000-0000-0000-000000000000}
+
 #property to force the institution creation when a new onboarding to pnpg is performed only in pnpg environment
-onboarding-function.force-institution-persist= ${FORCE_INSTITUTION_PERSIST:false}
-onboarding-function.appinsights.connection-string=${APPLICATIONINSIGHTS_CONNECTION_STRING:InstrumentationKey=00000000-0000-0000-0000-000000000000}
+onboarding-functions.force-institution-persist= ${FORCE_INSTITUTION_PERSIST:false}
+
 
 ## REST CLIENT #
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest2.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest2.java
@@ -34,7 +34,7 @@ public class CompletionServiceDefaultTest2 {
     public static class ForceCreationProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
-            return Map.of("onboarding-function.force-institution-persist", "true");
+            return Map.of("onboarding-functions.force-institution-persist", "true");
         }
     }
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -217,7 +217,7 @@ public class NotificationEventServiceDefaultTest {
         assertEquals(properties.get("state"), "state");
         assertEquals(properties.get("fileName"), "fileName");
         assertEquals(properties.get("filePath"), "filePath");
-        assertEquals(properties.get("contentType"), "contentType");
+        assertEquals(properties.get("contentType"), "application/octet-stream");
 
         assertEquals(properties.get("description"), "description");
         assertEquals(properties.get("digitalAddress"), "mail");

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -6,10 +6,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
-import it.pagopa.selfcare.onboarding.dto.BillingToSend;
-import it.pagopa.selfcare.onboarding.dto.InstitutionToNotify;
-import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
-import it.pagopa.selfcare.onboarding.dto.QueueEvent;
+import it.pagopa.selfcare.onboarding.dto.*;
 import it.pagopa.selfcare.onboarding.entity.Billing;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
@@ -233,6 +230,58 @@ public class NotificationEventServiceDefaultTest {
 
         assertEquals(properties.get("billing.recipientCode"), "12345");
         assertEquals(properties.get("billing.isPublicService"), "false");
+    }
+
+    @Test
+    void notificationEventMapRootParentTest() {
+        NotificationToSend notificationToSend =  new NotificationToSend();
+        notificationToSend.setId("id");
+        notificationToSend.setInternalIstitutionID("internal");
+        notificationToSend.setProduct("prod");
+        notificationToSend.setState("state");
+        notificationToSend.setFileName("fileName");
+        notificationToSend.setFilePath("filePath");
+        notificationToSend.setContentType("contentType");
+
+        InstitutionToNotify institution = new InstitutionToNotify();
+        institution.setDescription("description");
+        institution.setInstitutionType(InstitutionType.SA);
+        institution.setDigitalAddress("mail");
+        RootParent rootParent = new RootParent();
+        rootParent.setDescription("RootDescription");
+        rootParent.setId("RootId");
+        rootParent.setOriginId("RootOriginId");
+        institution.setRootParent(rootParent);
+        notificationToSend.setInstitution(institution);
+
+        BillingToSend billing = new BillingToSend();
+        billing.setRecipientCode("12345");
+        billing.setPublicService(true);
+        billing.setVatNumber("123");
+        billing.setTaxCodeInvoicing("456");
+        notificationToSend.setBilling(billing);
+
+        Map<String, String> properties = NotificationEventServiceDefault.notificationEventMap(notificationToSend);
+        assertNotNull(properties);
+        assertEquals(properties.get("id"), "id");
+        assertEquals(properties.get("internalIstitutionID"), "internal");
+        assertEquals(properties.get("product"), "prod");
+        assertEquals(properties.get("state"), "state");
+        assertEquals(properties.get("fileName"), "fileName");
+        assertEquals(properties.get("filePath"), "filePath");
+        assertEquals(properties.get("contentType"), "application/octet-stream");
+
+        assertEquals(properties.get("description"), "description");
+        assertEquals(properties.get("digitalAddress"), "mail");
+        assertEquals(properties.get("institutionType"), "SA");
+        assertEquals(properties.get("root.parentId"), "RootId");
+        assertEquals(properties.get("root.parentDescription"), "RootDescription");
+        assertEquals(properties.get("root.parentOriginId"), "RootOriginId");
+
+        assertEquals(properties.get("billing.recipientCode"), "12345");
+        assertEquals(properties.get("billing.isPublicService"), "true");
+        assertEquals(properties.get("billing.VatNumber"), "123");
+        assertEquals(properties.get("billing.TaxCodeInvoicing"), "456");
     }
 
     private Onboarding createOnboarding() {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -4,6 +4,7 @@ import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
@@ -41,9 +42,6 @@ public class NotificationEventServiceDefaultTest {
     @InjectMock
     ProductService productService;
 
-    @InjectMock
-    private TelemetryClient telemetryClient;
-
     @RestClient
     @InjectMock
     EventHubRestClient eventHubRestClient;
@@ -72,9 +70,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-
-//        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
-
+        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(3))
                 .sendMessage(anyString(), anyString());
@@ -90,7 +86,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
         when(queueEventExaminer.determineEventType(any())).thenReturn(QueueEvent.ADD);
         messageServiceDefault.send(context, onboarding, null);
         verify(eventHubRestClient, times(3))
@@ -114,7 +110,7 @@ public class NotificationEventServiceDefaultTest {
         mockNotificationMapper(true);
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(3))
                 .sendMessage(anyString(), anyString());
@@ -130,7 +126,7 @@ public class NotificationEventServiceDefaultTest {
         mockNotificationMapper(false);
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verifyNoInteractions(eventHubRestClient);
     }
@@ -146,7 +142,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(9))
                 .sendMessage(anyString(), anyString());

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.onboarding.service;
 
+import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
@@ -40,6 +41,9 @@ public class NotificationEventServiceDefaultTest {
     @InjectMock
     ProductService productService;
 
+    @InjectMock
+    private TelemetryClient telemetryClient;
+
     @RestClient
     @InjectMock
     EventHubRestClient eventHubRestClient;
@@ -68,7 +72,9 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+
+//        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
+
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(3))
                 .sendMessage(anyString(), anyString());

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -3,7 +3,6 @@ package it.pagopa.selfcare.onboarding.service;
 import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
-import io.smallrye.mutiny.Uni;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
@@ -69,7 +68,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
+        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(3))
                 .sendMessage(anyString(), anyString());
@@ -85,7 +84,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
+        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
         when(queueEventExaminer.determineEventType(any())).thenReturn(QueueEvent.ADD);
         messageServiceDefault.send(context, onboarding, null);
         verify(eventHubRestClient, times(3))
@@ -109,7 +108,7 @@ public class NotificationEventServiceDefaultTest {
         mockNotificationMapper(true);
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
+        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(3))
                 .sendMessage(anyString(), anyString());
@@ -125,7 +124,7 @@ public class NotificationEventServiceDefaultTest {
         mockNotificationMapper(false);
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
+        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verifyNoInteractions(eventHubRestClient);
     }
@@ -141,7 +140,7 @@ public class NotificationEventServiceDefaultTest {
         when(institutionApi.retrieveInstitutionByIdUsingGET(any())).thenReturn(new InstitutionResponse());
         ExecutionContext context = mock(ExecutionContext.class);
         doReturn(Logger.getGlobal()).when(context).getLogger();
-        when(eventHubRestClient.sendMessage(anyString(), anyString())).thenReturn(Uni.createFrom().nullItem());
+        doNothing().when(eventHubRestClient).sendMessage(anyString(), anyString());
         messageServiceDefault.send(context, onboarding, QueueEvent.ADD);
         verify(eventHubRestClient, times(9))
                 .sendMessage(anyString(), anyString());

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.onboarding.service;
 
-import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -4,7 +4,9 @@ import com.microsoft.azure.functions.ExecutionContext;
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
+import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
+import it.pagopa.selfcare.onboarding.dto.InstitutionToNotify;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
 import it.pagopa.selfcare.onboarding.entity.Billing;
@@ -25,10 +27,11 @@ import org.openapi.quarkus.core_json.api.InstitutionApi;
 import org.openapi.quarkus.core_json.model.InstitutionResponse;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @QuarkusTest
@@ -189,6 +192,36 @@ public class NotificationEventServiceDefaultTest {
         verifyNoInteractions(tokenRepository);
         verifyNoInteractions(institutionApi);
         verifyNoInteractions(eventHubRestClient);
+    }
+
+    @Test
+    void notificationEventMapTest() {
+        NotificationToSend notificationToSend =  new NotificationToSend();
+        notificationToSend.setId("id");
+        InstitutionToNotify institution = new InstitutionToNotify();
+        institution.setDescription("description");
+        institution.setInstitutionType(InstitutionType.SA);
+        institution.setDigitalAddress("mail");
+        notificationToSend.setInstitution(institution);
+        notificationToSend.setInternalIstitutionID("internal");
+        notificationToSend.setProduct("prod");
+        notificationToSend.setState("state");
+        notificationToSend.setFileName("fileName");
+        notificationToSend.setFilePath("filePath");
+        notificationToSend.setContentType("contentType");
+        Map<String, String> properties = NotificationEventServiceDefault.notificationEventMap(notificationToSend);
+        assertNotNull(properties);
+        assertEquals(properties.get("id"), "id");
+        assertEquals(properties.get("internalIstitutionID"), "internal");
+        assertEquals(properties.get("product"), "prod");
+        assertEquals(properties.get("state"), "state");
+        assertEquals(properties.get("fileName"), "fileName");
+        assertEquals(properties.get("filePath"), "filePath");
+        assertEquals(properties.get("contentType"), "contentType");
+
+        assertEquals(properties.get("description"), "description");
+        assertEquals(properties.get("digitalAddress"), "mail");
+        assertEquals(properties.get("institutionType"), "SA");
     }
 
     private Onboarding createOnboarding() {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -6,6 +6,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import it.pagopa.selfcare.onboarding.client.eventhub.EventHubRestClient;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.WorkflowType;
+import it.pagopa.selfcare.onboarding.dto.BillingToSend;
 import it.pagopa.selfcare.onboarding.dto.InstitutionToNotify;
 import it.pagopa.selfcare.onboarding.dto.NotificationToSend;
 import it.pagopa.selfcare.onboarding.dto.QueueEvent;
@@ -198,17 +199,24 @@ public class NotificationEventServiceDefaultTest {
     void notificationEventMapTest() {
         NotificationToSend notificationToSend =  new NotificationToSend();
         notificationToSend.setId("id");
-        InstitutionToNotify institution = new InstitutionToNotify();
-        institution.setDescription("description");
-        institution.setInstitutionType(InstitutionType.SA);
-        institution.setDigitalAddress("mail");
-        notificationToSend.setInstitution(institution);
         notificationToSend.setInternalIstitutionID("internal");
         notificationToSend.setProduct("prod");
         notificationToSend.setState("state");
         notificationToSend.setFileName("fileName");
         notificationToSend.setFilePath("filePath");
         notificationToSend.setContentType("contentType");
+
+        InstitutionToNotify institution = new InstitutionToNotify();
+        institution.setDescription("description");
+        institution.setInstitutionType(InstitutionType.SA);
+        institution.setDigitalAddress("mail");
+        notificationToSend.setInstitution(institution);
+
+        BillingToSend billing = new BillingToSend();
+        billing.setRecipientCode("12345");
+        billing.setPublicService(false);
+        notificationToSend.setBilling(billing);
+
         Map<String, String> properties = NotificationEventServiceDefault.notificationEventMap(notificationToSend);
         assertNotNull(properties);
         assertEquals(properties.get("id"), "id");
@@ -222,6 +230,9 @@ public class NotificationEventServiceDefaultTest {
         assertEquals(properties.get("description"), "description");
         assertEquals(properties.get("digitalAddress"), "mail");
         assertEquals(properties.get("institutionType"), "SA");
+
+        assertEquals(properties.get("billing.recipientCode"), "12345");
+        assertEquals(properties.get("billing.isPublicService"), "false");
     }
 
     private Onboarding createOnboarding() {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefaultTest.java
@@ -101,6 +101,7 @@ public class NotificationEventServiceDefaultTest {
     @Test
     void sendMessageWithoutToken() {
         final Onboarding onboarding = createOnboarding();
+        onboarding.setId("123");
         final Product product = createProduct();
         when(productService.getProduct(any())).thenReturn(product);
         when(tokenRepository.findByOnboardingId(any())).thenReturn(Optional.empty());

--- a/apps/onboarding-functions/src/test/resources/application.properties
+++ b/apps/onboarding-functions/src/test/resources/application.properties
@@ -8,6 +8,7 @@ quarkus.azure-functions.app-service-plan-name=example
 ## MAIL AND MAIL TEMPLATE ##
 onboarding-functions.sender-mail = ${MAIL_SENDER_ADDRESS:test@test.it}
 onboarding-functions.notification-admin-email = default
+onboarding-functions.appinsights.connection-string=${APPLICATIONINSIGHTS_CONNECTION_STRING:InstrumentationKey=00000000-0000-0000-0000-000000000000}
 
 ## MAIL TEMPLATE
 onboarding-functions.mail-template.path.onboarding.complete-path = default

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -986,6 +986,8 @@ public class OnboardingServiceDefault implements OnboardingService {
         Uni<InstitutionsResponse> responseUni;
         if (Objects.nonNull(request.getTaxCode()) && Objects.nonNull(request.getSubunitCode())) {
             responseUni = institutionApi.getInstitutionsUsingGET(request.getTaxCode(), request.getSubunitCode(), null, null);
+        } else  if (Objects.nonNull(request.getTaxCode())) {
+            responseUni = institutionApi.getInstitutionsUsingGET(request.getTaxCode(), null, null, null);
         } else {
             responseUni = institutionApi.getInstitutionsUsingGET(null, null, request.getOrigin(), request.getOriginId());
         }

--- a/infra/container_apps/hub_spid_login/container_app.tf
+++ b/infra/container_apps/hub_spid_login/container_app.tf
@@ -20,9 +20,9 @@ module "container_app_hub_spid_login" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Liveness"
-      failureThreshold = 5
+      timeoutSeconds      = 5
+      type                = "Liveness"
+      failureThreshold    = 5
       initialDelaySeconds = 1
     },
     {
@@ -31,9 +31,9 @@ module "container_app_hub_spid_login" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Readiness"
-      failureThreshold = 3
+      timeoutSeconds      = 5
+      type                = "Readiness"
+      failureThreshold    = 3
       initialDelaySeconds = 3
     },
     {
@@ -42,9 +42,9 @@ module "container_app_hub_spid_login" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      failureThreshold = 30
-      type             = "Startup"
+      timeoutSeconds      = 5
+      failureThreshold    = 30
+      type                = "Startup"
       initialDelaySeconds = 30
     }
   ]

--- a/infra/container_apps/hub_spid_login/env/dev/terraform.tfvars
+++ b/infra/container_apps/hub_spid_login/env/dev/terraform.tfvars
@@ -1,7 +1,7 @@
-prefix    = "selc"
-env_short = "d"
+prefix           = "selc"
+env_short        = "d"
 suffix_increment = "-002"
-cae_name = "cae-002"
+cae_name         = "cae-002"
 
 tags = {
   CreatedBy   = "Terraform"

--- a/infra/container_apps/onboarding-cdc/env/dev/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/dev/terraform.tfvars
@@ -1,7 +1,7 @@
-prefix    = "selc"
-env_short = "d"
+prefix           = "selc"
+env_short        = "d"
 suffix_increment = "-002"
-cae_name = "cae-002"
+cae_name         = "cae-002"
 
 tags = {
   CreatedBy   = "Terraform"
@@ -50,7 +50,7 @@ app_settings = [
     value = "true"
   },
   {
-    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    name  = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
     value = "5"
   }
 ]

--- a/infra/container_apps/onboarding-cdc/env/prod-pnpg/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/prod-pnpg/terraform.tfvars
@@ -1,6 +1,6 @@
 prefix    = "selc"
 env_short = "p"
-is_pnpg          = true
+is_pnpg   = true
 
 tags = {
   CreatedBy   = "Terraform"

--- a/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/prod/terraform.tfvars
@@ -35,7 +35,7 @@ app_settings = [
     value = "https://selc-p-onboarding-fn.azurewebsites.net"
   },
   {
-    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    name  = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
     value = "5"
   }
 ]

--- a/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
+++ b/infra/container_apps/onboarding-cdc/env/uat/terraform.tfvars
@@ -37,7 +37,7 @@ app_settings = [
     value = "https://selc-u-onboarding-fn.azurewebsites.net"
   },
   {
-    name = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
+    name  = "ONBOARDING-CDC-MINUTES-THRESHOLD-FOR-UPDATE-NOTIFICATION"
     value = "5"
   }
 ]

--- a/infra/container_apps/onboarding-cdc/main.tf
+++ b/infra/container_apps/onboarding-cdc/main.tf
@@ -31,9 +31,9 @@ module "container_app_onboarding_cdc" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Liveness"
-      failureThreshold = 3
+      timeoutSeconds      = 5
+      type                = "Liveness"
+      failureThreshold    = 3
       initialDelaySeconds = 1
     },
     {
@@ -42,9 +42,9 @@ module "container_app_onboarding_cdc" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Readiness"
-      failureThreshold = 30
+      timeoutSeconds      = 5
+      type                = "Readiness"
+      failureThreshold    = 30
       initialDelaySeconds = 3
     },
     {
@@ -53,9 +53,9 @@ module "container_app_onboarding_cdc" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      failureThreshold = 5
-      type             = "Startup"
+      timeoutSeconds      = 5
+      failureThreshold    = 5
+      type                = "Startup"
       initialDelaySeconds = 5
     }
   ]

--- a/infra/container_apps/onboarding-ms/container_app.tf
+++ b/infra/container_apps/onboarding-ms/container_app.tf
@@ -21,9 +21,9 @@ module "container_app_onboarding_ms" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Liveness"
-      failureThreshold = 3
+      timeoutSeconds      = 5
+      type                = "Liveness"
+      failureThreshold    = 3
       initialDelaySeconds = 1
     },
     {
@@ -32,9 +32,9 @@ module "container_app_onboarding_ms" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      type             = "Readiness"
-      failureThreshold = 30
+      timeoutSeconds      = 5
+      type                = "Readiness"
+      failureThreshold    = 30
       initialDelaySeconds = 3
     },
     {
@@ -43,9 +43,9 @@ module "container_app_onboarding_ms" {
         port   = 8080
         scheme = "HTTP"
       }
-      timeoutSeconds   = 5
-      failureThreshold = 5
-      type             = "Startup"
+      timeoutSeconds      = 5
+      failureThreshold    = 5
+      type                = "Startup"
       initialDelaySeconds = 5
     }
   ]

--- a/infra/container_apps/onboarding-ms/env/dev/terraform.tfvars
+++ b/infra/container_apps/onboarding-ms/env/dev/terraform.tfvars
@@ -1,7 +1,7 @@
-prefix    = "selc"
-env_short = "d"
+prefix           = "selc"
+env_short        = "d"
 suffix_increment = "-002"
-cae_name = "cae-002"
+cae_name         = "cae-002"
 
 tags = {
   CreatedBy   = "Terraform"

--- a/infra/functions/onboarding-functions/env/dev-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev-pnpg/terraform.tfvars
@@ -39,6 +39,7 @@ storage_account_info = {
 }
 
 app_settings = {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"              = "@Microsoft.KeyVault(SecretUri=https://selc-d-pnpg-kv.vault.azure.net/secrets/appinsights-connection-string/)",
   "USER_REGISTRY_URL"                                  = "https://api.uat.pdv.pagopa.it/user-registry/v1",
   "MONGODB_CONNECTION_URI"                             = "@Microsoft.KeyVault(SecretUri=https://selc-d-pnpg-kv.vault.azure.net/secrets/mongodb-connection-string/)",
   "USER_REGISTRY_API_KEY"                              = "@Microsoft.KeyVault(SecretUri=https://selc-d-pnpg-kv.vault.azure.net/secrets/user-registry-api-key/)",

--- a/infra/functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev/terraform.tfvars
@@ -94,7 +94,7 @@ app_settings = {
   "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
   "BYPASS_CHECK_ORGANIZATION"                          = "false"
   "PROD_FD_URL"                                        = "https://fid00001fe.siachain.sv.sia.eu:30008"
-  "FD_TOKEN_GRANT_TYPE"                          = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-grant-type/)"
-  "FD_TOKEN_CLIENT_ID"                           = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-client-id/)"
-  "FD_TOKEN_CLIENT_SECRET"                       = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-client-secret/)"
+  "FD_TOKEN_GRANT_TYPE"                                = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-grant-type/)"
+  "FD_TOKEN_CLIENT_ID"                                 = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-client-id/)"
+  "FD_TOKEN_CLIENT_SECRET"                             = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/prod-fd-client-secret/)"
 }

--- a/infra/functions/onboarding-functions/env/dev/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/dev/terraform.tfvars
@@ -38,6 +38,7 @@ storage_account_info = {
 }
 
 app_settings = {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"              = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/appinsights-connection-string/)",
   "USER_REGISTRY_URL"                                  = "https://api.uat.pdv.pagopa.it/user-registry/v1",
   "MONGODB_CONNECTION_URI"                             = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/mongodb-connection-string/)",
   "USER_REGISTRY_API_KEY"                              = "@Microsoft.KeyVault(SecretUri=https://selc-d-kv.vault.azure.net/secrets/user-registry-api-key/)",

--- a/infra/functions/onboarding-functions/env/prod-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/prod-pnpg/terraform.tfvars
@@ -39,11 +39,12 @@ storage_account_info = {
 }
 
 app_settings = {
-  "USER_REGISTRY_URL"                = "https://api.pdv.pagopa.it/user-registry/v1",
-  "MONGODB_CONNECTION_URI"           = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/mongodb-connection-string/)",
-  "USER_REGISTRY_API_KEY"            = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/user-registry-api-key/)",
-  "BLOB_STORAGE_CONN_STRING_PRODUCT" = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/blob-storage-product-connection-string/)",
-  "STORAGE_CONTAINER_PRODUCT"        = "selc-p-product",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/appinsights-connection-string/)",
+  "USER_REGISTRY_URL"                     = "https://api.pdv.pagopa.it/user-registry/v1",
+  "MONGODB_CONNECTION_URI"                = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/mongodb-connection-string/)",
+  "USER_REGISTRY_API_KEY"                 = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/user-registry-api-key/)",
+  "BLOB_STORAGE_CONN_STRING_PRODUCT"      = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/blob-storage-product-connection-string/)",
+  "STORAGE_CONTAINER_PRODUCT"             = "selc-p-product",
 
   ## PNPG contains template mail in checkout storage
   "BLOB_STORAGE_CONN_STRING_CONTRACT" = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/blob-storage-contract-connection-string/)",
@@ -58,27 +59,27 @@ app_settings = {
   "MAIL_SERVER_PORT"              = "465",
   "MAIL_TEMPLATE_COMPLETE_PATH"   = "resources/templates/email/onboarding_1.0.0.json",
 
-  "MS_USER_URL"           = "https://selc-p-pnpg-user-ms-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
-  "MS_CORE_URL"           = "https://selc-p-pnpg-ms-core-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
-  "JWT_BEARER_TOKEN"      = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)",
-  "MS_PARTY_REGISTRY_URL" = "https://selc-p-pnpg-party-reg-proxy-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
-  "PAGOPA_LOGO_ENABLE"    = "false"
-  "RETRY_MAX_ATTEMPTS"    = "3"
-  "FIRST_RETRY_INTERVAL"  = "5"
-  "BACKOFF_COEFFICIENT"   = "1"
-  "EVENT_HUB_BASE_PATH"                                = "https://selc-p-eventhub-ns.servicebus.windows.net",
-  "STANDARD_SHARED_ACCESS_KEY_NAME"                    = "selfcare-wo"
-  "EVENTHUB_SC_CONTRACTS_SELFCARE_WO_KEY_LC"           = "string"
-  "STANDARD_TOPIC_NAME"                                = "SC-Contracts"
-  "SAP_SHARED_ACCESS_KEY_NAME"                         = "external-interceptor-wo"
-  "EVENTHUB_SC_CONTRACTS_SAP_SELFCARE_WO_KEY_LC"       = "string"
-  "SAP_TOPIC_NAME"                                     = "SC-Contracts-SAP"
-  "FD_SHARED_ACCESS_KEY_NAME"                          = "external-interceptor-wo"
-  "EVENTHUB_SC_CONTRACTS_FD_SELFCARE_WO_KEY_LC"        = "string"
-  "FD_TOPIC_NAME"                                      = "Selfcare-FD"
-  "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
-  "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
-  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
+  "MS_USER_URL"                                  = "https://selc-p-pnpg-user-ms-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
+  "MS_CORE_URL"                                  = "https://selc-p-pnpg-ms-core-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
+  "JWT_BEARER_TOKEN"                             = "@Microsoft.KeyVault(SecretUri=https://selc-p-pnpg-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)",
+  "MS_PARTY_REGISTRY_URL"                        = "https://selc-p-pnpg-party-reg-proxy-ca.calmmoss-0be48755.westeurope.azurecontainerapps.io",
+  "PAGOPA_LOGO_ENABLE"                           = "false"
+  "RETRY_MAX_ATTEMPTS"                           = "3"
+  "FIRST_RETRY_INTERVAL"                         = "5"
+  "BACKOFF_COEFFICIENT"                          = "1"
+  "EVENT_HUB_BASE_PATH"                          = "https://selc-p-eventhub-ns.servicebus.windows.net",
+  "STANDARD_SHARED_ACCESS_KEY_NAME"              = "selfcare-wo"
+  "EVENTHUB_SC_CONTRACTS_SELFCARE_WO_KEY_LC"     = "string"
+  "STANDARD_TOPIC_NAME"                          = "SC-Contracts"
+  "SAP_SHARED_ACCESS_KEY_NAME"                   = "external-interceptor-wo"
+  "EVENTHUB_SC_CONTRACTS_SAP_SELFCARE_WO_KEY_LC" = "string"
+  "SAP_TOPIC_NAME"                               = "SC-Contracts-SAP"
+  "FD_SHARED_ACCESS_KEY_NAME"                    = "external-interceptor-wo"
+  "EVENTHUB_SC_CONTRACTS_FD_SELFCARE_WO_KEY_LC"  = "string"
+  "FD_TOPIC_NAME"                                = "Selfcare-FD"
+  "SAP_ALLOWED_INSTITUTION_TYPE"                 = "PA,GSP,SA,AS,SCP"
+  "SAP_ALLOWED_ORIGINS"                          = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"    = "5"
 
   ## IGNORE VALUES
 

--- a/infra/functions/onboarding-functions/env/prod/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/prod/terraform.tfvars
@@ -38,6 +38,7 @@ storage_account_info = {
 }
 
 app_settings = {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"              = "@Microsoft.KeyVault(SecretUri=https://selc-p-kv.vault.azure.net/secrets/appinsights-connection-string/)",
   "USER_REGISTRY_URL"                                  = "https://api.pdv.pagopa.it/user-registry/v1",
   "MONGODB_CONNECTION_URI"                             = "@Microsoft.KeyVault(SecretUri=https://selc-p-kv.vault.azure.net/secrets/mongodb-connection-string/)",
   "USER_REGISTRY_API_KEY"                              = "@Microsoft.KeyVault(SecretUri=https://selc-p-kv.vault.azure.net/secrets/user-registry-api-key/)",

--- a/infra/functions/onboarding-functions/env/uat-pnpg/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/uat-pnpg/terraform.tfvars
@@ -39,11 +39,12 @@ storage_account_info = {
 }
 
 app_settings = {
-  "USER_REGISTRY_URL"                = "https://api.uat.pdv.pagopa.it/user-registry/v1",
-  "MONGODB_CONNECTION_URI"           = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/mongodb-connection-string/)",
-  "USER_REGISTRY_API_KEY"            = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/user-registry-api-key/)",
-  "BLOB_STORAGE_CONN_STRING_PRODUCT" = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/blob-storage-product-connection-string/)",
-  "STORAGE_CONTAINER_PRODUCT"        = "selc-u-product",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING" = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/appinsights-connection-string/)",
+  "USER_REGISTRY_URL"                     = "https://api.uat.pdv.pagopa.it/user-registry/v1",
+  "MONGODB_CONNECTION_URI"                = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/mongodb-connection-string/)",
+  "USER_REGISTRY_API_KEY"                 = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/user-registry-api-key/)",
+  "BLOB_STORAGE_CONN_STRING_PRODUCT"      = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/blob-storage-product-connection-string/)",
+  "STORAGE_CONTAINER_PRODUCT"             = "selc-u-product",
 
   ## PNPG contains template mail in checkout storage
   "BLOB_STORAGE_CONN_STRING_CONTRACT" = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/blob-storage-product-connection-string/)",
@@ -57,27 +58,27 @@ app_settings = {
   "MAIL_SERVER_PORT"              = "465",
   "MAIL_TEMPLATE_COMPLETE_PATH"   = "resources/templates/email/onboarding_1.0.0.json",
 
-  "MS_USER_URL"           = "https://selc-u-pnpg-user-ms-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
-  "MS_CORE_URL"           = "https://selc-u-pnpg-ms-core-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
-  "JWT_BEARER_TOKEN"      = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)",
-  "MS_PARTY_REGISTRY_URL" = "https://selc-u-pnpg-party-reg-proxy-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
-  "PAGOPA_LOGO_ENABLE"    = "false",
-  "RETRY_MAX_ATTEMPTS"    = "3"
-  "FIRST_RETRY_INTERVAL"  = "5"
-  "BACKOFF_COEFFICIENT"   = "1"
-  "EVENT_HUB_BASE_PATH"                                = "https://selc-u-eventhub-ns.servicebus.windows.net",
-  "STANDARD_SHARED_ACCESS_KEY_NAME"                    = "selfcare-wo"
-  "EVENTHUB-SC-CONTRACTS-SELFCARE-WO-KEY-LC"           = "string"
-  "STANDARD_TOPIC_NAME"                                = "SC-Contracts"
-  "SAP_SHARED_ACCESS_KEY_NAME"                         = "external-interceptor-wo"
-  "EVENTHUB-SC-CONTRACTS-SAP-SELFCARE-WO-KEY-LC"       = "string"
-  "SAP_TOPIC_NAME"                                     = "SC-Contracts-SAP"
-  "FD_SHARED_ACCESS_KEY_NAME"                          = "external-interceptor-wo"
-  "EVENTHUB-SC-CONTRACTS-FD-SELFCARE-WO-KEY-LC"        = "string"
-  "FD_TOPIC_NAME"                                      = "Selfcare-FD"
-  "SAP_ALLOWED_INSTITUTION_TYPE"                       = "PA,GSP,SA,AS,SCP"
-  "SAP_ALLOWED_ORIGINS"                                = "IPA,SELC"
-  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"          = "5"
+  "MS_USER_URL"                                  = "https://selc-u-pnpg-user-ms-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
+  "MS_CORE_URL"                                  = "https://selc-u-pnpg-ms-core-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
+  "JWT_BEARER_TOKEN"                             = "@Microsoft.KeyVault(SecretUri=https://selc-u-pnpg-kv.vault.azure.net/secrets/jwt-bearer-token-functions/)",
+  "MS_PARTY_REGISTRY_URL"                        = "https://selc-u-pnpg-party-reg-proxy-ca.orangeground-0bd2d4dc.westeurope.azurecontainerapps.io",
+  "PAGOPA_LOGO_ENABLE"                           = "false",
+  "RETRY_MAX_ATTEMPTS"                           = "3"
+  "FIRST_RETRY_INTERVAL"                         = "5"
+  "BACKOFF_COEFFICIENT"                          = "1"
+  "EVENT_HUB_BASE_PATH"                          = "https://selc-u-eventhub-ns.servicebus.windows.net",
+  "STANDARD_SHARED_ACCESS_KEY_NAME"              = "selfcare-wo"
+  "EVENTHUB-SC-CONTRACTS-SELFCARE-WO-KEY-LC"     = "string"
+  "STANDARD_TOPIC_NAME"                          = "SC-Contracts"
+  "SAP_SHARED_ACCESS_KEY_NAME"                   = "external-interceptor-wo"
+  "EVENTHUB-SC-CONTRACTS-SAP-SELFCARE-WO-KEY-LC" = "string"
+  "SAP_TOPIC_NAME"                               = "SC-Contracts-SAP"
+  "FD_SHARED_ACCESS_KEY_NAME"                    = "external-interceptor-wo"
+  "EVENTHUB-SC-CONTRACTS-FD-SELFCARE-WO-KEY-LC"  = "string"
+  "FD_TOPIC_NAME"                                = "Selfcare-FD"
+  "SAP_ALLOWED_INSTITUTION_TYPE"                 = "PA,GSP,SA,AS,SCP"
+  "SAP_ALLOWED_ORIGINS"                          = "IPA,SELC"
+  "MINUTES_THRESHOLD_FOR_UPDATE_NOTIFICATION"    = "5"
 
   ## IGNORE VALUES
 

--- a/infra/functions/onboarding-functions/env/uat/terraform.tfvars
+++ b/infra/functions/onboarding-functions/env/uat/terraform.tfvars
@@ -38,6 +38,7 @@ storage_account_info = {
 }
 
 app_settings = {
+  "APPLICATIONINSIGHTS_CONNECTION_STRING"              = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/appinsights-connection-string/)",
   "USER_REGISTRY_URL"                                  = "https://api.uat.pdv.pagopa.it/user-registry/v1",
   "MONGODB_CONNECTION_URI"                             = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/mongodb-connection-string/)",
   "USER_REGISTRY_API_KEY"                              = "@Microsoft.KeyVault(SecretUri=https://selc-u-kv.vault.azure.net/secrets/user-registry-api-key/)",

--- a/infra/functions/onboarding-functions/functions.tf
+++ b/infra/functions/onboarding-functions/functions.tf
@@ -63,11 +63,11 @@ resource "azurerm_key_vault_access_policy" "keyvault_functions_access_policy" {
 }
 
 data "azurerm_resource_group" "nat_rg" {
-  name     = "${local.base_domain_name}-nat-rg"
+  name = "${local.base_domain_name}-nat-rg"
 }
 
 data "azurerm_resource_group" "vnet_rg" {
-  name     = "${local.base_domain_vnet_name}-vnet-rg"
+  name = "${local.base_domain_vnet_name}-vnet-rg"
 }
 
 data "azurerm_public_ip" "pip_outbound" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Adding new telemetry client when send new notification event to eventhub queue.

<!--- Describe your changes in detail -->

#### Motivation and Context
Currently onboarding does not monitor when send notification failure.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.