### PR TITLE
[SELC-5384] fix: added check for EC recipient code in case of AOO/UO onboarding

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -1082,7 +1082,7 @@ public class OnboardingServiceDefault implements OnboardingService {
     public Uni<CustomError> checkRecipientCode(String recipientCode, String originId) {
       return onboardingUtils.getUoFromRecipientCode(recipientCode).onItem()
                .transformToUni(uoResource ->
-                       onboardingUtils.validationRecipientCode(originId, uoResource));
+                       onboardingUtils.getValidationRecipientCodeError(originId, uoResource));
     }
 
     private static Uni<Long> updateOnboardingValues(String onboardingId, Onboarding onboarding) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -14,6 +14,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.WebApplicationException;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.openapi.quarkus.party_registry_proxy_json.api.AooApi;
 import org.openapi.quarkus.party_registry_proxy_json.api.UoApi;
 import org.openapi.quarkus.party_registry_proxy_json.model.UOResource;
 
@@ -27,6 +28,10 @@ public class OnboardingUtils {
     @RestClient
     @Inject
     UoApi uoApi;
+
+    @RestClient
+    @Inject
+    AooApi aooApi;
 
     private static final String ADDITIONAL_INFORMATION_REQUIRED = "Additional Information is required when institutionType is GSP and productId is pagopa";
     private static final String OTHER_NOTE_REQUIRED = "Other Note is required when other boolean are false";
@@ -46,13 +51,10 @@ public class OnboardingUtils {
     }
 
     private Uni<Void> checkRecipientCode(Onboarding onboarding) {
-        if (Objects.nonNull(onboarding.getInstitution())
-                && InstitutionType.PA.equals(onboarding.getInstitution().getInstitutionType())
-                && Objects.nonNull(onboarding.getBilling())
-                && Objects.nonNull(onboarding.getBilling().getRecipientCode())) {
+        if (isInvoiceablePA(onboarding)) {
             final String recipientCode = onboarding.getBilling().getRecipientCode();
             return getUoFromRecipientCode(recipientCode)
-                    .flatMap(uoResource -> validationRecipientCode(onboarding.getInstitution().getOriginId(), uoResource))
+                    .onItem().transformToUni(uoResource -> validationRecipientCode(onboarding, uoResource))
                     .onItem().transformToUni(customError -> {
                         if (Objects.nonNull(customError)) {
                             return Uni.createFrom().failure(new InvalidRequestException(customError.getMessage()));
@@ -61,6 +63,22 @@ public class OnboardingUtils {
                     });
         }
         return Uni.createFrom().nullItem();
+    }
+
+    private Uni<CustomError> validationRecipientCode(Onboarding onboarding, UOResource uoResource) {
+        switch (onboarding.getInstitution().getSubunitType()) {
+            case AOO -> {
+                return aooApi.findByUnicodeUsingGET(onboarding.getInstitution().getSubunitCode(), null)
+                        .onItem().transformToUni(aooResource -> getValidationRecipientCodeError(aooResource.getCodiceIpa(), uoResource));
+            }
+            case UO -> {
+                return uoApi.findByUnicodeUsingGET1(onboarding.getInstitution().getSubunitCode(), null)
+                        .onItem().transformToUni(innerUoResource -> getValidationRecipientCodeError(innerUoResource.getCodiceIpa(), uoResource));
+            }
+            default -> {
+                return getValidationRecipientCodeError(onboarding.getInstitution().getOriginId(), uoResource);
+            }
+        }
     }
 
     public Uni<UOResource> getUoFromRecipientCode(String recipientCode) {
@@ -74,8 +92,8 @@ public class OnboardingUtils {
                         : Uni.createFrom().failure(ex));
     }
 
-    public Uni<CustomError> validationRecipientCode(String originId, UOResource uoResource) {
-        if (!originId.equals(uoResource.getCodiceIpa())) {
+    public Uni<CustomError> getValidationRecipientCodeError(String originIdEC, UOResource uoResource) {
+        if (!originIdEC.equals(uoResource.getCodiceIpa())) {
             return Uni.createFrom().item(DENIED_NO_ASSOCIATION);
         }
         if (Objects.isNull(uoResource.getCodiceFiscaleSfe())) {
@@ -140,5 +158,12 @@ public class OnboardingUtils {
                 && Objects.nonNull(onboarding.getBilling())
                 && Objects.nonNull(onboarding.getBilling().getTaxCodeInvoicing())
                 && Objects.nonNull(onboarding.getInstitution().getTaxCode());
+    }
+
+    private boolean isInvoiceablePA(Onboarding onboarding) {
+        return Objects.nonNull(onboarding.getInstitution())
+                && InstitutionType.PA.equals(onboarding.getInstitution().getInstitutionType())
+                && Objects.nonNull(onboarding.getBilling())
+                && Objects.nonNull(onboarding.getBilling().getRecipientCode());
     }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -33,7 +33,6 @@ public class OnboardingUtils {
     @RestClient
     @Inject
     AooApi aooApi;
-    private static final String DEFAULT_VALUE = "EC";
     private static final String ADDITIONAL_INFORMATION_REQUIRED = "Additional Information is required when institutionType is GSP and productId is pagopa";
     private static final String OTHER_NOTE_REQUIRED = "Other Note is required when other boolean are false";
     private static final String BILLING_OR_RECIPIENT_CODE_REQUIRED = "Billing and/or recipient code are required";

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtils.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.onboarding.service.util;
 
 import io.smallrye.mutiny.Uni;
-import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.ProductId;
 import it.pagopa.selfcare.onboarding.constants.CustomError;
@@ -20,6 +19,8 @@ import org.openapi.quarkus.party_registry_proxy_json.model.UOResource;
 
 import java.util.Objects;
 
+import static it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType.EC;
+import static it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType.UO;
 import static it.pagopa.selfcare.onboarding.constants.CustomError.*;
 
 @ApplicationScoped
@@ -32,7 +33,7 @@ public class OnboardingUtils {
     @RestClient
     @Inject
     AooApi aooApi;
-
+    private static final String DEFAULT_VALUE = "EC";
     private static final String ADDITIONAL_INFORMATION_REQUIRED = "Additional Information is required when institutionType is GSP and productId is pagopa";
     private static final String OTHER_NOTE_REQUIRED = "Other Note is required when other boolean are false";
     private static final String BILLING_OR_RECIPIENT_CODE_REQUIRED = "Billing and/or recipient code are required";
@@ -66,7 +67,8 @@ public class OnboardingUtils {
     }
 
     private Uni<CustomError> validationRecipientCode(Onboarding onboarding, UOResource uoResource) {
-        switch (onboarding.getInstitution().getSubunitType()) {
+
+        switch ((onboarding.getInstitution().getSubunitType() != null) ? onboarding.getInstitution().getSubunitType() : EC ) {
             case AOO -> {
                 return aooApi.findByUnicodeUsingGET(onboarding.getInstitution().getSubunitCode(), null)
                         .onItem().transformToUni(aooResource -> getValidationRecipientCodeError(aooResource.getCodiceIpa(), uoResource));
@@ -154,7 +156,7 @@ public class OnboardingUtils {
 
     private boolean isUO(Onboarding onboarding) {
         return Objects.nonNull(onboarding.getInstitution().getSubunitCode())
-                && onboarding.getInstitution().getSubunitType().equals(InstitutionPaSubunitType.UO)
+                && UO.equals(onboarding.getInstitution().getSubunitType())
                 && Objects.nonNull(onboarding.getBilling())
                 && Objects.nonNull(onboarding.getBilling().getTaxCodeInvoicing())
                 && Objects.nonNull(onboarding.getInstitution().getTaxCode());

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1633,7 +1633,7 @@ class OnboardingServiceDefaultTest {
                 .thenReturn(Uni.createFrom().item(uoResource));
 
         // Mock the response from onboardingUtils.validationRecipientCode
-        when(onboardingUtils.validationRecipientCode(eq(originId), eq(uoResource)))
+        when(onboardingUtils.getValidationRecipientCodeError(eq(originId), eq(uoResource)))
                 .thenReturn(Uni.createFrom().item(customError));
 
         // Call the method under test

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
@@ -18,7 +18,10 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openapi.quarkus.party_registry_proxy_json.api.AooApi;
 import org.openapi.quarkus.party_registry_proxy_json.api.UoApi;
+import org.openapi.quarkus.party_registry_proxy_json.model.AOOResource;
+import org.openapi.quarkus.party_registry_proxy_json.model.AOOsResource;
 import org.openapi.quarkus.party_registry_proxy_json.model.UOResource;
 import org.openapi.quarkus.party_registry_proxy_json.model.UOsResource;
 import org.wildfly.common.Assert;
@@ -34,6 +37,11 @@ public class OnboardingUtilsTest {
     @InjectMock
     @RestClient
     UoApi uoApi;
+
+    @InjectMock
+    @RestClient
+    AooApi aooApi;
+
     @Inject
     OnboardingUtils onboardingUtils;
 
@@ -219,9 +227,9 @@ public class OnboardingUtilsTest {
         institution.setSubunitType(InstitutionPaSubunitType.AOO);
         institution.setInstitutionType(InstitutionType.PA);
         institution.setTaxCode("taxCode");
-        UOResource uoResource = new UOResource();
-        uoResource.setCodiceFiscaleEnte("taxCode");
-        uoResource.setCodiceIpa("ipaCode");
+        AOOResource resource = new AOOResource();
+        resource.setCodiceFiscaleEnte("taxCode");
+        resource.setCodiceIpa("ipaCode");
         onboarding.setInstitution(institution);
         onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
         Billing billing = new Billing();
@@ -229,11 +237,18 @@ public class OnboardingUtilsTest {
         billing.setRecipientCode("recipientCode");
         onboarding.setBilling(billing);
 
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceIpa("ipaCode");
+        uoResource.setCodiceFiscaleEnte("taxCode1");
+
         when(uoApi.findByUnicodeUsingGET1(any(), any()))
                 .thenReturn(Uni.createFrom().item(uoResource));
 
-        UOsResource uOsResource = new UOsResource();
-        uOsResource.setItems(List.of(uoResource));
+        when(aooApi.findByUnicodeUsingGET(any(), any()))
+                .thenReturn(Uni.createFrom().item(resource));
+
+        AOOsResource uOsResource = new AOOsResource();
+        uOsResource.setItems(List.of(resource));
 
         UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
                 .customValidationOnboardingData(onboarding, dummyProduct())
@@ -253,10 +268,9 @@ public class OnboardingUtilsTest {
         institution.setSubunitType(InstitutionPaSubunitType.AOO);
         institution.setInstitutionType(InstitutionType.PA);
         institution.setTaxCode("taxCode");
-        UOResource uoResource = new UOResource();
-        uoResource.setCodiceFiscaleEnte("taxCode");
-        uoResource.setCodiceIpa("ipaCode");
-        uoResource.setCodiceFiscaleSfe("taxCodeInvoicing");
+        AOOResource aooResource = new AOOResource();
+        aooResource.setCodiceFiscaleEnte("taxCode");
+        aooResource.setCodiceIpa("ipaCode");
         onboarding.setInstitution(institution);
         onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
         Billing billing = new Billing();
@@ -264,11 +278,19 @@ public class OnboardingUtilsTest {
         billing.setRecipientCode("recipientCode");
         onboarding.setBilling(billing);
 
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceIpa("customIpaCode");
+        uoResource.setCodiceFiscaleEnte("taxCode1");
+        uoResource.setCodiceFiscaleSfe("taxCodeInvoicing1");
+
         when(uoApi.findByUnicodeUsingGET1(any(), any()))
                 .thenReturn(Uni.createFrom().item(uoResource));
 
-        UOsResource uOsResource = new UOsResource();
-        uOsResource.setItems(List.of(uoResource));
+        when(aooApi.findByUnicodeUsingGET(any(), any()))
+                .thenReturn(Uni.createFrom().item(aooResource));
+
+        AOOsResource uOsResource = new AOOsResource();
+        uOsResource.setItems(List.of(aooResource));
 
         UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
                 .customValidationOnboardingData(onboarding, dummyProduct())
@@ -285,7 +307,6 @@ public class OnboardingUtilsTest {
         Institution institution = new Institution();
         institution.setOriginId("ipaCode");
         institution.setSubunitCode("subunitCode");
-        institution.setSubunitType(InstitutionPaSubunitType.AOO);
         institution.setInstitutionType(InstitutionType.PA);
         institution.setTaxCode("taxCode");
         UOResource uoResource = new UOResource();

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/util/OnboardingUtilsTest.java
@@ -259,6 +259,40 @@ public class OnboardingUtilsTest {
     }
 
     @Test
+    void checkRecipientCodeUONoBilling() {
+
+        Onboarding onboarding = new Onboarding();
+        Institution institution = new Institution();
+        institution.setOriginId("ipaCode");
+        institution.setSubunitCode("subunitCode");
+        institution.setSubunitType(InstitutionPaSubunitType.UO);
+        institution.setInstitutionType(InstitutionType.PA);
+        institution.setTaxCode("taxCode");
+        AOOResource resource = new AOOResource();
+        resource.setCodiceFiscaleEnte("taxCode");
+        resource.setCodiceIpa("ipaCode");
+        onboarding.setInstitution(institution);
+        onboarding.setProductId(ProductId.PROD_IO_SIGN.getValue());
+        Billing billing = new Billing();
+        billing.setRecipientCode("recipientCode");
+        onboarding.setBilling(billing);
+
+        UOResource uoResource = new UOResource();
+        uoResource.setCodiceIpa("ipaCode");
+        uoResource.setCodiceFiscaleEnte("taxCode1");
+
+        when(uoApi.findByUnicodeUsingGET1(any(), any()))
+                .thenReturn(Uni.createFrom().item(uoResource));
+
+        UniAssertSubscriber<Onboarding> subscriber = onboardingUtils
+                .customValidationOnboardingData(onboarding, dummyProduct())
+                .subscribe()
+                .withSubscriber(UniAssertSubscriber.create());
+
+        subscriber.assertFailedWith(InvalidRequestException.class);
+    }
+
+    @Test
     void checkRecipientCodeNoAssociation() {
 
         Onboarding onboarding = new Onboarding();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added check for EC recipient code in case of AOO/UO onboarding

#### Motivation and Context

In case of AOO/UO onbaording, there is no need to throw an exception if recipentCode is equal to UO subunitCode and this UO is part of EC hierarchy. 

#### How Has This Been Tested?

I have deployed the microservice locally and tested the onboarding process for both case, AOO and UO

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.