### PR TITLE
[SELC-5786] feat: set admin aggregate's role to ADMIN_EA

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -5,7 +5,6 @@ import it.pagopa.selfcare.onboarding.entity.AggregateInstitution;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.User;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,6 +12,9 @@ import org.mapstruct.Named;
 
 import java.util.List;
 import java.util.Objects;
+
+import static it.pagopa.selfcare.onboarding.common.PartyRole.ADMIN_EA;
+import static it.pagopa.selfcare.onboarding.common.ProductId.PROD_PAGOPA;
 
 @Mapper(componentModel = "cdi")
 public interface OnboardingMapper {
@@ -45,6 +47,9 @@ public interface OnboardingMapper {
     default List<User> mapAggregateUsers(Onboarding onboarding, AggregateInstitution aggregateInstitution) {
         if (Objects.nonNull(aggregateInstitution) && !CollectionUtils.isEmpty(aggregateInstitution.getUsers())) {
             return aggregateInstitution.getUsers();
+        }
+        if(PROD_PAGOPA.getValue().equals(onboarding.getProductId())){
+            onboarding.getUsers().forEach(user -> user.setRole(ADMIN_EA));
         }
         return onboarding.getUsers();
     }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingMapperTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/OnboardingMapperTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static it.pagopa.selfcare.onboarding.common.ProductId.PROD_PAGOPA;
+
 @QuarkusTest
 class OnboardingMapperTest {
 
@@ -66,6 +68,28 @@ class OnboardingMapperTest {
         Assertions.assertEquals(1, response.getUsers().size());
         Assertions.assertEquals("aggregatorUser", response.getUsers().get(0).getId());
         Assertions.assertEquals(PartyRole.MANAGER, response.getUsers().get(0).getRole());
+        Assertions.assertEquals("aggregatorProductRole", response.getUsers().get(0).getProductRole());
+    }
+
+    @Test
+    void mapToOnboardingAggregateOrchestratorInputTestWithoutAggregatesUserProdPagoPA(){
+        Onboarding onboarding = new Onboarding();
+        onboarding.setId("example");
+        onboarding.setProductId(PROD_PAGOPA.getValue());
+        User user = new User();
+        user.setId("aggregatorUser");
+        user.setRole(PartyRole.MANAGER);
+        user.setProductRole("aggregatorProductRole");
+        onboarding.setUsers(List.of(user));
+
+        AggregateInstitution aggregateInstitution = new AggregateInstitution();
+        aggregateInstitution.setUsers(null);
+        onboarding.setAggregates(List.of(aggregateInstitution));
+
+        OnboardingAggregateOrchestratorInput response = onboardingMapper.mapToOnboardingAggregateOrchestratorInput(onboarding, aggregateInstitution);
+        Assertions.assertEquals(1, response.getUsers().size());
+        Assertions.assertEquals("aggregatorUser", response.getUsers().get(0).getId());
+        Assertions.assertEquals(PartyRole.ADMIN_EA, response.getUsers().get(0).getRole());
         Assertions.assertEquals("aggregatorProductRole", response.getUsers().get(0).getProductRole());
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- set  admin aggregate's role to ADMIN_EA when product is PagoPA

<!--- Describe your changes in detail -->

#### Motivation and Context
The setting of role ADMIN_EA for PagoPA aggregates was needed to manage the actions allowed for pagoPA aggregates.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by invoking Onboarding Orchestrator locally on a onboarding with aggregates and product prod-pagopa

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.