### PR TITLE
hotfix: added not null check for workflow type when sending notification

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
@@ -14,6 +14,7 @@ import it.pagopa.selfcare.onboarding.exception.FunctionOrchestratedException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 
@@ -87,7 +88,7 @@ public class Utils {
     }
 
     public static boolean isNotInstitutionOnboarding(Onboarding onboarding) {
-        return !ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.contains(onboarding.getWorkflowType());
+        return Objects.nonNull(onboarding.getWorkflowType()) && !ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.contains(onboarding.getWorkflowType());
     }
 
     public static String getOnboardingAggregateString(ObjectMapper objectMapper, OnboardingAggregateOrchestratorInput onboarding) {


### PR DESCRIPTION
#### List of Changes

added not null check for workflow type when sending notification 

#### Motivation and Context

The onboardings documents created with previous microservice have not the attribute workflowType, so when we try to send  a notification for these onboardings we receive an exception

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.