### PR TITLE
[SELC-5400] fix: Added check on getUserFromPdv for check manager API

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -1064,17 +1064,20 @@ public class OnboardingServiceDefault implements OnboardingService {
                         .collect().asList()
                         .onItem().transformToUni(this::getOnboardingList)
                         .onItem().ifNull().failWith(resourceNotFoundExceptionSupplier(onboardingUserRequest))
-                        .onItem().transform(items ->
-                                items.stream().map(onboarding -> onboarding.getUsers().stream()
-                                                .filter(userToOnboard -> PartyRole.MANAGER == userToOnboard.getRole())
-                                                .map(User::getId)
-                                                .findAny().orElse(null)).toList())
+                        .onItem().transform(this::getManagerIds)
                         .onItem().transformToUni(uuids -> {
                             if (uuids.contains(uuid.toString())) {
                                 return Uni.createFrom().item(true);
                             }
                             return Uni.createFrom().item(false);
-                        }));
+                        }))
+                .onFailure().recoverWithUni(ex -> {
+                    if (ex instanceof ResourceNotFoundException
+                            || ((WebApplicationException) ex).getResponse().getStatus() != 404) {
+                        return Uni.createFrom().failure(ex);
+                    }
+                    return Uni.createFrom().item(false);
+                });
     }
 
     public Uni<CustomError> checkRecipientCode(String recipientCode, String originId) {
@@ -1109,5 +1112,13 @@ public class OnboardingServiceDefault implements OnboardingService {
             return Uni.createFrom().nullItem();
         }
         return Uni.createFrom().item(onboardings);
+    }
+
+    // Retrieve manager uuids from previous onboardings in case of workflowType USERS
+    private List<String> getManagerIds(List<Onboarding> onboardings) {
+        return onboardings.stream().map(onboarding -> onboarding.getUsers().stream()
+                .filter(userToOnboard -> PartyRole.MANAGER == userToOnboard.getRole())
+                .map(User::getId)
+                .findAny().orElse(null)).toList();
     }
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1895,6 +1895,39 @@ class OnboardingServiceDefaultTest {
     }
 
     @Test
+    void testCheckManagerWith404FromUserRegistry() {
+        OnboardingUserRequest request = createDummyUserRequest();
+        WebApplicationException exception = mock(WebApplicationException.class);
+        Response response = mock(Response.class);
+        when(response.getStatus()).thenReturn(404);
+        when(exception.getResponse()).thenReturn(response);
+        when(userRegistryApi.searchUsingPOST(any(), any()))
+                .thenReturn(Uni.createFrom().failure(exception));
+        UniAssertSubscriber<Boolean> subscriber = onboardingService
+                .checkManager(request)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertCompleted();
+        assertFalse(subscriber.getItem());
+    }
+
+    @Test
+    void testCheckManagerWith500FromUserRegistry() {
+        OnboardingUserRequest request = createDummyUserRequest();
+        WebApplicationException exception = mock(WebApplicationException.class);
+        Response response = mock(Response.class);
+        when(response.getStatus()).thenReturn(500);
+        when(exception.getResponse()).thenReturn(response);
+        when(userRegistryApi.searchUsingPOST(any(), any()))
+                .thenReturn(Uni.createFrom().failure(exception));
+        UniAssertSubscriber<Boolean> subscriber = onboardingService
+                .checkManager(request)
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+        subscriber.assertFailedWith(WebApplicationException.class);
+    }
+
+    @Test
     void testCheckManagerWithTrueCheck() {
         final UUID uuid = UUID.randomUUID();
         OnboardingUserRequest request = createDummyUserRequest();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added condition to check if user exists in PDV for api check-manager. If not, the method returns false

#### Motivation and Context

In order to not get a 5xx error code, in case the user sent into request does not exist, the API will return false

#### How Has This Been Tested?

I have run ms locally and tested the api for every scenario

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.