### PR TITLE
[SELC-5276] feat: Added check on recipient Code

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/constants/CustomError.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/constants/CustomError.java
@@ -11,7 +11,12 @@ public enum CustomError {
     INSTITUTION_NOT_ONBOARDED_BY_FILTERS("0004", "Has not been found an onboarded Institution with the provided filters"),
 
     INSTITUTION_NOT_FOUND("0000","Institution with taxCode %s origin %s originId %s subunitCode %s not found"),
-    USERS_UPDATE_NOT_ALLOWED("0025", "Invalid users information provided");
+    USERS_UPDATE_NOT_ALLOWED("0025", "Invalid users information provided"),
+
+    DENIED_NO_BILLING("0040","Recipient code linked to an institution with invoicing service not active"),
+    DENIED_NO_ASSOCIATION("0041","Recipient code not linked to any institution"),
+    ;
+
 
     private final String code;
     private final String detail;

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/NotificationServiceDefaultTest.java
@@ -51,7 +51,6 @@ class NotificationServiceDefaultTest {
     }
 
     @Test
-    @RunOnVertxContext
     @DisplayName("Should try to send all notifications when notifications api calls succeed")
     public void shouldTryToSendAllNotifications() {
         OnboardingGetFilters filters = OnboardingGetFilters.builder().status("COMPLETED").build();
@@ -65,10 +64,10 @@ class NotificationServiceDefaultTest {
 
         subscriber.assertCompleted().awaitSubscription().assertItem(null);
         verify(notificationApi, times(3)).apiNotificationPost(any(), any());
+        subscriber.cancel();
     }
 
     @Test
-    @RunOnVertxContext
     @DisplayName("Should try to send all notifications when notifications api calls throw ignorable error")
     public void shouldTryToSendAllNotificationsWhenApiThrowIgnorableError() {
         OnboardingGetFilters filters = OnboardingGetFilters.builder().status("COMPLETED").build();
@@ -85,6 +84,7 @@ class NotificationServiceDefaultTest {
 
         subscriber.assertCompleted().awaitSubscription();
         verify(notificationApi, times(3)).apiNotificationPost(any(), any());
+        subscriber.cancel();
     }
 
     @Test

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
@@ -42,7 +42,6 @@ public class OnboardingUtilsTest {
     void shouldOnboardingInstitutionWithAdditionalInfo(String type) {
 
         Billing billing = new Billing();
-        billing.setRecipientCode("recipientCode");
         Onboarding onboarding =  new Onboarding();
         Institution institution =  new Institution();
         institution.setInstitutionType(InstitutionType.GSP);
@@ -64,7 +63,6 @@ public class OnboardingUtilsTest {
     void shouldOnboardingInstitutionWithAdditionalInfoRequiredException() {
 
         Billing billing = new Billing();
-        billing.setRecipientCode("recipientCode");
         Onboarding onboarding =  new Onboarding();
         Institution institution =  new Institution();
         institution.setInstitutionType(InstitutionType.GSP);
@@ -86,7 +84,6 @@ public class OnboardingUtilsTest {
     void shouldOnboardingInstitutionWithOtherNoteRequiredException() {
 
         Billing billing = new Billing();
-        billing.setRecipientCode("recipientCode");
         Onboarding onboarding =  new Onboarding();
         Institution institution =  new Institution();
         institution.setInstitutionType(InstitutionType.GSP);
@@ -203,6 +200,75 @@ public class OnboardingUtilsTest {
         uOsResource.setItems(List.of(uoResource, uoResource2));
         when(uoApi.findAllUsingGET1(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(uOsResource));
+
+        UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
+                .customValidationOnboardingData(onboarding, dummyProduct())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertFailedWith(InvalidRequestException.class);
+    }
+
+    @Test
+    void checkRecipientCodeNoBilling() {
+
+        Onboarding onboarding = new Onboarding();
+        Institution institution = new Institution();
+        institution.setOriginId("ipaCode");
+        institution.setSubunitCode("subunitCode");
+        institution.setSubunitType(InstitutionPaSubunitType.AOO);
+        institution.setInstitutionType(InstitutionType.PA);
+        institution.setTaxCode("taxCode");
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceFiscaleEnte("taxCode");
+        uoResource.setCodiceIpa("ipaCode");
+        onboarding.setInstitution(institution);
+        onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
+        Billing billing = new Billing();
+        billing.setTaxCodeInvoicing("taxCodeInvoicing");
+        billing.setRecipientCode("recipientCode");
+        onboarding.setBilling(billing);
+
+        when(uoApi.findByUnicodeUsingGET1(any(), any()))
+                .thenReturn(Uni.createFrom().item(uoResource));
+
+        UOsResource uOsResource = new UOsResource();
+        uOsResource.setItems(List.of(uoResource));
+
+        UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
+                .customValidationOnboardingData(onboarding, dummyProduct())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertFailedWith(InvalidRequestException.class);
+    }
+
+    @Test
+    void checkRecipientCodeNoAssociation() {
+
+        Onboarding onboarding = new Onboarding();
+        Institution institution = new Institution();
+        institution.setOriginId("codiceIpe");
+        institution.setSubunitCode("subunitCode");
+        institution.setSubunitType(InstitutionPaSubunitType.AOO);
+        institution.setInstitutionType(InstitutionType.PA);
+        institution.setTaxCode("taxCode");
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceFiscaleEnte("taxCode");
+        uoResource.setCodiceIpa("ipaCode");
+        uoResource.setCodiceFiscaleSfe("taxCodeInvoicing");
+        onboarding.setInstitution(institution);
+        onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
+        Billing billing = new Billing();
+        billing.setTaxCodeInvoicing("taxCodeInvoicing");
+        billing.setRecipientCode("recipientCode");
+        onboarding.setBilling(billing);
+
+        when(uoApi.findByUnicodeUsingGET1(any(), any()))
+                .thenReturn(Uni.createFrom().item(uoResource));
+
+        UOsResource uOsResource = new UOsResource();
+        uOsResource.setItems(List.of(uoResource));
 
         UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
                 .customValidationOnboardingData(onboarding, dummyProduct())

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
@@ -278,6 +278,42 @@ public class OnboardingUtilsTest {
         subscriber.assertFailedWith(InvalidRequestException.class);
     }
 
+    @Test
+    void checkRecipientCodeSuccess() {
+
+        Onboarding onboarding = new Onboarding();
+        Institution institution = new Institution();
+        institution.setOriginId("ipaCode");
+        institution.setSubunitCode("subunitCode");
+        institution.setSubunitType(InstitutionPaSubunitType.AOO);
+        institution.setInstitutionType(InstitutionType.PA);
+        institution.setTaxCode("taxCode");
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceFiscaleEnte("taxCode");
+        uoResource.setCodiceIpa("ipaCode");
+        uoResource.setCodiceFiscaleSfe("codiceFiscaleSfe");
+        onboarding.setInstitution(institution);
+        onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
+        Billing billing = new Billing();
+        billing.setTaxCodeInvoicing("taxCodeInvoicing");
+        billing.setRecipientCode("recipientCode");
+        onboarding.setBilling(billing);
+
+        when(uoApi.findByUnicodeUsingGET1(any(), any()))
+                .thenReturn(Uni.createFrom().item(uoResource));
+
+        UOsResource uOsResource = new UOsResource();
+        uOsResource.setItems(List.of(uoResource));
+
+        UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
+                .customValidationOnboardingData(onboarding, dummyProduct())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        Onboarding actual = subscriber.awaitItem().getItem();
+        Assert.assertNotNull(actual);
+    }
+
 
     private static AdditionalInformations createSimpleAdditionalInformations(String type) {
         AdditionalInformations additionalInformations = new AdditionalInformations();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added check on recipient Code. In particular:

- UO is retrieved by recipientCode from registry
- the ipa code of this UO is compared with originId into request of onboarding
- In case they are different, an exception is thrown with a specific error (DENIED_NO_ASSOCIATION)
- In case they are equals, but the retrieved UO has not taxCodeInvoicing, an exception is thrown with a specific error (DENIED_NO_BILLING)
