### PR TITLE
[SELC-5733] feat: create aggregates csv for prod-pagopa

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
@@ -22,6 +22,12 @@ public class AggregateInstitution {
     private String originId;
     private Origin origin;
     private List<User> users;
+    private String taxCodePT;
+    private String descriptionPT;
+    private String iban;
+    private String service;
+    private String syncAsyncMode;
+    private String recipientCode;
 
     public String getTaxCode() {
         return taxCode;
@@ -119,5 +125,48 @@ public class AggregateInstitution {
         this.originId = originId;
     }
 
+    public String getTaxCodePT() {
+        return taxCodePT;
+    }
+
+    public void setTaxCodePT(String taxCodePT) {
+        this.taxCodePT = taxCodePT;
+    }
+
+    public String getDescriptionPT() {
+        return descriptionPT;
+    }
+
+    public void setDescriptionPT(String descriptionPT) { this.descriptionPT = descriptionPT; }
+
+    public String getIban() {
+        return iban;
+    }
+
+    public void setIban(String iban) {
+        this.iban = iban;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) { this.service = service; }
+
+    public String getSyncAsyncMode() {
+        return syncAsyncMode;
+    }
+
+    public void setSyncAsyncMode(String syncAsyncMode) {
+        this.syncAsyncMode = syncAsyncMode;
+    }
+
+    public String getRecipientCode() {
+        return recipientCode;
+    }
+
+    public void setRecipientCode(String recipientCode) {
+        this.recipientCode = recipientCode;
+    }
 
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
@@ -37,10 +37,10 @@ import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.function.Function;
 
 import static it.pagopa.selfcare.onboarding.common.ProductId.*;
-import static it.pagopa.selfcare.onboarding.utils.GenericError.GENERIC_ERROR;
-import static it.pagopa.selfcare.onboarding.utils.GenericError.UNABLE_TO_DOWNLOAD_FILE;
+import static it.pagopa.selfcare.onboarding.utils.GenericError.*;
 import static it.pagopa.selfcare.onboarding.utils.PdfMapper.*;
 import static it.pagopa.selfcare.onboarding.utils.Utils.CONTRACT_FILENAME_FUNC;
 
@@ -60,11 +60,44 @@ public class ContractServiceDefault implements ContractService {
 
     private final String logoPath;
 
-    private static final String[] CSV_HEADERS = {
+    private static final String[] CSV_HEADERS_IO = {
             "Ragione Sociale", "PEC", "Codice Fiscale", "P.IVA",
             "Sede legale - Indirizzo", "Sede legale - Citta'", "Sede legale - Provincia (Sigla)",
             "Codice IPA", "AOO/UO", "Codice Univoco"
     };
+
+    private static final String[] CSV_HEADERS_PAGOPA = {
+            "Ragione Sociale", "PEC", "Codice Fiscale", "P.IVA",
+            "Sede legale - Indirizzo", "Sede legale - Citta'", "Sede legale - Provincia (Sigla)",
+            "Ragione Sociale Partener Tecnologico", "Codice Fiscale Partner Tecnologico",
+            "IBAN", "Servizio", "Modalità Sincrona/Asincrona"
+    };
+
+    private static final Function<AggregateInstitution, List<Object>> IO_MAPPER = institution -> Arrays.asList(
+            institution.getDescription(),
+            institution.getDigitalAddress(),
+            institution.getTaxCode(),
+            institution.getVatNumber(),
+            institution.getAddress(),
+            institution.getCity(),
+            institution.getCounty(),
+            Optional.ofNullable(institution.getSubunitType()).map(originId -> "").orElse(institution.getOriginId()),
+            institution.getSubunitType(),
+            institution.getSubunitCode());
+
+    private static final Function<AggregateInstitution, List<Object>> PAGOPA_MAPPER = institution -> Arrays.asList(
+            institution.getDescription(),
+            institution.getDigitalAddress(),
+            institution.getTaxCode(),
+            institution.getVatNumber(),
+            institution.getAddress(),
+            institution.getCity(),
+            institution.getCounty(),
+            institution.getDescriptionPT(),
+            institution.getTaxCodePT(),
+            institution.getIban(),
+            institution.getService(),
+            institution.getSyncAsyncMode());
 
 
     public ContractServiceDefault(AzureStorageConfig azureStorageConfig,
@@ -271,23 +304,47 @@ public class ContractServiceDefault implements ContractService {
         try {
             Onboarding onboarding = onboardingWorkflow.getOnboarding();
             Path filePath = Files.createTempFile("tempfile", ".csv");
-            File csv = generateCsv(onboarding.getAggregates(), filePath);
+            File csv = generateAggregatesCsv(onboarding.getProductId(), onboarding.getAggregates(), filePath);
             final String path = String.format("%s%s/%s", azureStorageConfig.aggregatesPath(), onboarding.getId(),
                     onboarding.getProductId());
             final String filename = "aggregates.csv";
             azureBlobClient.uploadFile(path, filename, Files.readAllBytes(csv.toPath()));
         } catch (IOException e) {
-            throw new GenericOnboardingException(String.format("Can not load aggregates CSV, message: %s", e.getMessage()));
+            throw new GenericOnboardingException(String.format(LOAD_AGGREGATES_CSV_ERROR.getMessage(), e.getMessage()));
         }
     }
 
-    private File generateCsv(List<AggregateInstitution> institutions, Path filePath) {
+    private File generateAggregatesCsv(String productId, List<AggregateInstitution> institutions, Path filePath) {
+        String[] headers;
+        Function<AggregateInstitution, List<Object>> mapper;
 
+        // Determine headers and mapping logic based on productId
+        switch (productId) {
+            case "prod-io":
+                headers = CSV_HEADERS_IO;
+                mapper = IO_MAPPER;
+                break;
+            case "prod-pagopa":
+                headers = CSV_HEADERS_PAGOPA;
+                mapper = PAGOPA_MAPPER;
+                break;
+            case "prod-pn":
+                return new File(String.valueOf(filePath)); //prod-pn is available for aggregator's workflow but csv structure is still not defined.
+            default:
+                throw new IllegalArgumentException(String.format("Product %s is not available for aggregators", productId));
+        }
+
+        return createAggregatesCsv(institutions, filePath, headers, mapper);
+
+    }
+
+    // Reusable CSV generation method
+    private File createAggregatesCsv(List<AggregateInstitution> institutions, Path filePath, String[] headers, Function<AggregateInstitution, List<Object>> mapper) {
         File csvFile = filePath.toFile();
 
         // Using the builder pattern to create the CSV format with headers
         CSVFormat csvFormat = CSVFormat.Builder.create(CSVFormat.DEFAULT)
-                .setHeader(CSV_HEADERS)
+                .setHeader(headers)
                 .setDelimiter(';')
                 .build();
 
@@ -296,24 +353,11 @@ public class ContractServiceDefault implements ContractService {
 
             // Iterate over each AggregateInstitution object and write a row for each one
             for (AggregateInstitution institution : institutions) {
-
-                // Write the row with the institution data
-                csvPrinter.printRecord(
-                        institution.getDescription(),
-                        institution.getDigitalAddress(),
-                        institution.getTaxCode(),
-                        institution.getVatNumber(),
-                        institution.getAddress(),
-                        institution.getCity(),
-                        institution.getCounty(),
-                        Optional.ofNullable(institution.getSubunitType()).map(originId -> "").orElse(institution.getOriginId()),
-                        institution.getSubunitType(),
-                        institution.getSubunitCode()
-                );
+                csvPrinter.printRecord(mapper.apply(institution));
             }
 
         } catch (IOException e) {
-            throw new GenericOnboardingException(String.format("Can not create aggregates CSV, message: %s", e.getMessage()));
+            throw new GenericOnboardingException(String.format(CREATE_AGGREGATES_CSV_ERROR.getMessage(), e.getMessage()));
         }
         return csvFile;
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
@@ -338,7 +338,6 @@ public class ContractServiceDefault implements ContractService {
 
     }
 
-    // Reusable CSV generation method
     private File createAggregatesCsv(List<AggregateInstitution> institutions, Path filePath, String[] headers, Function<AggregateInstitution, List<Object>> mapper) {
         File csvFile = filePath.toFile();
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/GenericError.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/GenericError.java
@@ -57,7 +57,10 @@ public enum GenericError {
     GET_INSTITUTION_BY_PRODUCTID_ERROR("0053", "Error while searching institutions related to given productId"),
     VERIFY_USER_ERROR("0000", "Error while searching institutions related to given productId"),
     GET_USER_ERROR("0000", "Error while searching user given UserID"),
-    GENERIC_ERROR("0000", "Generic Error");
+    GENERIC_ERROR("0000", "Generic Error"),
+    LOAD_AGGREGATES_CSV_ERROR("0000", "Can not load aggregates CSV, message: %s"),
+    CREATE_AGGREGATES_CSV_ERROR("0000", "Can not create aggregates CSV, message: %s");
+
     private final String code;
     private final String detail;
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.onboarding.config.PagoPaSignatureConfig;
 import it.pagopa.selfcare.onboarding.crypto.PadesSignService;
 import it.pagopa.selfcare.onboarding.entity.*;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,7 +22,6 @@ import org.openapi.quarkus.user_registry_json.model.UserResource;
 import org.openapi.quarkus.user_registry_json.model.WorkContactResource;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -318,7 +318,7 @@ class ContractServiceDefaultTest {
 
 
     @Test
-    void uploadCsvAggregatesIO() throws IOException {
+    void uploadCsvAggregatesIO() {
         final String contractHtml = "contract";
 
         OnboardingWorkflow onboardingWorkflow = createOnboardingWorkflowIO();
@@ -333,7 +333,7 @@ class ContractServiceDefaultTest {
     }
 
     @Test
-    void uploadCsvAggregatesPagoPa() throws IOException {
+    void uploadCsvAggregatesPagoPa() {
         final String contractHtml = "contract";
 
         OnboardingWorkflow onboardingWorkflow = createOnboardingWorkflowPagoPa();
@@ -344,6 +344,33 @@ class ContractServiceDefaultTest {
 
         Mockito.verify(azureBlobClient, times(1))
                 .uploadFile(any(), any(), any());
+
+    }
+
+    @Test
+    void uploadCsvAggregatesProdPn() {
+        final String contractHtml = "contract";
+
+        Onboarding onboarding = createOnboarding();
+        onboarding.setProductId("prod-pn");
+        OnboardingWorkflow onboardingWorkflow = new OnboardingWorkflowAggregator(onboarding, "string");
+
+        Mockito.when(azureBlobClient.uploadFile(any(), any(), any())).thenReturn(contractHtml);
+
+        contractService.uploadAggregatesCsv(onboardingWorkflow);
+
+        Mockito.verify(azureBlobClient, times(1))
+                .uploadFile(any(), any(), any());
+
+    }
+
+    @Test
+    void uploadCsvAggregatesProductNotValid() {
+        Onboarding onboarding = createOnboarding();
+        onboarding.setProductId("prod-interop");
+        OnboardingWorkflow onboardingWorkflow = new OnboardingWorkflowAggregator(onboarding, "string");;
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> contractService.uploadAggregatesCsv(onboardingWorkflow));
 
     }
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefaultTest.java
@@ -80,7 +80,7 @@ class ContractServiceDefaultTest {
         return onboarding;
     }
 
-    AggregateInstitution createAggregateInstitution(int number) {
+    AggregateInstitution createAggregateInstitutionIO(int number) {
         AggregateInstitution aggregateInstitution = new AggregateInstitution();
         aggregateInstitution.setTaxCode(String.format("taxCode%s", number));
         aggregateInstitution.setOriginId(String.format("originId%s", number));
@@ -93,24 +93,58 @@ class ContractServiceDefaultTest {
         return aggregateInstitution;
     }
 
-    AggregateInstitution createAggregateInstitutionAOO(int number) {
-        AggregateInstitution aggregateInstitution = createAggregateInstitution(number);
+    AggregateInstitution createAggregateInstitutionAOO_IO(int number) {
+        AggregateInstitution aggregateInstitution = createAggregateInstitutionIO(number);
         aggregateInstitution.setSubunitType("AOO");
         aggregateInstitution.setSubunitCode(String.format("code%s", number));
         return aggregateInstitution;
     }
 
-    OnboardingWorkflow createOnboardingWorkflow() {
+    AggregateInstitution createAggregateInstitutionPagoPa(int number) {
+        AggregateInstitution aggregateInstitution = new AggregateInstitution();
+        aggregateInstitution.setTaxCode(String.format("taxCode%s", number));
+        aggregateInstitution.setDescription(String.format("description%s", number));
+        aggregateInstitution.setVatNumber(String.format("vatNumber%s", number));
+        aggregateInstitution.setAddress(String.format("address%s", number));
+        aggregateInstitution.setCity(String.format("city%s", number));
+        aggregateInstitution.setCounty(String.format("county%s", number));
+        aggregateInstitution.setDigitalAddress(String.format("pec%s", number));
+        aggregateInstitution.setTaxCodePT(String.format("taxCodePT%s", number));
+        aggregateInstitution.setDescriptionPT(String.format("descriptionPT%s", number));
+        aggregateInstitution.setIban(String.format("iban%s", number));
+        aggregateInstitution.setService(String.format("service%s", number));
+        aggregateInstitution.setSyncAsyncMode(String.format("mode%s", number));
+        return aggregateInstitution;
+    }
+
+    OnboardingWorkflow createOnboardingWorkflowIO() {
         Onboarding onboarding = createOnboarding();
+        onboarding.setProductId("prod-io");
         List<AggregateInstitution> aggregateInstitutionList = new ArrayList<>();
 
         for (int i = 1; i <= 5; i++) {
-            AggregateInstitution aggregateInstitution = createAggregateInstitution(i);
+            AggregateInstitution aggregateInstitution = createAggregateInstitutionIO(i);
             aggregateInstitutionList.add(aggregateInstitution);
         }
 
         for(int i = 6; i<= 10; i++) {
-            AggregateInstitution aggregateInstitution = createAggregateInstitutionAOO(i);
+            AggregateInstitution aggregateInstitution = createAggregateInstitutionAOO_IO(i);
+            aggregateInstitutionList.add(aggregateInstitution);
+        }
+
+        onboarding.setAggregates(aggregateInstitutionList);
+
+        return new OnboardingWorkflowAggregator(onboarding, "string");
+
+    }
+
+    OnboardingWorkflow createOnboardingWorkflowPagoPa() {
+        Onboarding onboarding = createOnboarding();
+        onboarding.setProductId("prod-pagopa");
+        List<AggregateInstitution> aggregateInstitutionList = new ArrayList<>();
+
+        for (int i = 1; i <= 7; i++) {
+            AggregateInstitution aggregateInstitution = createAggregateInstitutionPagoPa(i);
             aggregateInstitutionList.add(aggregateInstitution);
         }
 
@@ -284,10 +318,25 @@ class ContractServiceDefaultTest {
 
 
     @Test
-    void uploadCsvAggregates() throws IOException {
+    void uploadCsvAggregatesIO() throws IOException {
         final String contractHtml = "contract";
 
-        OnboardingWorkflow onboardingWorkflow = createOnboardingWorkflow();
+        OnboardingWorkflow onboardingWorkflow = createOnboardingWorkflowIO();
+
+        Mockito.when(azureBlobClient.uploadFile(any(), any(), any())).thenReturn(contractHtml);
+
+        contractService.uploadAggregatesCsv(onboardingWorkflow);
+
+        Mockito.verify(azureBlobClient, times(1))
+                .uploadFile(any(), any(), any());
+
+    }
+
+    @Test
+    void uploadCsvAggregatesPagoPa() throws IOException {
+        final String contractHtml = "contract";
+
+        OnboardingWorkflow onboardingWorkflow = createOnboardingWorkflowPagoPa();
 
         Mockito.when(azureBlobClient.uploadFile(any(), any(), any())).thenReturn(contractHtml);
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/AggregateInstitution.java
@@ -20,7 +20,6 @@ public class AggregateInstitution {
     private Origin origin;
     private String vatNumber;
     private List<User> users;
-
     private String recipientCode;
     private String digitalAddress;
     private String city;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- modify method generateAggregatesCsv to include prod-pagopa
- add pagopa fields in AggregateInstitution
- add unit test

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running the branch locally and invoking Onboarding Orchestrator with the following scenarios:
- onboarding with status REQUEST, productId = "prod-io"
- onboarding with status REQUEST, productId = "prod-pagopa"
- onboarding with status REQUEST, productId = "prod-pn"
- onboarding with status REQUEST, productId not equal to "prod-io", "prod-pagopa", "prod-pn"

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.