### PR TITLE
[PNPG-249] feat: added WorkflowExecutorForUsersPg

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -157,6 +157,7 @@ public class OnboardingFunctions {
                 case IMPORT -> workflowExecutor = new WorkflowExecutorImport(objectMapper, optionsRetry);
                 case USERS -> workflowExecutor = new WorkflowExecutorForUsers(objectMapper, optionsRetry);
                 case INCREMENT_REGISTRATION_AGGREGATOR -> workflowExecutor = new WorkflowExecutorIncrementRegistrationAggregator(objectMapper, optionsRetry, onboardingMapper);
+                case USERS_PG -> workflowExecutor = new WorkflowExecutorForUsersPg(objectMapper, optionsRetry);
                 default -> throw new IllegalArgumentException("Workflow options not found!");
             }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -24,7 +24,7 @@ public class ActivityName {
     public static final String RESEND_NOTIFICATIONS_ACTIVITY = "ResendNotificationsActivity";
     public static final String CREATE_AGGREGATES_CSV_ACTIVITY = "CreateAggregatesCsv";
     public static final String EXISTS_DELEGATION_ACTIVITY = "ExistsDelegationActivity";
-    public static final String DELETE_OLD_PG_MANAGERS_ACTIVITY = "DeleteOldPgManagers";
+    public static final String DELETE_MANAGERS_BY_IC_AND_ADE = "DeleteManagersByIcAndAde";
 
     private ActivityName() {
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -24,6 +24,7 @@ public class ActivityName {
     public static final String RESEND_NOTIFICATIONS_ACTIVITY = "ResendNotificationsActivity";
     public static final String CREATE_AGGREGATES_CSV_ACTIVITY = "CreateAggregatesCsv";
     public static final String EXISTS_DELEGATION_ACTIVITY = "ExistsDelegationActivity";
+    public static final String DELETE_OLD_PG_MANAGERS_ACTIVITY = "DeleteOldPgManagers";
 
     private ActivityName() {
     }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
@@ -31,6 +31,7 @@ public record WorkflowExecutorForUsersPg(ObjectMapper objectMapper, TaskOptions 
         final String onboardingString = getOnboardingString(objectMapper(), onboardingWorkflow.getOnboarding());
         ctx.callActivity(DELETE_MANAGERS_BY_IC_AND_ADE, onboardingString, optionsRetry(), String.class).await();
         ctx.callActivity(CREATE_USERS_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
+        ctx.callActivity(STORE_ONBOARDING_ACTIVATEDAT, onboardingString, optionsRetry(), String.class).await();
         return Optional.of(COMPLETED);
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
@@ -1,0 +1,41 @@
+package it.pagopa.selfcare.onboarding.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.durabletask.TaskOptions;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
+import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowUser;
+
+import java.util.Optional;
+
+import static it.pagopa.selfcare.onboarding.common.OnboardingStatus.COMPLETED;
+import static it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowType.USER;
+import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
+import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingString;
+
+public record WorkflowExecutorForUsersPg(ObjectMapper objectMapper, TaskOptions optionsRetry) implements WorkflowExecutor {
+    @Override
+    public Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<OnboardingStatus> executeToBeValidatedState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
+        final String onboardingString = getOnboardingString(objectMapper(), onboardingWorkflow.getOnboarding());
+        ctx.callActivity(DELETE_OLD_PG_MANAGERS_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
+        ctx.callActivity(CREATE_USERS_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
+        return Optional.of(COMPLETED);
+    }
+
+    @Override
+    public OnboardingWorkflow createOnboardingWorkflow(Onboarding onboarding) {
+        return new OnboardingWorkflowUser(onboarding, USER.name());
+    }
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForUsersPg.java
@@ -29,7 +29,7 @@ public record WorkflowExecutorForUsersPg(ObjectMapper objectMapper, TaskOptions 
     @Override
     public Optional<OnboardingStatus> executePendingState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
         final String onboardingString = getOnboardingString(objectMapper(), onboardingWorkflow.getOnboarding());
-        ctx.callActivity(DELETE_OLD_PG_MANAGERS_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
+        ctx.callActivity(DELETE_MANAGERS_BY_IC_AND_ADE, onboardingString, optionsRetry(), String.class).await();
         ctx.callActivity(CREATE_USERS_ACTIVITY, onboardingString, optionsRetry(), String.class).await();
         return Optional.of(COMPLETED);
     }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -749,10 +749,11 @@ class OnboardingFunctionsTest {
         function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        verify(orchestrationContext, times(3))
+        verify(orchestrationContext, times(4))
                 .callActivity(captorActivity.capture(), any(), any(),any());
         assertEquals(DELETE_MANAGERS_BY_IC_AND_ADE, captorActivity.getAllValues().get(0));
         assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(1));
+        assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(2));
     }
 
     @Test

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -736,6 +736,26 @@ class OnboardingFunctionsTest {
     }
 
     @Test
+    void usersPgOrchestrator() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("onboardingId");
+        onboarding.setStatus(OnboardingStatus.PENDING);
+        onboarding.setWorkflowType(WorkflowType.USERS_PG);
+        onboarding.setInstitution(new Institution());
+
+        TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+
+
+        function.onboardingsOrchestrator(orchestrationContext, executionContext);
+
+        ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+        verify(orchestrationContext, times(3))
+                .callActivity(captorActivity.capture(), any(), any(),any());
+        assertEquals(DELETE_OLD_PG_MANAGERS_ACTIVITY, captorActivity.getAllValues().get(0));
+        assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(1));
+    }
+
+    @Test
     void createInstitutionAndPersistInstitutionId() {
 
         final String institutionId = "institutionId";

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -736,7 +736,7 @@ class OnboardingFunctionsTest {
     }
 
     @Test
-    void usersPgOrchestrator() {
+    void usersPgOrchestrator_whenStatusPending() {
         Onboarding onboarding = new Onboarding();
         onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.PENDING);
@@ -756,7 +756,7 @@ class OnboardingFunctionsTest {
     }
 
     @Test
-    void usersPgOrchestrator2() {
+    void usersPgOrchestrator_whenStatusRequest() {
         Onboarding onboarding = new Onboarding();
         onboarding.setId("onboardingId");
         onboarding.setStatus(OnboardingStatus.REQUEST);

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -769,7 +769,7 @@ class OnboardingFunctionsTest {
         function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-        verify(orchestrationContext, times(1))
+        verify(orchestrationContext, times(0))
                 .callActivity(captorActivity.capture(), any(), any(),any());
     }
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -756,6 +756,24 @@ class OnboardingFunctionsTest {
     }
 
     @Test
+    void usersPgOrchestrator2() {
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("onboardingId");
+        onboarding.setStatus(OnboardingStatus.REQUEST);
+        onboarding.setWorkflowType(WorkflowType.USERS_PG);
+        onboarding.setInstitution(new Institution());
+
+        TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+
+
+        function.onboardingsOrchestrator(orchestrationContext, executionContext);
+
+        ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+        verify(orchestrationContext, times(1))
+                .callActivity(captorActivity.capture(), any(), any(),any());
+    }
+
+    @Test
     void createInstitutionAndPersistInstitutionId() {
 
         final String institutionId = "institutionId";

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -751,7 +751,7 @@ class OnboardingFunctionsTest {
         ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
         verify(orchestrationContext, times(3))
                 .callActivity(captorActivity.capture(), any(), any(),any());
-        assertEquals(DELETE_OLD_PG_MANAGERS_ACTIVITY, captorActivity.getAllValues().get(0));
+        assertEquals(DELETE_MANAGERS_BY_IC_AND_ADE, captorActivity.getAllValues().get(0));
         assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(1));
     }
 


### PR DESCRIPTION
#### List of Changes

added WorkflowExecutorForUsersPg

#### Motivation and Context

This workflow is able to perform the deletion of old pg managers inactive, and create the new manager.

#### How Has This Been Tested?


#### Screenshots (if appropriate):

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.