### PR TITLE
chore: Add operationId to OpenAPI Documentation

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -382,6 +382,7 @@
       "get" : {
         "tags" : [ "support", "Onboarding" ],
         "summary" : "Returns onboardings record by institution taxCode/subunitCode/origin/originId",
+        "operationId" : "onboardingInstitutionUsingGET",
         "parameters" : [ {
           "name" : "origin",
           "in" : "query",
@@ -850,6 +851,7 @@
       "put" : {
         "tags" : [ "internal-v1" ],
         "summary" : "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution.It checks the contract's signature and upload the contract on an azure storageAt the end, function triggers async activities related to complete onboarding that consist of create the institution, activate the onboarding and sending data to notification queue.",
+        "operationId" : "completeOnboardingUsingPUT",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -944,6 +946,7 @@
       "put" : {
         "tags" : [ "support", "internal-v1", "Onboarding" ],
         "summary" : "Perform complete operation of an onboarding request as /complete but without signature verification of the contract",
+        "operationId" : "completeOnboardingTokenConsume",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",
@@ -1066,6 +1069,7 @@
       "put" : {
         "tags" : [ "support", "Onboarding" ],
         "summary" : "Update onboarding request receiving onboarding id.Function can change some values. ",
+        "operationId" : "updateOnboardiUsingPUT",
         "parameters" : [ {
           "name" : "onboardingId",
           "in" : "path",

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -265,6 +265,7 @@ paths:
       - support
       - Onboarding
       summary: Returns onboardings record by institution taxCode/subunitCode/origin/originId
+      operationId: onboardingInstitutionUsingGET
       parameters:
       - name: origin
         in: query
@@ -596,6 +597,7 @@ paths:
         \ and upload the contract on an azure storageAt the end, function triggers\
         \ async activities related to complete onboarding that consist of create the\
         \ institution, activate the onboarding and sending data to notification queue."
+      operationId: completeOnboardingUsingPUT
       parameters:
       - name: onboardingId
         in: path
@@ -670,6 +672,7 @@ paths:
       - Onboarding
       summary: Perform complete operation of an onboarding request as /complete but
         without signature verification of the contract
+      operationId: completeOnboardingTokenConsume
       parameters:
       - name: onboardingId
         in: path
@@ -760,6 +763,7 @@ paths:
       - Onboarding
       summary: 'Update onboarding request receiving onboarding id.Function can change
         some values. '
+      operationId: updateOnboardiUsingPUT
       parameters:
       - name: onboardingId
         in: path

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -183,7 +183,7 @@ public class OnboardingController {
     @Operation(summary = "Perform complete operation of an onboarding request receiving onboarding id and contract signed by the institution." +
             "It checks the contract's signature and upload the contract on an azure storage" +
             "At the end, function triggers async activities related to complete onboarding " +
-            "that consist of create the institution, activate the onboarding and sending data to notification queue.")
+            "that consist of create the institution, activate the onboarding and sending data to notification queue.", operationId = "completeOnboardingUsingPUT")
 
     @PUT
     @Path("/{onboardingId}/complete")
@@ -211,7 +211,7 @@ public class OnboardingController {
                         .build());
     }
 
-    @Operation(summary = "Perform complete operation of an onboarding request as /complete but without signature verification of the contract")
+    @Operation(summary = "Perform complete operation of an onboarding request as /complete but without signature verification of the contract", operationId = "completeOnboardingTokenConsume")
     @PUT
     @Path("/{onboardingId}/consume")
     @Tag(name = "support")
@@ -302,7 +302,7 @@ public class OnboardingController {
         return onboardingService.onboardingPending(onboardingId);
     }
 
-    @Operation(summary = "Returns onboardings record by institution taxCode/subunitCode/origin/originId")
+    @Operation(summary = "Returns onboardings record by institution taxCode/subunitCode/origin/originId", operationId = "onboardingInstitutionUsingGET")
     @GET
     @Tag(name = "support")
     @Tag(name = "Onboarding")
@@ -322,7 +322,7 @@ public class OnboardingController {
     }
 
     @Operation(summary = "Update onboarding request receiving onboarding id." +
-            "Function can change some values. ")
+            "Function can change some values. ", operationId = "updateOnboardiUsingPUT")
     @PUT
     @Tag(name = "support")
     @Tag(name = "Onboarding")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* Added: Manual assignment of operationId for each API operation in the OpenAPI specification.
* Updated the OpenAPI generation process to ensure that operationId is explicitly set for all operations.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR addresses the issue where operationId was missing in the automatically generated OpenAPI documentation by Quarkus. By default, Quarkus does not automatically set the operationId in the OpenAPI specification. This can lead to difficulties when integrating with API clients or tools that rely on operationId for method names or routing.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.