### PR TITLE
[SELC-5632] feat: added getProductRaw on product-sdk to retrieve data without refreshing configuration

### DIFF
--- a/apps/onboarding-functions/pom.xml
+++ b/apps/onboarding-functions/pom.xml
@@ -193,17 +193,17 @@
     <dependency>
       <groupId>it.pagopa.selfcare</groupId>
       <artifactId>onboarding-sdk-crypto</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
     </dependency>
     <dependency>
       <groupId>it.pagopa.selfcare</groupId>
       <artifactId>onboarding-sdk-azure-storage</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
     </dependency>
     <dependency>
       <groupId>it.pagopa.selfcare</groupId>
       <artifactId>onboarding-sdk-product</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/apps/onboarding-ms/pom.xml
+++ b/apps/onboarding-ms/pom.xml
@@ -243,12 +243,12 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-azure-storage</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.1</version>
         </dependency>
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-product</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.1</version>
         </dependency>
 
     </dependencies>

--- a/apps/pom.xml
+++ b/apps/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>it.pagopa.selfcare</groupId>
             <artifactId>onboarding-sdk-common</artifactId>
-            <version>0.3.0</version>
+            <version>0.3.1</version>
         </dependency>
     </dependencies>
 

--- a/libs/onboarding-sdk-azure-storage/pom.xml
+++ b/libs/onboarding-sdk-azure-storage/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>it.pagopa.selfcare</groupId>
         <artifactId>onboarding-sdk-pom</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
         <relativePath>../onboarding-sdk-pom</relativePath>
     </parent>
 

--- a/libs/onboarding-sdk-common/pom.xml
+++ b/libs/onboarding-sdk-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.pagopa.selfcare</groupId>
         <artifactId>onboarding-sdk-pom</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
         <relativePath>../onboarding-sdk-pom</relativePath>
     </parent>
     <artifactId>onboarding-sdk-common</artifactId>

--- a/libs/onboarding-sdk-crypto/pom.xml
+++ b/libs/onboarding-sdk-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>it.pagopa.selfcare</groupId>
         <artifactId>onboarding-sdk-pom</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
         <relativePath>../onboarding-sdk-pom</relativePath>
     </parent>
     <artifactId>onboarding-sdk-crypto</artifactId>

--- a/libs/onboarding-sdk-pom/pom.xml
+++ b/libs/onboarding-sdk-pom/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>onboarding-sdk-pom</artifactId>
     <packaging>pom</packaging>
     <name>onboarding-sdk-pom</name>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/libs/onboarding-sdk-product/pom.xml
