### PR TITLE
[SELC-5804] fix: Removed required field filename for import psp

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -2309,11 +2309,10 @@
         }
       },
       "OnboardingImportContract" : {
-        "required" : [ "fileName", "filePath", "createdAt" ],
+        "required" : [ "filePath", "createdAt" ],
         "type" : "object",
         "properties" : {
           "fileName" : {
-            "minLength" : 1,
             "type" : "string"
           },
           "filePath" : {

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -1670,13 +1670,11 @@ components:
             $ref: "#/components/schemas/OnboardingGet"
     OnboardingImportContract:
       required:
-      - fileName
       - filePath
       - createdAt
       type: object
       properties:
         fileName:
-          minLength: 1
           type: string
         filePath:
           minLength: 1

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingImportContract.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/request/OnboardingImportContract.java
@@ -15,7 +15,6 @@ import java.time.LocalDateTime;
 @Builder
 public class OnboardingImportContract {
 
-    @NotEmpty(message = "fileName is required")
     private String fileName;
     @NotEmpty(message = "filePath is required")
     private String filePath;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

 Removed required field filenamefor import psp

#### Motivation and Context

This constraint's deletion is necessary for external-api in order to invoke the psp import api without this parameter (that in this case will be built from product json)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.