### PR TITLE
[SELC-5629] fix: getAllRoleMappings sdk when both maps are non-null with overlapping keys

### DIFF
--- a/.github/workflows/pr_libs.yml
+++ b/.github/workflows/pr_libs.yml
@@ -13,7 +13,7 @@ on:
       - reopened
       - ready_for_review
     paths:
-      - './libs/**'
+      - 'libs/**'
       - '.github/workflows/pr_libs.yml'
       - '.github/workflows/call_code_review.yml'
 

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/Product.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/Product.java
@@ -152,12 +152,20 @@ public class Product {
     public Map<PartyRole, List<ProductRoleInfo>> getAllRoleMappings() {
         Map<PartyRole, List<ProductRoleInfo>> roleInfoMap = new HashMap<>();
         Optional.ofNullable(roleMappings)
-                .ifPresent(roleMappings -> roleMappings.forEach((key, value) -> roleInfoMap.put(key, List.of(value))));
+                .ifPresent(roleMappings -> roleMappings.forEach((key, value) -> {
+                    List<ProductRoleInfo> productRoles = new ArrayList<>();
+                    productRoles.add(value);
+                    roleInfoMap.put(key, productRoles);
+                }));
         Optional.ofNullable(roleMappingsByInstitutionType)
                 .map(Map::values)
                 .ifPresent(items -> items.stream()
                         .map(Map::entrySet)
-                        .forEach(item -> item.forEach(entry -> roleInfoMap.put(entry.getKey(), List.of(entry.getValue())))));
+                        .forEach(item -> item.forEach(entry -> {
+                            List<ProductRoleInfo> productRoles = roleInfoMap.getOrDefault(entry.getKey(), new ArrayList<>());
+                            productRoles.add(entry.getValue());
+                            roleInfoMap.put(entry.getKey(), productRoles);
+                        } )));
         return roleInfoMap;
     }
 

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/ProductRole.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/ProductRole.java
@@ -1,5 +1,7 @@
 package it.pagopa.selfcare.product.entity;
 
+import java.util.Objects;
+
 public class ProductRole {
 
     private String code;
@@ -28,5 +30,17 @@ public class ProductRole {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductRole that)) return false;
+        return Objects.equals(getCode(), that.getCode()) && Objects.equals(getLabel(), that.getLabel()) && Objects.equals(getDescription(), that.getDescription());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCode(), getLabel(), getDescription());
     }
 }

--- a/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/ProductRoleInfo.java
+++ b/libs/onboarding-sdk-product/src/main/java/it/pagopa/selfcare/product/entity/ProductRoleInfo.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.product.entity;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ProductRoleInfo {
 
@@ -34,5 +35,17 @@ public class ProductRoleInfo {
 
     public void setRoles(List<ProductRole> roles) {
         this.roles = roles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductRoleInfo that)) return false;
+        return isMultiroleAllowed() == that.isMultiroleAllowed() && Objects.equals(getPhasesAdditionAllowed(), that.getPhasesAdditionAllowed()) && Objects.equals(getRoles(), that.getRoles());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isMultiroleAllowed(), getPhasesAdditionAllowed(), getRoles());
     }
 }

