### PR TITLE
[SELC-5322] feat: added check to avoid error in case of 404 for pdv

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactory.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactory.java
@@ -7,10 +7,14 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import org.eclipse.microprofile.rest.client.ext.ClientHeadersFactory;
 
 import java.util.List;
+import java.util.Objects;
 
 
 @ApplicationScoped
 public class AuthenticationPropagationHeadersFactory implements ClientHeadersFactory {
+
+    private static final String USER_ID_HEADER = "user-uuid";
+    private static final String JWT_BEARER_TOKEN_ENV = "JWT_BEARER_TOKEN";
 
     @Inject
     JwtSessionService tokenService;
@@ -18,11 +22,12 @@ public class AuthenticationPropagationHeadersFactory implements ClientHeadersFac
     @Override
     public MultivaluedMap<String, String> update(MultivaluedMap<String, String> incomingHeaders, MultivaluedMap<String, String> clientOutgoingHeaders) {
         String bearerToken;
-        if (!clientOutgoingHeaders.isEmpty() && clientOutgoingHeaders.containsKey("user-uuid")) {
-            final String uuid = clientOutgoingHeaders.get("user-uuid").get(0);
-            bearerToken = tokenService.createJwt(uuid);
+        if (!clientOutgoingHeaders.isEmpty() && clientOutgoingHeaders.containsKey(USER_ID_HEADER)) {
+            final String uuid = clientOutgoingHeaders.get(USER_ID_HEADER).get(0);
+            final String jwt = tokenService.createJwt(uuid);
+            bearerToken = Objects.nonNull(jwt) ? jwt : System.getenv(JWT_BEARER_TOKEN_ENV);
         } else {
-            bearerToken = System.getenv("JWT_BEARER_TOKEN");
+            bearerToken = System.getenv(JWT_BEARER_TOKEN_ENV);
         }
         clientOutgoingHeaders.put("Authorization", List.of("Bearer " + bearerToken));
         return clientOutgoingHeaders;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefault.java
@@ -44,13 +44,14 @@ public class JwtSessionServiceDefault implements JwtSessionService {
     @Override
     public String createJwt(String userId) {
         PrivateKey privateKey;
+        UserResource userResource;
         try {
             privateKey = getPrivateKey(tokenConfig.signingKey());
+            userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, userId);
         } catch (Exception e) {
-            logger.error("Impossible to get private key. Error: {}", e.getMessage(), e);
+            logger.error("Impossible to create jwt token. Error: {}", e.getMessage(), e);
             return null;
         }
-        UserResource userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, userId);
         return Jwts.builder()
                 .setId(UUID.randomUUID().toString())
                 .setIssuedAt(new Date())

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefault.java
@@ -43,28 +43,26 @@ public class JwtSessionServiceDefault implements JwtSessionService {
 
     @Override
     public String createJwt(String userId) {
-        PrivateKey privateKey;
-        UserResource userResource;
         try {
-            privateKey = getPrivateKey(tokenConfig.signingKey());
-            userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, userId);
+            PrivateKey privateKey = getPrivateKey(tokenConfig.signingKey());
+            UserResource userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, userId);
+            return Jwts.builder()
+                    .setId(UUID.randomUUID().toString())
+                    .setIssuedAt(new Date())
+                    .setIssuer(tokenConfig.issuer())
+                    .setExpiration(Date.from(new Date().toInstant().plus(Duration.parse(tokenConfig.duration()))))
+                    .claim("family_name", userResource.getFamilyName().getValue())
+                    .claim("fiscal_number", userResource.getFiscalCode())
+                    .claim("name", userResource.getName().getValue())
+                    .claim("uid", userId)
+                    .signWith(SignatureAlgorithm.RS256, privateKey)
+                    .setHeaderParam(JwsHeader.KEY_ID, tokenConfig.kid())
+                    .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                    .compact();
         } catch (Exception e) {
             logger.error("Impossible to create jwt token. Error: {}", e.getMessage(), e);
             return null;
         }
-        return Jwts.builder()
-                .setId(UUID.randomUUID().toString())
-                .setIssuedAt(new Date())
-                .setIssuer(tokenConfig.issuer())
-                .setExpiration(Date.from(new Date().toInstant().plus(Duration.parse(tokenConfig.duration()))))
-                .claim("family_name", userResource.getFamilyName().getValue())
-                .claim("fiscal_number", userResource.getFiscalCode())
-                .claim("name", userResource.getName().getValue())
-                .claim("uid", userId)
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .setHeaderParam(JwsHeader.KEY_ID, tokenConfig.kid())
-                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-                .compact();
     }
 
     private PrivateKey getPrivateKey(String signingKey) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactoryTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactoryTest.java
@@ -24,4 +24,13 @@ class AuthenticationPropagationHeadersFactoryTest {
         authenticationPropagationHeadersFactory.update(incomingHeaders, outgoingHeaders);
         assertTrue(outgoingHeaders.containsKey("Authorization"));
     }
+
+    @Test
+    void emptyHeader() {
+        MultivaluedHashMap<String, String> incomingHeaders = new MultivaluedHashMap<>();
+        MultivaluedHashMap<String, String> outgoingHeaders = new MultivaluedHashMap<>();
+        authenticationPropagationHeadersFactory.update(incomingHeaders, outgoingHeaders);
+        assertTrue(outgoingHeaders.containsKey("Authorization"));
+    }
+
 }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactoryTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/client/auth/AuthenticationPropagationHeadersFactoryTest.java
@@ -1,6 +1,8 @@
 package it.pagopa.selfcare.onboarding.client.auth;
 
+import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.selfcare.onboarding.service.JwtSessionService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 class AuthenticationPropagationHeadersFactoryTest {
@@ -16,11 +20,24 @@ class AuthenticationPropagationHeadersFactoryTest {
     @Inject
     AuthenticationPropagationHeadersFactory authenticationPropagationHeadersFactory;
 
+    @InjectMock
+    JwtSessionService jwtSessionService;
+
     @Test
     void update() {
         MultivaluedHashMap<String, String> incomingHeaders = new MultivaluedHashMap<>();
         MultivaluedHashMap<String, String> outgoingHeaders = new MultivaluedHashMap<>();
         outgoingHeaders.put("user-uuid", List.of(UUID.randomUUID().toString()));
+        authenticationPropagationHeadersFactory.update(incomingHeaders, outgoingHeaders);
+        assertTrue(outgoingHeaders.containsKey("Authorization"));
+    }
+
+    @Test
+    void updateWithNullJwt() {
+        MultivaluedHashMap<String, String> incomingHeaders = new MultivaluedHashMap<>();
+        MultivaluedHashMap<String, String> outgoingHeaders = new MultivaluedHashMap<>();
+        outgoingHeaders.put("user-uuid", List.of(UUID.randomUUID().toString()));
+        when(jwtSessionService.createJwt(any())).thenReturn(null);
         authenticationPropagationHeadersFactory.update(incomingHeaders, outgoingHeaders);
         assertTrue(outgoingHeaders.containsKey("Authorization"));
     }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/JwtSessionServiceDefaultTest.java
@@ -4,6 +4,7 @@ import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
@@ -60,6 +61,20 @@ class JwtSessionServiceDefaultTest {
         when(userRegistryApi.findByIdUsingGET(any(), any())).thenReturn(userResource);
         String jwt = tokenService.createJwt(userId);
         assertTrue(Objects.nonNull(jwt));
+    }
+
+    @Test
+    void createNullJwt() {
+        final String userId = "userId";
+        UserResource userResource = new UserResource();
+        userResource.setFiscalCode("fiscalCode");
+        CertifiableFieldResourceOfstring certifiedField = new CertifiableFieldResourceOfstring();
+        certifiedField.setValue("name");
+        userResource.setName(certifiedField);
+        userResource.setFamilyName(certifiedField);
+        when(userRegistryApi.findByIdUsingGET(any(), any())).thenThrow(new ResourceNotFoundException("An error occurred", "Code"));
+        String jwt = tokenService.createJwt(userId);
+        assertTrue(Objects.isNull(jwt));
     }
 
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added condition to avoid error in CREATE_USERS function in case of 404 from PDV service. In this case, the bearer token of API request to user-ms is built by env variable.

#### Motivation and Context

When workflowType is IMPORT, the field userRequestUuid of onboarding is mocked. In order to manage the 404 from pdv, a new check has been added

#### How Has This Been Tested?

I have deployed the feature branch in dev and tested the completion of entire process of onboarding

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.