### PR TITLE
[SELC-5476] Feat: Added user mapping for aggregate users

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
@@ -18,6 +18,7 @@ public class AggregateInstitution {
     private String zipCode;
     private String originId;
     private Origin origin;
+    private List<User> users;
 
     public String getTaxCode() {
         return taxCode;
@@ -26,6 +27,10 @@ public class AggregateInstitution {
     public void setTaxCode(String taxCode) {
         this.taxCode = taxCode;
     }
+
+    public List<User> getUsers() {return users;}
+
+    public void setUsers(List<User> users) {this.users = users;}
 
     public String getSubunitCode() {
         return subunitCode;

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -4,10 +4,14 @@ import it.pagopa.selfcare.onboarding.dto.OnboardingAggregateOrchestratorInput;
 import it.pagopa.selfcare.onboarding.entity.AggregateInstitution;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.entity.User;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
+import java.util.List;
 import java.util.Objects;
 
 @Mapper(componentModel = "cdi")
@@ -20,6 +24,7 @@ public interface OnboardingMapper {
     Onboarding mapToOnboarding(OnboardingAggregateOrchestratorInput input);
 
     @Mapping(target = "aggregate", expression = "java(mapFromAggregateInstitution(aggregateInstitution))")
+    @Mapping(target = "users", expression = "java(mapAggregateUsers(onboarding, aggregateInstitution))")
     OnboardingAggregateOrchestratorInput mapToOnboardingAggregateOrchestratorInput(Onboarding onboarding, AggregateInstitution aggregateInstitution);
 
     /**
@@ -34,6 +39,14 @@ public interface OnboardingMapper {
             aggregate.setInstitutionType(institution.getInstitutionType());
         }
         return aggregate;
+    }
+
+    @Named("mapAggregateUsers")
+    default List<User> mapAggregateUsers(Onboarding onboarding, AggregateInstitution aggregateInstitution) {
+        if (Objects.nonNull(aggregateInstitution) && !CollectionUtils.isEmpty(aggregateInstitution.getUsers())) {
+            return aggregateInstitution.getUsers();
+        }
+        return onboarding.getUsers();
     }
 
     Institution mapFromAggregateInstitution(AggregateInstitution aggregateInstitution);

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingMapperTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingMapperTest.java
@@ -1,0 +1,93 @@
+package it.pagopa.selfcare.onboarding;
+
+import io.quarkus.test.junit.QuarkusTest;
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import it.pagopa.selfcare.onboarding.dto.OnboardingAggregateOrchestratorInput;
+import it.pagopa.selfcare.onboarding.entity.AggregateInstitution;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.entity.User;
+import it.pagopa.selfcare.onboarding.mapper.OnboardingMapperImpl;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+@QuarkusTest
+class OnboardingMapperTest {
+
+    @Inject
+    private OnboardingMapperImpl onboardingMapper;
+
+    @Test
+    void mapToOnboardingAggregateOrchestratorInputTestWithAggregateUsers(){
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("example");
+        onboarding.setProductId("productId");
+        User user = new User();
+        user.setId("aggregatorUser");
+        user.setRole(PartyRole.MANAGER);
+        user.setProductRole("aggregatorProductRole");
+        onboarding.setUsers(List.of(user));
+
+        User user2 = new User();
+        user2.setId("aggregateUser");
+        user2.setRole(PartyRole.MANAGER);
+        user2.setProductRole("aggregateProductRole");
+        AggregateInstitution aggregateInstitution = new AggregateInstitution();
+        aggregateInstitution.setUsers(List.of(user2));
+        onboarding.setAggregates(List.of(aggregateInstitution));
+
+        OnboardingAggregateOrchestratorInput response = onboardingMapper.mapToOnboardingAggregateOrchestratorInput(onboarding, aggregateInstitution);
+        Assertions.assertEquals(1, response.getUsers().size());
+        Assertions.assertEquals("aggregateUser", response.getUsers().get(0).getId());
+        Assertions.assertEquals(PartyRole.MANAGER, response.getUsers().get(0).getRole());
+        Assertions.assertEquals("aggregateProductRole", response.getUsers().get(0).getProductRole());
+
+    }
+
+    @Test
+    void mapToOnboardingAggregateOrchestratorInputTestWithoutAggregatesUser(){
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("example");
+        onboarding.setProductId("productId");
+        User user = new User();
+        user.setId("aggregatorUser");
+        user.setRole(PartyRole.MANAGER);
+        user.setProductRole("aggregatorProductRole");
+        onboarding.setUsers(List.of(user));
+
+        AggregateInstitution aggregateInstitution = new AggregateInstitution();
+        aggregateInstitution.setUsers(null);
+        onboarding.setAggregates(List.of(aggregateInstitution));
+
+        OnboardingAggregateOrchestratorInput response = onboardingMapper.mapToOnboardingAggregateOrchestratorInput(onboarding, aggregateInstitution);
+        Assertions.assertEquals(1, response.getUsers().size());
+        Assertions.assertEquals("aggregatorUser", response.getUsers().get(0).getId());
+        Assertions.assertEquals(PartyRole.MANAGER, response.getUsers().get(0).getRole());
+        Assertions.assertEquals("aggregatorProductRole", response.getUsers().get(0).getProductRole());
+    }
+
+    @Test
+    void mapToOnboardingAggregateOrchestratorInputTestWithAggregatesUserEmptyList(){
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("example");
+        onboarding.setProductId("productId");
+        User user = new User();
+        user.setId("aggregatorUser");
+        user.setRole(PartyRole.MANAGER);
+        user.setProductRole("aggregatorProductRole");
+        onboarding.setUsers(List.of(user));
+
+        AggregateInstitution aggregateInstitution = new AggregateInstitution();
+        aggregateInstitution.setUsers(Collections.emptyList());
+        onboarding.setAggregates(List.of(aggregateInstitution));
+
+        OnboardingAggregateOrchestratorInput response = onboardingMapper.mapToOnboardingAggregateOrchestratorInput(onboarding, aggregateInstitution);
+        Assertions.assertEquals(1, response.getUsers().size());
+        Assertions.assertEquals("aggregatorUser", response.getUsers().get(0).getId());
+        Assertions.assertEquals(PartyRole.MANAGER, response.getUsers().get(0).getRole());
+        Assertions.assertEquals("aggregatorProductRole", response.getUsers().get(0).getProductRole());
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added user mapping for aggregate users
<!--- Describe your changes in detail -->

#### Motivation and Context
In the case of aggregator entities, for the users of the aggregated entities, it is necessary to map, if present, those related to the aggregated entity; otherwise, those of the aggregator.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.