### PR TITLE
refactor: standardize using onboarding-sdk-version on entire project

### DIFF
--- a/apps/onboarding-cdc/pom.xml
+++ b/apps/onboarding-cdc/pom.xml
@@ -24,7 +24,6 @@
         <quarkus.platform.version>3.5.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <onboarding-sdk.version>0.2.1</onboarding-sdk.version>
         <quarkus-openapi-generator.version>2.4.1</quarkus-openapi-generator.version>
     </properties>
     <dependencyManagement>
@@ -114,12 +113,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-common</artifactId>
-            <version>${onboarding-sdk.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -190,6 +190,21 @@
         <artifactId>applicationinsights-web</artifactId>
         <version>2.6.4</version>
     </dependency>
+    <dependency>
+      <groupId>it.pagopa.selfcare</groupId>
+      <artifactId>onboarding-sdk-crypto</artifactId>
+      <version>0.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>it.pagopa.selfcare</groupId>
+      <artifactId>onboarding-sdk-azure-storage</artifactId>
+      <version>0.2.1</version>
+    </dependency>
+    <dependency>
+      <groupId>it.pagopa.selfcare</groupId>
+      <artifactId>onboarding-sdk-product</artifactId>
+      <version>0.2.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -21,7 +21,6 @@
     <quarkus.platform.version>3.5.1</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
-    <onboarding-sdk.version>0.2.1</onboarding-sdk.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
 
@@ -65,26 +64,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-mailer</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>it.pagopa.selfcare</groupId>
-      <artifactId>onboarding-sdk-azure-storage</artifactId>
-      <version>${onboarding-sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>it.pagopa.selfcare</groupId>
-      <artifactId>onboarding-sdk-product</artifactId>
-      <version>${onboarding-sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>it.pagopa.selfcare</groupId>
-      <artifactId>onboarding-sdk-common</artifactId>
-      <version>${onboarding-sdk.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>it.pagopa.selfcare</groupId>
-      <artifactId>onboarding-sdk-crypto</artifactId>
-      <version>${onboarding-sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -23,7 +23,6 @@
         <quarkus.platform.version>3.11.2</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.1.2</surefire-plugin.version>
-        <onboarding-sdk.version>0.2.1</onboarding-sdk.version>
         <quarkus-openapi-generator.version>2.4.1</quarkus-openapi-generator.version>
     </properties>
     <dependencyManagement>
@@ -138,22 +137,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-test-security-jwt</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-common</artifactId>
-            <version>${onboarding-sdk.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-azure-storage</artifactId>
-            <version>${onboarding-sdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-product</artifactId>
-            <version>${onboarding-sdk.version}</version>
         </dependency>
 
 

--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -234,6 +234,17 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-azure-storage</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-product</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -15,22 +15,7 @@
     <dependencies>
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-azure-storage</artifactId>
-            <version>0.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-common</artifactId>
-            <version>0.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>it.pagopa.selfcare</groupId>
-            <artifactId>onboarding-sdk-crypto</artifactId>
             <version>0.2.1</version>
         </dependency>
     </dependencies>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -12,6 +12,29 @@
     <artifactId>onboarding-apps</artifactId>
     <packaging>pom</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-azure-storage</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-product</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-common</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>onboarding-sdk-crypto</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+    </dependencies>
+
     <profiles>
         <profile>
             <id>onboarding-ms</id>

--- a/libs/onboarding-sdk-product/pom.xml
+++ b/libs/onboarding-sdk-product/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <jackson.version>2.15.2</jackson.version>
-        <onboarding-sdk.version>0.2.1</onboarding-sdk.version>
     </properties>
 
     <dependencies>
@@ -26,13 +25,13 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-azure-storage</artifactId>
-            <version>${onboarding-sdk.version}</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-common</artifactId>
-            <version>${onboarding-sdk.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Set onboarding-sdk dependencies version on apps module guarantee that also these versions are upgraded when perform set: versions on maven

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to force to use the last version of onboarding-sdk on entire project. This fix an issue that occurs when sdk upgrade the version and apps don't use this last version. The error happen during deploy when Docker image are builded.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.