+++ b/libs/onboarding-sdk-product/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>it.pagopa.selfcare</groupId>
         <artifactId>onboarding-sdk-pom</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
         <relativePath>../onboarding-sdk-pom</relativePath>
     </parent>
     <artifactId>onboarding-sdk-product</artifactId>
     <name>onboarding-sdk-product</name>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
 
     <properties>
         <jackson.version>2.15.2</jackson.version>

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductService.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductService.java
@@ -11,11 +11,13 @@ import java.util.List;
 import java.util.Map;
 
 public interface ProductService {
-    public List<Product> getProducts(boolean rootOnly, boolean valid) ;
+    List<Product> getProducts(boolean rootOnly, boolean valid) ;
 
     void validateRoleMappings(Map<PartyRole, ? extends ProductRoleInfo> roleMappings);
 
     Product getProduct(String productId);
+
+    Product getProductRaw(String productId);
 
     void fillContractTemplatePathAndVersion(Product product, InstitutionType institutionType);
 

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductServiceCacheable.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductServiceCacheable.java
@@ -8,6 +8,7 @@ import it.pagopa.selfcare.onboarding.common.PartyRole;
 import it.pagopa.selfcare.product.entity.Product;
 import it.pagopa.selfcare.product.entity.ProductRole;
 import it.pagopa.selfcare.product.entity.ProductRoleInfo;
+import it.pagopa.selfcare.product.exception.ProductNotFoundException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -60,6 +61,21 @@ public class ProductServiceCacheable implements ProductService{
     @Override
     public Product getProduct(String productId) {
         refreshProduct();
+        return productService.getProduct(productId);
+    }
+
+
+    /**
+     * Return a product present on the map by productId without any filter
+     * retrieving data from institutionContractMappings map
+     *
+     * @param productId String
+     * @return Product
+     * @throws IllegalArgumentException if @param id is null
+     * @throws ProductNotFoundException if product is not found
+     */
+    @Override
+    public Product getProductRaw(String productId) {
         return productService.getProduct(productId);
     }
 

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductServiceDefault.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/service/ProductServiceDefault.java
@@ -113,6 +113,20 @@ public class ProductServiceDefault implements ProductService {
         return getProduct(productId, false);
     }
 
+    /**
+     * Return a product present on the map by productId without any filter
+     * retrieving data from institutionContractMappings map
+     *
+     * @param productId String
+     * @return Product
+     * @throws IllegalArgumentException if @param id is null
+     * @throws ProductNotFoundException if product is not found
+     */
+    @Override
+    public Product getProductRaw(String productId) {
+        return getProduct(productId, false);
+    }
+
     private Product getProduct(String productId, boolean filterValid) {
 
         if (Objects.isNull(productId)) {

--- a/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/service/ProductServiceCacheableTest.java
+++ b/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/service/ProductServiceCacheableTest.java
@@ -18,8 +18,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ProductServiceCacheableTest {
     private static final String PRODUCT_JSON_STRING = "[{\"id\":\"prod-test-parent\",\"status\":\"ACTIVE\"}," +
@@ -166,6 +165,23 @@ class ProductServiceCacheableTest {
         Product product = productServiceCacheable.getProduct("prod-test");
         //then
         assertNotNull(product);
+    }
+
+    @Test
+    void getProductRaw() {
+        final String filePath = "filePath";
+        AzureBlobClient azureBlobClient = mock(AzureBlobClient.class);
+        BlobProperties blobPropertiesMock = mock(BlobProperties.class);
+
+        when(azureBlobClient.getProperties(any())).thenReturn(blobPropertiesMock);
+        when(blobPropertiesMock.getLastModified()).thenReturn(OffsetDateTime.now());
+        when(azureBlobClient.getFileAsText(any())).thenReturn(PRODUCT_JSON_STRING);
+        ProductServiceCacheable productServiceCacheable = new ProductServiceCacheable(azureBlobClient, filePath);
+        //when
+        Product product = productServiceCacheable.getProductRaw("prod-test");
+        //then
+        assertNotNull(product);
+        verify(blobPropertiesMock, times(1)).getLastModified();
     }
 
     @Test

--- a/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/service/ProductServiceDefaultTest.java
+++ b/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/service/ProductServiceDefaultTest.java
@@ -114,6 +114,12 @@ class ProductServiceDefaultTest {
     }
 
     @Test
+    void getProductRaw_shouldGetProduct() throws JsonProcessingException {
+        ProductServiceDefault productService = new ProductServiceDefault(PRODUCT_JSON_STRING);
+        assertNotNull(productService.getProductRaw("prod-test"));
+    }
+
+    @Test
     void getProductValid_shouldThrowProductNotFoundExceptionIfProductInactive() throws JsonProcessingException {
         ProductServiceDefault productService = new ProductServiceDefault(PRODUCT_JSON_STRING);
         assertThrows(ProductNotFoundException.class, () -> productService.getProductIsValid("prod-inactive"));

--- a/test-coverage/pom.xml
+++ b/test-coverage/pom.xml
@@ -77,22 +77,22 @@
                 <dependency>
                     <groupId>it.pagopa.selfcare</groupId>
                     <artifactId>onboarding-sdk-product</artifactId>
-                    <version>0.3.0</version>
+                    <version>0.3.1</version>
                 </dependency>
                 <dependency>
                     <groupId>it.pagopa.selfcare</groupId>
                     <artifactId>onboarding-sdk-common</artifactId>
-                    <version>0.3.0</version>
+                    <version>0.3.1</version>
                 </dependency>
                 <dependency>
                     <groupId>it.pagopa.selfcare</groupId>
                     <artifactId>onboarding-sdk-azure-storage</artifactId>
-                    <version>0.3.0</version>
+                    <version>0.3.1</version>
                 </dependency>
                 <dependency>
                     <groupId>it.pagopa.selfcare</groupId>
                     <artifactId>onboarding-sdk-crypto</artifactId>
-                    <version>0.3.0</version>
+                    <version>0.3.1</version>
                 </dependency>
             </dependencies>
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This new method is useful when you want to retrieve some description for a lot of products in the same instant. In this case, calling azure storage is useless because the configuration can't be change in one instant.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.