### PR TITLE
[PNPG-250] feat: DELETE_MANAGERS_BY_IC_AND_ADE activity implementation

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -311,4 +311,10 @@ public class OnboardingFunctions {
         context.getLogger().info(String.format(FORMAT_LOGGER_ONBOARDING_STRING, CREATE_AGGREGATES_CSV_ACTIVITY, onboardingWorkflowString));
         contractService.uploadAggregatesCsv(readOnboardingWorkflowValue(objectMapper, onboardingWorkflowString));
     }
+
+    @FunctionName(DELETE_OLD_PG_MANAGERS_ACTIVITY)
+    public void deleteOldPgManagers(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
+        context.getLogger().info(() -> String.format(FORMAT_LOGGER_ONBOARDING_STRING, DELETE_OLD_PG_MANAGERS_ACTIVITY, onboardingString));
+        completionService.deleteOldPgManagers(readOnboardingValue(objectMapper, onboardingString));
+    }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -312,9 +312,9 @@ public class OnboardingFunctions {
         contractService.uploadAggregatesCsv(readOnboardingWorkflowValue(objectMapper, onboardingWorkflowString));
     }
 
-    @FunctionName(DELETE_OLD_PG_MANAGERS_ACTIVITY)
+    @FunctionName(DELETE_MANAGERS_BY_IC_AND_ADE)
     public void deleteOldPgManagers(@DurableActivityTrigger(name = "onboardingString") String onboardingString, final ExecutionContext context) {
-        context.getLogger().info(() -> String.format(FORMAT_LOGGER_ONBOARDING_STRING, DELETE_OLD_PG_MANAGERS_ACTIVITY, onboardingString));
+        context.getLogger().info(() -> String.format(FORMAT_LOGGER_ONBOARDING_STRING, DELETE_MANAGERS_BY_IC_AND_ADE, onboardingString));
         completionService.deleteOldPgManagers(readOnboardingValue(objectMapper, onboardingString));
     }
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -24,7 +24,7 @@ public class ActivityName {
     public static final String RESEND_NOTIFICATIONS_ACTIVITY = "ResendNotificationsActivity";
     public static final String CREATE_AGGREGATES_CSV_ACTIVITY = "CreateAggregatesCsv";
     public static final String EXISTS_DELEGATION_ACTIVITY = "ExistsDelegationActivity";
-    public static final String DELETE_OLD_PG_MANAGERS_ACTIVITY = "DeleteOldPgManagers";
+    public static final String DELETE_MANAGERS_BY_IC_AND_ADE = "DeleteManagersByIcAndAde";
 
     private ActivityName() {
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -24,6 +24,7 @@ public class ActivityName {
     public static final String RESEND_NOTIFICATIONS_ACTIVITY = "ResendNotificationsActivity";
     public static final String CREATE_AGGREGATES_CSV_ACTIVITY = "CreateAggregatesCsv";
     public static final String EXISTS_DELEGATION_ACTIVITY = "ExistsDelegationActivity";
+    public static final String DELETE_OLD_PG_MANAGERS_ACTIVITY = "DeleteOldPgManagers";
 
     private ActivityName() {
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionService.java
@@ -31,4 +31,6 @@ public interface CompletionService {
 
     String existsDelegation(OnboardingAggregateOrchestratorInput onboardingAggregateOrchestratorInput);
 
+    void deleteOldPgManagers(Onboarding onboarding);
+
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -470,7 +470,7 @@ public class CompletionServiceDefault implements CompletionService {
     private void deleteManagerFromProduct(String uid, String institutionId, String productId) {
         try (Response response = userApi.usersUserIdInstitutionsInstitutionIdProductsProductIdDelete(institutionId, productId, uid)) {
             if (!SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
-                throw new GenericOnboardingException("Impossible to delete user: " + uid);
+                throw new GenericOnboardingException(String.format("Failed to delete user %s from product %s in institution %s", uid, productId, institutionId));
             }
         }
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -421,7 +421,7 @@ public class CompletionServiceDefault implements CompletionService {
 
         return activeManagers.stream()
                 .map(UserInstitutionResponse::getUserId)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private String retrieveTaxCode(String uid) {
@@ -470,7 +470,7 @@ public class CompletionServiceDefault implements CompletionService {
     private void deleteManagerFromProduct(String uid, String institutionId, String productId) {
         try (Response response = userApi.usersUserIdInstitutionsInstitutionIdProductsProductIdDelete(institutionId, productId, uid)) {
             if (!SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
-                throw new RuntimeException("Impossible to delete user: " + uid);
+                throw new GenericOnboardingException("Impossible to delete user: " + uid);
             }
         }
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -1,10 +1,7 @@
 package it.pagopa.selfcare.onboarding.service;
 
 import com.microsoft.azure.functions.ExecutionContext;
-import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
-import it.pagopa.selfcare.onboarding.common.InstitutionType;
-import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
-import it.pagopa.selfcare.onboarding.common.Origin;
+import it.pagopa.selfcare.onboarding.common.*;
 import it.pagopa.selfcare.onboarding.dto.OnboardingAggregateOrchestratorInput;
 import it.pagopa.selfcare.onboarding.entity.*;
 import it.pagopa.selfcare.onboarding.exception.GenericOnboardingException;
@@ -28,8 +25,16 @@ import org.openapi.quarkus.core_json.api.DelegationApi;
 import org.openapi.quarkus.core_json.api.InstitutionApi;
 import org.openapi.quarkus.core_json.model.*;
 import org.openapi.quarkus.party_registry_proxy_json.api.AooApi;
+import org.openapi.quarkus.party_registry_proxy_json.api.InfocamereApi;
+import org.openapi.quarkus.party_registry_proxy_json.api.NationalRegistriesApi;
 import org.openapi.quarkus.party_registry_proxy_json.api.UoApi;
+import org.openapi.quarkus.party_registry_proxy_json.model.BusinessesResource;
+import org.openapi.quarkus.party_registry_proxy_json.model.GetInstitutionsByLegalDto;
+import org.openapi.quarkus.party_registry_proxy_json.model.GetInstitutionsByLegalFilterDto;
+import org.openapi.quarkus.party_registry_proxy_json.model.LegalVerificationResult;
 import org.openapi.quarkus.user_json.model.AddUserRoleDto;
+import org.openapi.quarkus.user_json.model.OnboardedProductState;
+import org.openapi.quarkus.user_json.model.UserInstitutionResponse;
 import org.openapi.quarkus.user_registry_json.api.UserApi;
 
 import java.time.LocalDateTime;
@@ -43,7 +48,6 @@ import java.util.stream.Collectors;
 import static it.pagopa.selfcare.onboarding.common.OnboardingStatus.REJECTED;
 import static it.pagopa.selfcare.onboarding.common.PartyRole.MANAGER;
 import static it.pagopa.selfcare.onboarding.common.WorkflowType.CONFIRMATION_AGGREGATE;
-import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_FIELD_LIST;
 import static jakarta.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static org.openapi.quarkus.core_json.model.DelegationResponse.StatusEnum.ACTIVE;
 
@@ -71,6 +75,16 @@ public class CompletionServiceDefault implements CompletionService {
     @RestClient
     @Inject
     org.openapi.quarkus.party_registry_proxy_json.api.InstitutionApi institutionRegistryProxyApi;
+    @RestClient
+    @Inject
+    org.openapi.quarkus.user_json.api.InstitutionApi userInstitutionApi;
+    @RestClient
+    @Inject
+    InfocamereApi infocamereApi;
+    @RestClient
+    @Inject
+    NationalRegistriesApi nationalRegistriesApi;
+
 
     private final InstitutionMapper institutionMapper;
     private final OnboardingRepository onboardingRepository;
@@ -82,6 +96,7 @@ public class CompletionServiceDefault implements CompletionService {
     private final OnboardingMapper onboardingMapper;
     private final boolean hasToSendEmail;
     private final boolean forceInstitutionCreation;
+    private static final String USERS_FIELD_LIST = "fiscalCode,familyName,name";
 
     public CompletionServiceDefault(ProductService productService,
                                     NotificationService notificationService,
@@ -375,5 +390,106 @@ public class CompletionServiceDefault implements CompletionService {
                 .filter(workContract -> StringUtils.isNotBlank(workContract.getEmail().getValue()))
                 .map(workContract -> workContract.getEmail().getValue())
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteOldPgManagers(Onboarding onboarding) {
+        String institutionId = onboarding.getInstitution().getId();
+        String productId = onboarding.getProductId();
+        List<String> oldPgManagersUid = retrieveActiveManagersOnInstitution(institutionId, productId);
+        Origin origin = onboarding.getInstitution().getOrigin();
+
+        oldPgManagersUid.stream()
+            .map(uid -> new PgManagerInfo(uid, retrieveTaxCode(uid)))
+            .filter(pgManagerInfo -> !isActiveManagerOnRegistries(pgManagerInfo.getTaxCode(), onboarding.getInstitution().getTaxCode(), origin))
+            .forEach(pgManagerInfo -> deleteManagerFromProduct(pgManagerInfo.getUid(), institutionId, productId));
+    }
+
+    private List<String> retrieveActiveManagersOnInstitution(String institutionId, String productId) {
+        List<UserInstitutionResponse> activeManagers = userInstitutionApi.institutionsInstitutionIdUserInstitutionsGet(
+                institutionId,
+                null,
+                List.of(productId),
+                List.of(MANAGER.name()),
+                List.of(OnboardedProductState.ACTIVE.name()),
+                null
+        );
+
+        if(Objects.isNull(activeManagers) || CollectionUtils.isEmpty(activeManagers)) {
+            return Collections.emptyList();
+        }
+
+        return activeManagers.stream()
+                .map(UserInstitutionResponse::getUserId)
+                .collect(Collectors.toList());
+    }
+
+    private String retrieveTaxCode(String uid) {
+        return userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, uid).getFiscalCode();
+    }
+
+    private boolean isActiveManagerOnRegistries(String userTaxCode, String institutionTaxCode, Origin origin) {
+        return switch (origin) {
+            case INFOCAMERE -> isActiveManagerOnInfocamereRegistry(userTaxCode, institutionTaxCode);
+            case ADE -> isActiveManagerOnAdeRegistry(userTaxCode, institutionTaxCode);
+            default -> throw new GenericOnboardingException("Origin not supported");
+        };
+    }
+
+    private boolean isActiveManagerOnInfocamereRegistry(String userTaxCode, String institutionTaxCode) {
+        BusinessesResource businessesResource = infocamereApi.institutionsByLegalTaxIdUsingPOST(toGetInstitutionByLegalDto(userTaxCode));
+        if(Objects.isNull(businessesResource) || CollectionUtils.isEmpty(businessesResource.getBusinesses())) {
+            return false;
+        }
+
+        return businessesResource.getBusinesses().stream()
+                .anyMatch(business -> institutionTaxCode.equals(business.getBusinessTaxId()));
+    }
+
+    private GetInstitutionsByLegalDto toGetInstitutionByLegalDto(String userTaxCode) {
+        GetInstitutionsByLegalDto getInstitutionsByLegalDto = new GetInstitutionsByLegalDto();
+        GetInstitutionsByLegalFilterDto getInstitutionsByLegalFilterDto = new GetInstitutionsByLegalFilterDto();
+        getInstitutionsByLegalFilterDto.setLegalTaxId(userTaxCode);
+        getInstitutionsByLegalDto.setFilter(getInstitutionsByLegalFilterDto);
+        return getInstitutionsByLegalDto;
+    }
+
+    private boolean isActiveManagerOnAdeRegistry(String userTaxCode, String institutionTaxCode) {
+        try {
+            LegalVerificationResult legalVerificationResult = nationalRegistriesApi.verifyLegalUsingGET(userTaxCode, institutionTaxCode);
+            return legalVerificationResult.getVerificationResult();
+        } catch (WebApplicationException e) {
+            // 400 status code means that the user is not a manager of the institution
+            if (e.getResponse().getStatus() == 400) {
+                return false;
+            }
+            throw new GenericOnboardingException(String.format("Error during verify legal %s", e.getMessage()));
+        }
+    }
+
+    private void deleteManagerFromProduct(String uid, String institutionId, String productId) {
+        try (Response response = userApi.usersUserIdInstitutionsInstitutionIdProductsProductIdDelete(institutionId, productId, uid)) {
+            if (!SUCCESSFUL.equals(response.getStatusInfo().getFamily())) {
+                throw new RuntimeException("Impossible to delete user: " + uid);
+            }
+        }
+    }
+
+    private static class PgManagerInfo {
+        private final String uid;
+        private final String taxCode;
+
+        public PgManagerInfo(String uid, String taxCode) {
+            this.uid = uid;
+            this.taxCode = taxCode;
+        }
+
+        public String getUid() {
+            return uid;
+        }
+
+        public String getTaxCode() {
+            return taxCode;
+        }
     }
 }

--- a/apps/onboarding-functions/src/main/resources/application.properties
+++ b/apps/onboarding-functions/src/main/resources/application.properties
@@ -62,6 +62,9 @@ quarkus.openapi-generator.codegen.spec.user_json.additional-api-type-annotations
 quarkus.rest-client."org.openapi.quarkus.user_json.api.UserApi".url=${MS_USER_URL:http://localhost:8081}
 quarkus.rest-client."org.openapi.quarkus.user_json.api.UserApi".read-timeout=60000
 quarkus.rest-client."org.openapi.quarkus.user_json.api.UserApi".connection-pool-size=1024
+quarkus.rest-client."org.openapi.quarkus.user_json.api.InstitutionApi".url=${MS_USER_URL:http://localhost:8081}
+quarkus.rest-client."org.openapi.quarkus.user_json.api.InstitutionApi".read-timeout=60000
+quarkus.rest-client."org.openapi.quarkus.user_json.api.InstitutionApi".connection-pool-size=1024
 
 quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.enable-security-generation=false
 quarkus.openapi-generator.codegen.spec.party_registry_proxy_json.additional-api-type-annotations=@org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders(it.pagopa.selfcare.onboarding.client.auth.AuthenticationPropagationHeadersFactory.class)
@@ -69,10 +72,14 @@ quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.UoApi".ur
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.AooApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.InstitutionApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.GeographicTaxonomiesApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.InfocamereApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.NationalRegistriesApi".url=${MS_PARTY_REGISTRY_URL:http://localhost:8080}
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.UoApi".read-timeout=30000
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.AooApi".read-timeout=30000
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.InstitutionApi".read-timeout=30000
 quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.GeographicTaxonomiesApi".read-timeout=30000
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.InfocamereApi".read-timeout=30000
+quarkus.rest-client."org.openapi.quarkus.party_registry_proxy_json.api.NationalRegistriesApi".read-timeout=30000
 
 
 ## AZURE STORAGE ##

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -882,4 +882,17 @@ class OnboardingFunctionsTest {
         verify(completionService, times(1))
                 .sendTestEmail(executionContext);
     }
+
+    @Test
+    void deleteOldPgManagers() {
+        final String onboardingString = "{\"onboardingId\":\"onboardingId\"}";
+
+        when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
+        doNothing().when(completionService).deleteOldPgManagers(any());
+
+        function.deleteOldPgManagers(onboardingString, executionContext);
+
+        verify(completionService, times(1))
+                .deleteOldPgManagers(any());
+    }
 }


### PR DESCRIPTION
#### List of Changes

DELETE_OLD_PG_MANAGERS activity implementation

#### Motivation and Context

This activity is responsible of finding all the managers of an institution and check on related registry (ADE or INFOCAMERE) if they are still managers. In case they are not managers anymore will be deleted from institution.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.