### PR TITLE
[SELC-5669] Feat: Modified onboardingPaAggregation to persist also vatNumber given from csv

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/AggregateInstitutionRequest.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/AggregateInstitutionRequest.java
@@ -17,6 +17,7 @@ public class AggregateInstitutionRequest {
 
     private String subunitCode;
     private String subunitType;
+    private String vatNumber;
     private List<GeographicTaxonomy> geographicTaxonomies;
     private String address;
     private String zipCode;

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
@@ -17,6 +17,7 @@ public class AggregateInstitution {
     private String zipCode;
     private String originId;
     private Origin origin;
+    private String vatNumber;
     private List<User> users;
 
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
@@ -1,11 +1,14 @@
 package it.pagopa.selfcare.onboarding.entity;
 
 import it.pagopa.selfcare.onboarding.common.Origin;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@SuppressWarnings("java:S1068")
 public class AggregateInstitution {
 
     private String taxCode;

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -46,13 +46,13 @@ import static org.mockito.Mockito.*;
 @QuarkusTestResource(MongoTestResource.class)
 class OnboardingControllerTest {
 
-    final static OnboardingPspRequest onboardingPspValid;
-    final static UserRequest userDTO;
-    final static OnboardingPgRequest onboardingPgValid;
-    final static OnboardingDefaultRequest onboardingBaseValid;
+    static final OnboardingPspRequest onboardingPspValid;
+    static final UserRequest userDTO;
+    static final OnboardingPgRequest onboardingPgValid;
+    static final OnboardingDefaultRequest onboardingBaseValid;
 
-    final static InstitutionBaseRequest institution;
-    final static InstitutionPspRequest institutionPsp;
+    static final InstitutionBaseRequest institution;
+    static final InstitutionPspRequest institutionPsp;
 
     @InjectMock
     OnboardingService onboardingService;
@@ -626,7 +626,7 @@ class OnboardingControllerTest {
         ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
         Mockito.verify(onboardingService, times(1))
                 .onboardingCompletion(captor.capture(), any());
-        assertEquals(captor.getValue().getInstitution().getInstitutionType(), InstitutionType.PG);
+        assertEquals(InstitutionType.PG, captor.getValue().getInstitution().getInstitutionType());
     }
 
     @Test


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Modified onboardingPaAggregation to persist also vatNumber given from csv
<!--- Describe your changes in detail -->

#### Motivation and Context
For the contract of the aggregating entities, it is necessary to include all the data of the aggregated entities, both those retrieved from IPA and those sent via CSV and not overwritten by IPA. Therefore, it is essential that all this data is available during the initial persistence.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.