### PR TITLE
[SELC-5276] fix: Throw exception in of 404 for getUOFromRecipientCode

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -1080,7 +1080,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     }
 
     public Uni<CustomError> checkRecipientCode(String recipientCode, String originId) {
-      return uoApi.findByUnicodeUsingGET1(recipientCode, null).onItem()
+      return onboardingUtils.getUoFromRecipientCode(recipientCode).onItem()
                .transformToUni(uoResource ->
                        onboardingUtils.validationRecipientCode(originId, uoResource));
     }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -44,7 +44,8 @@ public class OnboardingUtils {
     }
 
     private Uni<Void> checkRecipientCode(Onboarding onboarding) {
-        if (onboarding.getInstitution().getInstitutionType().equals(InstitutionType.PA)
+        if (Objects.nonNull(onboarding.getInstitution())
+                && InstitutionType.PA.equals(onboarding.getInstitution().getInstitutionType())
                 && Objects.nonNull(onboarding.getBilling())
                 && Objects.nonNull(onboarding.getBilling().getRecipientCode())) {
             return uoApi.findByUnicodeUsingGET1(onboarding.getBilling().getRecipientCode(), null)

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -44,7 +44,8 @@ public class OnboardingUtils {
     }
 
     private Uni<Void> checkRecipientCode(Onboarding onboarding) {
-        if (Objects.nonNull(onboarding.getBilling())
+        if (onboarding.getInstitution().getInstitutionType().equals(InstitutionType.PA)
+                && Objects.nonNull(onboarding.getBilling())
                 && Objects.nonNull(onboarding.getBilling().getRecipientCode())) {
             return uoApi.findByUnicodeUsingGET1(onboarding.getBilling().getRecipientCode(), null)
                     .flatMap(uoResource -> validationRecipientCode(onboarding.getInstitution().getOriginId(), uoResource))


### PR DESCRIPTION
#### List of Changes

Throw exception in of 404 for getUOFromRecipientCode

#### Motivation and Context

In case registry proxy returns 404 for getUO from recipient code, a ResourceNotFoundException is thrown

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.