--- a/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/entity/ProductTest.java
+++ b/libs/onboarding-sdk-product/src/test/java/it/pagopa/selfcare/product/entity/ProductTest.java
@@ -1,0 +1,127 @@
+package it.pagopa.selfcare.product.entity;
+
+import it.pagopa.selfcare.onboarding.common.PartyRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProductTest {
+
+    ProductRoleInfo dummmyProductRoleInfo(PartyRole partyRole) {
+        ProductRoleInfo productRoleInfo = new ProductRoleInfo();
+        ProductRole productRole = new ProductRole();
+        productRole.setCode(partyRole.name());
+        productRoleInfo.setRoles(List.of(productRole));
+        return productRoleInfo;
+    }
+
+    @Test
+    @DisplayName("Test when only roleMappings is non-null")
+    public void testGetAllRoleMappings_OnlyRoleMappings() {
+        Map<PartyRole, ProductRoleInfo> roleMappings = new HashMap<>();
+        ProductRoleInfo manager = dummmyProductRoleInfo(PartyRole.MANAGER);
+        ProductRoleInfo operator = dummmyProductRoleInfo(PartyRole.OPERATOR);
+        roleMappings.put(PartyRole.MANAGER, manager);
+        roleMappings.put(PartyRole.OPERATOR, operator);
+
+        Product product = new Product();
+        product.setRoleMappings(roleMappings);
+        product.setRoleMappingsByInstitutionType(null);
+
+        Map<PartyRole, List<ProductRoleInfo>> result = product.getAllRoleMappings();
+
+        assertEquals(2, result.size(), "Map should contain 2 keys");
+        assertEquals(List.of(manager), result.get(PartyRole.MANAGER));
+        assertEquals(List.of(operator), result.get(PartyRole.OPERATOR));
+    }
+
+    @Test
+    @DisplayName("Test when only roleMappingsByInstitutionType is non-null")
+    public void testGetAllRoleMappings_OnlyRoleMappingsByInstitutionType() {
+        Map<String, Map<PartyRole, ProductRoleInfo>> roleMappingsByInstitutionType = new HashMap<>();
+
+        Map<PartyRole, ProductRoleInfo> institution1 = new HashMap<>();
+        institution1.put(PartyRole.MANAGER, dummmyProductRoleInfo(PartyRole.MANAGER));
+        institution1.put(PartyRole.OPERATOR, dummmyProductRoleInfo(PartyRole.OPERATOR));
+
+        Map<PartyRole, ProductRoleInfo> institution2 = new HashMap<>();
+        institution2.put(PartyRole.DELEGATE, dummmyProductRoleInfo(PartyRole.DELEGATE));
+        institution2.put(PartyRole.OPERATOR, dummmyProductRoleInfo(PartyRole.OPERATOR));
+
+        roleMappingsByInstitutionType.put("Institution1", institution1);
+        roleMappingsByInstitutionType.put("Institution2", institution2);
+
+        Product product = new Product();
+        product.setRoleMappings(null);
+        product.setRoleMappingsByInstitutionType(roleMappingsByInstitutionType);
+
+        Map<PartyRole, List<ProductRoleInfo>> result = product.getAllRoleMappings();
+
+        assertEquals(3, result.size(), "Map should contain 3 keys");
+        assertEquals(List.of(dummmyProductRoleInfo(PartyRole.MANAGER)), result.get(PartyRole.MANAGER));
+        assertEquals(List.of(dummmyProductRoleInfo(PartyRole.DELEGATE)), result.get(PartyRole.DELEGATE));
+        assertEquals(Arrays.asList(
+                dummmyProductRoleInfo(PartyRole.OPERATOR),
+                dummmyProductRoleInfo(PartyRole.OPERATOR)
+        ), result.get(PartyRole.OPERATOR));
+    }
+
+    @Test
+    @DisplayName("Test when both maps are non-null with overlapping keys")
+    public void testGetAllRoleMappings_BothMapsNonNullWithOverlap() {
+        // Setup roleMappings
+        Map<PartyRole, ProductRoleInfo> roleMappings = new HashMap<>();
+        roleMappings.put(PartyRole.MANAGER, dummmyProductRoleInfo(PartyRole.MANAGER));
+        roleMappings.put(PartyRole.DELEGATE, dummmyProductRoleInfo(PartyRole.OPERATOR));
+
+        // Setup roleMappingsByInstitutionType
+        Map<String, Map<PartyRole, ProductRoleInfo>> roleMappingsByInstitutionType = new HashMap<>();
+
+        Map<PartyRole, ProductRoleInfo> institution1 = new HashMap<>();
+        institution1.put(PartyRole.MANAGER, dummmyProductRoleInfo(PartyRole.MANAGER));
+        institution1.put(PartyRole.OPERATOR, dummmyProductRoleInfo(PartyRole.OPERATOR));
+
+        Map<PartyRole, ProductRoleInfo> institution2 = new HashMap<>();
+        institution2.put(PartyRole.DELEGATE, dummmyProductRoleInfo(PartyRole.DELEGATE));
+        institution2.put(PartyRole.OPERATOR, dummmyProductRoleInfo(PartyRole.OPERATOR));
+
+        roleMappingsByInstitutionType.put("Institution1", institution1);
+        roleMappingsByInstitutionType.put("Institution2", institution2);
+
+        Product product = new Product();
+        product.setRoleMappings(roleMappings);
+        product.setRoleMappingsByInstitutionType(roleMappingsByInstitutionType);
+
+        Map<PartyRole, List<ProductRoleInfo>> result = product.getAllRoleMappings();
+
+        assertEquals(3, result.size(), "Map should contain 3 keys");
+
+        // Verify MANAGER
+        List<ProductRoleInfo> adminList = result.get(PartyRole.MANAGER);
+        assertNotNull(adminList, "List for MANAGER should not be null");
+        assertEquals(2, adminList.size(), "List for MANAGER should contain 2 elements");
+        assertTrue(adminList.contains(dummmyProductRoleInfo(PartyRole.MANAGER)));
+        assertTrue(adminList.contains(dummmyProductRoleInfo(PartyRole.MANAGER)));
+
+        // Verify DELEGATE
+        List<ProductRoleInfo> userList = result.get(PartyRole.DELEGATE);
+        assertNotNull(userList, "List for DELEGATE should not be null");
+        assertEquals(2, userList.size(), "List for DELEGATE should contain 2 elements");
+        assertTrue(userList.contains(dummmyProductRoleInfo(PartyRole.DELEGATE)));
+        assertTrue(userList.contains(dummmyProductRoleInfo(PartyRole.DELEGATE)));
+
+        // Verify OPERATOR
+        List<ProductRoleInfo> guestList = result.get(PartyRole.OPERATOR);
+        assertNotNull(guestList, "List for OPERATOR should not be null");
+        assertEquals(2, guestList.size(), "List for OPERATOR should contain 2 elements");
+        assertTrue(guestList.contains(dummmyProductRoleInfo(PartyRole.OPERATOR)));
+        assertTrue(guestList.contains(dummmyProductRoleInfo(PartyRole.OPERATOR)));
+    }
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Fix getAllRoleMappings method

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
overlapping keys causes replace of roleMappings productRole association. This PR fix this issue maintain both productRoles list 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.