### PR TITLE
[SELC-5299] fix: updated query to retrieve onboarding to resend even without workflowType

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -183,7 +183,7 @@ public class NotificationEventServiceDefault implements NotificationEventService
             Optional.ofNullable(notificationToSend.getBilling().getRecipientCode()).ifPresent(value -> propertiesMap.put("billing.recipientCode", value));
             Optional.ofNullable(notificationToSend.getBilling().getTaxCodeInvoicing()).ifPresent(value -> propertiesMap.put("billing.TaxCodeInvoicing", value));
             Optional.ofNullable(notificationToSend.getBilling().getVatNumber()).ifPresent(value -> propertiesMap.put("billing.VatNumber", value));
-            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", value ? "true" : "false"));
+            Optional.ofNullable(notificationToSend.getBilling().isPublicService()).ifPresent(value -> propertiesMap.put("billing.isPublicService", Boolean.TRUE.equals(value) ? "true" : "false"));
         }
 
         return propertiesMap;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/NotificationEventServiceDefault.java
@@ -80,13 +80,13 @@ public class NotificationEventServiceDefault implements NotificationEventService
             return;
         }
 
-        Product product = productService.getProduct(onboarding.getProductId());
-        if (product.getConsumers() == null || product.getConsumers().isEmpty()) {
-            context.getLogger().warning(() -> String.format("Node consumers is null or empty for product with ID %s", onboarding.getProductId()));
-            return;
-        }
-
         try {
+            Product product = productService.getProduct(onboarding.getProductId());
+            if (product.getConsumers() == null || product.getConsumers().isEmpty()) {
+                context.getLogger().warning(() -> String.format("Node consumers is null or empty for product with ID %s", onboarding.getProductId()));
+                return;
+            }
+
             if(Objects.isNull(queueEvent)) {
                 queueEvent = queueEventExaminer.determineEventType(onboarding);
             }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -54,6 +54,7 @@ public class OnboardingService {
     public static final String ACTIVATED_AT_FIELD = "activatedAt";
     public static final String DELETED_AT_FIELD = "deletedAt";
     public static final String CREATED_AT = "createdAt";
+    private static final String WORKFLOW_TYPE = "workFlowType";
 
     @RestClient
     @Inject
@@ -289,9 +290,9 @@ public class OnboardingService {
         query.append("productId", productId);
         query.append("status", new Document("$in", status.stream().map(OnboardingStatus::name).toList()));
          if (workflowTypeExist) {
-             query.append("workflowType", new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList()));
+             query.append(WORKFLOW_TYPE, new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList()));
          } else {
-             query.append("workflowType", new Document("$exists", false));
+             query.append(WORKFLOW_TYPE, new Document("$exists", false));
          }
         Document dateQuery = new Document();
         Optional.ofNullable(from).ifPresent(value -> query.append(dateField, dateQuery.append("$gte", LocalDate.parse(from, DateTimeFormatter.ISO_LOCAL_DATE))));
@@ -331,8 +332,8 @@ public class OnboardingService {
         }
 
         List<Document> workflowCriteria = new ArrayList<>();
-        workflowCriteria.add(new Document("workflowType", new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList())));
-        workflowCriteria.add(new Document("workflowType", new Document("$exists", false)));
+        workflowCriteria.add(new Document(WORKFLOW_TYPE, new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList())));
+        workflowCriteria.add(new Document(WORKFLOW_TYPE, new Document("$exists", false)));
         query.append("$or", workflowCriteria);
         return query;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -329,7 +329,11 @@ public class OnboardingService {
         if(!dateQuery.isEmpty()) {
             query.append(CREATED_AT, dateQuery);
         }
-        query.append("workflowType", new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList()));
+
+        List<Document> workflowCriteria = new ArrayList<>();
+        workflowCriteria.add(new Document("workflowType", new Document("$in", ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.stream().map(Enum::name).toList())));
+        workflowCriteria.add(new Document("workflowType", new Document("$exists", false)));
+        query.append("$or", workflowCriteria);
         return query;
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/Utils.java
@@ -14,6 +14,7 @@ import it.pagopa.selfcare.onboarding.exception.FunctionOrchestratedException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BinaryOperator;
 
@@ -87,7 +88,7 @@ public class Utils {
     }
 
     public static boolean isNotInstitutionOnboarding(Onboarding onboarding) {
-        return !ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.contains(onboarding.getWorkflowType());
+        return Objects.nonNull(onboarding.getWorkflowType()) && !ALLOWED_WORKFLOWS_FOR_INSTITUTION_NOTIFICATIONS.contains(onboarding.getWorkflowType());
     }
 
     public static String getOnboardingAggregateString(ObjectMapper objectMapper, OnboardingAggregateOrchestratorInput onboarding) {


### PR DESCRIPTION
#### List of Changes

updated query to retrieve onboarding to resend even without workflowType

#### Motivation and Context

The query didn't retrieve the onboardings without the workflowType attribute (which are the onboarding created by the old microservice)

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.