### PR TITLE
[SELC - 6127] feat: updated onboardingCompletion APIs logic to accept file in input

### DIFF
--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -502,9 +502,19 @@
         "operationId" : "onboardingCompletion",
         "requestBody" : {
           "content" : {
-            "application/json" : {
+            "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/OnboardingDefaultRequest"
+                "required" : [ "contract", "onboardingRequest" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "format" : "binary",
+                    "type" : "string"
+                  },
+                  "onboardingRequest" : {
+                    "type" : "string"
+                  }
+                }
               }
             }
           }
@@ -680,9 +690,19 @@
         "operationId" : "onboardingPaCompletion",
         "requestBody" : {
           "content" : {
-            "application/json" : {
+            "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/OnboardingPaRequest"
+                "required" : [ "contract", "onboardingRequest" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "format" : "binary",
+                    "type" : "string"
+                  },
+                  "onboardingRequest" : {
+                    "type" : "string"
+                  }
+                }
               }
             }
           }
@@ -832,9 +852,19 @@
         "operationId" : "onboardingPspCompletion",
         "requestBody" : {
           "content" : {
-            "application/json" : {
+            "multipart/form-data" : {
               "schema" : {
-                "$ref" : "#/components/schemas/OnboardingPspRequest"
+                "required" : [ "contract", "onboardingRequest" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "format" : "binary",
+                    "type" : "string"
+                  },
+                  "onboardingRequest" : {
+                    "type" : "string"
+                  }
+                }
               }
             }
           }

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -366,9 +366,18 @@ paths:
       operationId: onboardingCompletion
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: "#/components/schemas/OnboardingDefaultRequest"
+              required:
+              - contract
+              - onboardingRequest
+              type: object
+              properties:
+                contract:
+                  format: binary
+                  type: string
+                onboardingRequest:
+                  type: string
       responses:
         "200":
           description: OK
@@ -498,9 +507,18 @@ paths:
       operationId: onboardingPaCompletion
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: "#/components/schemas/OnboardingPaRequest"
+              required:
+              - contract
+              - onboardingRequest
+              type: object
+              properties:
+                contract:
+                  format: binary
+                  type: string
+                onboardingRequest:
+                  type: string
       responses:
         "200":
           description: OK
@@ -606,9 +624,18 @@ paths:
       operationId: onboardingPspCompletion
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: "#/components/schemas/OnboardingPspRequest"
+              required:
+              - contract
+              - onboardingRequest
+              type: object
+              properties:
+                contract:
+                  format: binary
+                  type: string
+                onboardingRequest:
+                  type: string
       responses:
         "200":
           description: OK

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Objects;
 
+import static it.pagopa.selfcare.onboarding.util.Utils.parseOnboardingRequest;
 import static it.pagopa.selfcare.onboarding.util.Utils.retrieveContractFromFormData;
 
 @Authenticated
@@ -169,26 +170,58 @@ public class OnboardingController {
     )
     @Path("/completion")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingCompletion(@Valid OnboardingDefaultRequest onboardingRequest, @Context SecurityContext ctx) {
-        return readUserIdFromToken(ctx)
-                .onItem().transformToUni(userId -> onboardingService
-                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
+    public Uni<OnboardingResponse> onboardingCompletion(
+            @NotNull @RestForm("contract") File file,
+            @NotNull @RestForm("onboardingRequest") String onboardingRequestJson,
+            @Context ResteasyReactiveRequestContext ctx,
+            @Context SecurityContext securityContext) {
+
+        return readUserIdFromToken(securityContext)
+                .onItem()
+                .transformToUni(
+                        userId -> {
+                            // Parse JSON into OnboardingDefaultRequest
+                            OnboardingDefaultRequest onboardingRequest =
+                                    parseOnboardingRequest(onboardingRequestJson, OnboardingDefaultRequest.class);
+
+                            // Call the onboarding service
+                            return onboardingService.onboardingCompletion(
+                                    fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
+                                    onboardingRequest.getUsers(),
+                                    retrieveContractFromFormData(ctx.getFormData(), file));
+                        });
     }
 
     @Operation(
             summary = "Complete PA onboarding request and set status to COMPLETED.",
-            description = "Perform onboarding as /onboarding/pa but completing the onboarding request to COMPLETED phase."
-    )
+            description =
+                    "Perform onboarding as /onboarding/pa but completing the onboarding request to COMPLETED phase.")
     @POST
     @Path("/pa/completion")
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingPaCompletion(@Valid OnboardingPaRequest onboardingRequest, @Context SecurityContext ctx) {
-        return readUserIdFromToken(ctx)
-                .onItem().transformToUni(userId -> onboardingService
-                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
+    public Uni<OnboardingResponse> onboardingPaCompletion(
+            @NotNull @RestForm("contract") File file,
+            @NotNull @RestForm("onboardingRequest") String onboardingRequestJson,
+            @Context ResteasyReactiveRequestContext ctx,
+            @Context SecurityContext securityContext) {
+
+        return readUserIdFromToken(securityContext)
+                .onItem()
+                .transformToUni(
+                        userId -> {
+                            // Parse JSON into OnboardingDefaultRequest
+                            OnboardingPaRequest onboardingRequest =
+                                    parseOnboardingRequest(onboardingRequestJson, OnboardingPaRequest.class);
+
+                            // Call the onboarding service
+                            return onboardingService.onboardingCompletion(
+                                    fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
+                                    onboardingRequest.getUsers(),
+                                    retrieveContractFromFormData(ctx.getFormData(), file));
+                        });
     }
 
     @Operation(
@@ -221,16 +254,32 @@ public class OnboardingController {
 
     @Operation(
             summary = "Complete PSP onboarding request and set status to COMPLETED.",
-            description = "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase."
-    )
+            description =
+                    "Perform onboarding as /onboarding/psp but completing the onboarding request to COMPLETED phase.")
     @POST
     @Path("/psp/completion")
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingPspCompletion(@Valid OnboardingPspRequest onboardingRequest, @Context SecurityContext ctx) {
-        return readUserIdFromToken(ctx)
-                .onItem().transformToUni(userId -> onboardingService
-                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
+    public Uni<OnboardingResponse> onboardingPspCompletion(
+            @NotNull @RestForm("contract") File file,
+            @NotNull @RestForm("onboardingRequest") String onboardingRequestJson,
+            @Context ResteasyReactiveRequestContext ctx,
+            @Context SecurityContext securityContext) {
+
+        return readUserIdFromToken(securityContext)
+                .onItem()
+                .transformToUni(
+                        userId -> {
+                            // Parse JSON into OnboardingDefaultRequest
+                            OnboardingPspRequest onboardingRequest =
+                                    parseOnboardingRequest(onboardingRequestJson, OnboardingPspRequest.class);
+
+                            // Call the onboarding service
+                            return onboardingService.onboardingCompletion(
+                                    fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
+                                    onboardingRequest.getUsers(),
+                                    retrieveContractFromFormData(ctx.getFormData(), file));
+                        });
     }
 
     @Operation(
@@ -246,7 +295,7 @@ public class OnboardingController {
     public Uni<OnboardingResponse> onboardingPgCompletion(@Valid OnboardingPgRequest onboardingRequest, @Context SecurityContext ctx) {
         return readUserIdFromToken(ctx)
                 .onItem().transformToUni(userId -> onboardingService
-                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
+                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers(), null));
     }
 
     @Operation(

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -212,7 +212,7 @@ public class OnboardingController {
                 .onItem()
                 .transformToUni(
                         userId -> {
-                            // Parse JSON into OnboardingDefaultRequest
+                            // Parse JSON into OnboardingPaRequest
                             OnboardingPaRequest onboardingRequest =
                                     parseOnboardingRequest(onboardingRequestJson, OnboardingPaRequest.class);
 
@@ -270,7 +270,7 @@ public class OnboardingController {
                 .onItem()
                 .transformToUni(
                         userId -> {
-                            // Parse JSON into OnboardingDefaultRequest
+                            // Parse JSON into OnboardingPspRequest
                             OnboardingPspRequest onboardingRequest =
                                     parseOnboardingRequest(onboardingRequestJson, OnboardingPspRequest.class);
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -20,15 +20,27 @@ import java.util.List;
 
 public interface OnboardingService {
 
-    Uni<OnboardingResponse> onboarding(Onboarding onboarding, List<UserRequest> userRequests, List<AggregateInstitutionRequest> aggregates);
+    Uni<OnboardingResponse> onboarding(
+            Onboarding onboarding,
+            List<UserRequest> userRequests,
+            List<AggregateInstitutionRequest> aggregates);
 
-    Uni<OnboardingResponse> onboardingUsers(OnboardingUserRequest onboardingUserRequest, String userId, WorkflowType workflowType);
+    Uni<OnboardingResponse> onboardingUsers(
+            OnboardingUserRequest onboardingUserRequest, String userId, WorkflowType workflowType);
 
-    Uni<OnboardingResponse> onboardingImport(Onboarding onboarding, List<UserRequest> userRequests, OnboardingImportContract contractImported, boolean forceImport);
+    Uni<OnboardingResponse> onboardingImport(
+            Onboarding onboarding,
+            List<UserRequest> userRequests,
+            OnboardingImportContract contractImported,
+            boolean forceImport);
 
-    Uni<OnboardingResponse> onboardingCompletion(Onboarding onboarding, List<UserRequest> userRequests);
+    Uni<OnboardingResponse> onboardingCompletion(
+            Onboarding onboarding, List<UserRequest> userRequests, FormItem formItem);
 
-    Uni<OnboardingResponse> onboardingAggregationCompletion(Onboarding onboarding, List<UserRequest> userRequests, List<AggregateInstitutionRequest> aggregates);
+    Uni<OnboardingResponse> onboardingAggregationCompletion(
+            Onboarding onboarding,
+            List<UserRequest> userRequests,
+            List<AggregateInstitutionRequest> aggregates);
 
     Uni<OnboardingResponse> onboardingUserPg(Onboarding onboarding, List<UserRequest> userRequests);
 
@@ -46,9 +58,16 @@ public interface OnboardingService {
 
     Uni<OnboardingGet> onboardingPending(String onboardingId);
 
-    Uni<List<OnboardingResponse>> institutionOnboardings(String taxCode, String subunitCode, String origin, String originId, OnboardingStatus status);
+    Uni<List<OnboardingResponse>> institutionOnboardings(
+            String taxCode, String subunitCode, String origin, String originId, OnboardingStatus status);
 
-    Uni<List<OnboardingResponse>> verifyOnboarding(String taxCode, String subunitCode, String origin, String originId, OnboardingStatus status, String productId);
+    Uni<List<OnboardingResponse>> verifyOnboarding(
+            String taxCode,
+            String subunitCode,
+            String origin,
+            String originId,
+            OnboardingStatus status,
+            String productId);
 
     Uni<OnboardingGet> onboardingGet(String onboardingId);
 
@@ -60,6 +79,8 @@ public interface OnboardingService {
 
     Uni<CustomError> checkRecipientCode(String recipientCode, String originId);
 
-    Uni<OnboardingResponse> onboardingIncrement(Onboarding onboarding, List<UserRequest> userRequests, List<AggregateInstitutionRequest> aggregates);
-
+    Uni<OnboardingResponse> onboardingIncrement(
+            Onboarding onboarding,
+            List<UserRequest> userRequests,
+            List<AggregateInstitutionRequest> aggregates);
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -1261,7 +1261,7 @@ public class OnboardingServiceDefault implements OnboardingService {
 
     private Uni<Token> createToken(Onboarding onboarding, String onboardingId, FormItem formItem) {
         return Uni.createFrom()
-                .item(() -> createToken(onboarding, new Token(), onboardingId, formItem.getFile()));
+                .item(() -> createToken(onboarding, onboardingId, formItem.getFile()));
     }
 
     private Uni<Void> persistToken(Token tokenPersisted) {
@@ -1302,11 +1302,12 @@ public class OnboardingServiceDefault implements OnboardingService {
                 .replaceWith(filepath);
     }
 
-    private Token createToken(Onboarding onboarding, Token token, String onboardingId, File file) {
+    private Token createToken(Onboarding onboarding, String onboardingId, File file) {
         Product product = productService.getProduct(onboarding.getProductId());
         final String filename = CONTRACT_FILENAME_FUNC.apply(PDF_FORMAT_FILENAME, product.getTitle());
         DSSDocument document = new FileDocument(file);
         String digest = document.getDigest(DigestAlgorithm.SHA256);
+        Token token = new Token();
         token.setCreatedAt(LocalDateTime.now());
         token.setOnboardingId(onboardingId);
         token.setId(onboardingId);
@@ -1318,7 +1319,6 @@ public class OnboardingServiceDefault implements OnboardingService {
         token.setContractVersion(getContractTemplateVersion(product, onboarding));
         token.setChecksum(digest);
         token.setType(TokenType.INSTITUTION);
-        Panache.withTransaction(() -> Token.persist(token));
         return token;
     }
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -244,7 +244,7 @@ public class OnboardingServiceDefault implements OnboardingService {
         onboarding.setStatus(OnboardingStatus.PENDING);
 
         return fillUsersAndOnboardingCompletion(
-                onboarding, userRequests, null, TIMEOUT_ORCHESTRATION_RESPONSE, false, formItem);
+                onboarding, userRequests, TIMEOUT_ORCHESTRATION_RESPONSE, formItem);
     }
 
     @Override
@@ -290,12 +290,10 @@ public class OnboardingServiceDefault implements OnboardingService {
     private Uni<OnboardingResponse> fillUsersAndOnboardingCompletion(
             Onboarding onboarding,
             List<UserRequest> userRequests,
-            List<AggregateInstitutionRequest> aggregates,
             String timeout,
-            boolean isAggregatesIncrement,
             FormItem formItem) {
         return processOnboarding(
-                onboarding, userRequests, aggregates, timeout, isAggregatesIncrement, formItem);
+                onboarding, userRequests, null, timeout, false, formItem);
     }
 
     private Uni<OnboardingResponse> processOnboarding(

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -230,7 +230,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                             return onboarding;
                         })
                 .onItem()
-                .transformToUni(onboarding -> fillUsers(onboarding, request.getUsers(), null));
+                .transformToUni(onboarding -> verifyExistingOnboarding(onboarding, request.getUsers(), null));
     }
 
     /**
@@ -287,7 +287,7 @@ public class OnboardingServiceDefault implements OnboardingService {
 
         onboarding.setCreatedAt(LocalDateTime.now());
 
-        return fillUsers(onboarding, isAggregatesIncrement)
+        return verifyExistingOnboarding(onboarding, isAggregatesIncrement)
                 .onItem()
                 .transformToUni(product -> handleOnboarding(onboarding, userRequests, aggregates, timeout, product, null));
     }
@@ -300,12 +300,12 @@ public class OnboardingServiceDefault implements OnboardingService {
 
         onboarding.setCreatedAt(LocalDateTime.now());
 
-        return fillUsers(onboarding, false)
+        return verifyExistingOnboarding(onboarding, false)
                 .onItem()
                 .transformToUni(product -> handleOnboarding(onboarding, userRequests, null, timeout, product, formItem));
     }
 
-    private Uni<Product> fillUsers(Onboarding onboarding, boolean isAggregatesIncrement) {
+    private Uni<Product> verifyExistingOnboarding(Onboarding onboarding, boolean isAggregatesIncrement) {
         return getProductByOnboarding(onboarding)
                 .onItem()
                 .transformToUni(
@@ -390,7 +390,7 @@ public class OnboardingServiceDefault implements OnboardingService {
      *                response is delivered synchronously. If is null the timeout is default 1 sec and the
      *                response is delivered asynchronously
      */
-    private Uni<OnboardingResponse> fillUsers(
+    private Uni<OnboardingResponse> verifyExistingOnboarding(
             Onboarding onboarding, List<UserRequest> userRequests, String timeout) {
         onboarding.setCreatedAt(LocalDateTime.now());
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/Utils.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/util/Utils.java
@@ -1,28 +1,44 @@
 package it.pagopa.selfcare.onboarding.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.onboarding.constants.CustomError;
 import it.pagopa.selfcare.onboarding.exception.InvalidRequestException;
 import it.pagopa.selfcare.onboarding.model.FormItem;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.reactive.server.core.multipart.FormData;
 import org.jboss.resteasy.reactive.server.multipart.FormValue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Deque;
+import java.util.function.BinaryOperator;
 
 public class Utils {
     private static final String DEFAULT_CONTRACT_FORM_DATA_NAME = "contract";
+
     private Utils() {
     }
 
     public static FormItem retrieveContractFromFormData(FormData formData, File file) {
         Deque<FormValue> deck = formData.get(DEFAULT_CONTRACT_FORM_DATA_NAME);
-        if(deck.size() > 1) {
-            throw new InvalidRequestException(CustomError.TOO_MANY_CONTRACTS.getMessage(), CustomError.TOO_MANY_CONTRACTS.getCode());
+        if (deck.size() > 1) {
+            throw new InvalidRequestException(
+                    CustomError.TOO_MANY_CONTRACTS.getMessage(), CustomError.TOO_MANY_CONTRACTS.getCode());
         }
 
-        return FormItem.builder()
-                .file(file)
-                .fileName(deck.getFirst().getFileName())
-                .build();
+        return FormItem.builder().file(file).fileName(deck.getFirst().getFileName()).build();
     }
+
+    public static final BinaryOperator<String> CONTRACT_FILENAME_FUNC =
+            (filename, productName) ->
+                    String.format(filename, StringUtils.stripAccents(productName.replaceAll("\\s+", "_")));
+
+    public static <T> T parseOnboardingRequest(String onboardingRequestJson, Class<T> targetType) {
+        try {
+            return new ObjectMapper().readValue(onboardingRequestJson, targetType);
+        } catch (IOException e) {
+            throw new InvalidRequestException("Invalid onboardingRequest JSON format for " + targetType.getSimpleName());
+        }
+    }
+
 }

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -59,6 +59,9 @@ class OnboardingControllerTest {
 
     static final OnboardingUserPgRequest onboardingUserPgValid;
 
+    final String onboardingRequestJson =
+            "{\"productId\":\"prod-pn\",\"users\":[{\"taxCode\":\"GRSGNT71A62C950S\",\"name\":\"Gianantonio\",\"surname\":\"Grassi\",\"email\":\"g.grassi@test.it\",\"role\":\"MANAGER\"}],\"institution\":{\"institutionType\":\"PA\",\"taxCode\":\"80415740580\",\"origin\":\"IPA\",\"originId\":\"m_ef\",\"city\":\"ROMA\",\"country\":\"IT\",\"county\":\"RM\",\"description\":\"Ministero dell'Economia e delle Finanze\",\"digitalAddress\":\"mef@pec.mef.gov.it\",\"address\":\"Via XX Settembre, 97\",\"zipCode\":\"00187\",\"geographicTaxonomies\":[{\"code\":\"ITA\",\"desc\":\"ITALIA\"}],\"imported\":true},\"billing\":{\"vatNumber\":\"80415740580\",\"recipientCode\":\"Y7NS8B\",\"publicServices\":true}}";
+
     @InjectMock
     OnboardingService onboardingService;
 
@@ -576,61 +579,77 @@ class OnboardingControllerTest {
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingComplete() {
+    void onboardingCompletionMultipart() {
 
-        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
+        // Mock della risposta del servizio
+        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
+        // Creazione di un file fittizio per il test
+        File testFile = new File("src/test/resources/application.properties");
+
+        // Esecuzione della richiesta simulata
         given()
+                .multiPart("contract", testFile) // Aggiunta del file
+                .multiPart("onboardingRequest", onboardingRequestJson) // Aggiunta del JSON come stringa
+                .contentType("multipart/form-data")
                 .when()
-                .body(onboardingBaseValid)
-                .contentType(ContentType.JSON)
                 .post("/completion")
                 .then()
-                .statusCode(200);
+                .statusCode(200); // Verifica del codice di stato
 
-        Mockito.verify(onboardingService, times(1))
-                .onboardingCompletion(any(), any());
+        // Verifica che il servizio sia stato chiamato correttamente
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
     }
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingCompletePa() {
+    void onboardingPaCompletionMultipart() {
 
-        OnboardingPaRequest onboardingPaValid = dummyOnboardingPa();
-
-        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
+        // Mock della risposta del servizio
+        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
+        // Creazione di un file fittizio per il test
+        File testFile = new File("src/test/resources/application.properties");
+
+        // Esecuzione della richiesta simulata
         given()
+                .multiPart("contract", testFile) // Aggiunta del file
+                .multiPart("onboardingRequest", onboardingRequestJson) // Aggiunta del JSON come stringa
+                .contentType("multipart/form-data")
                 .when()
-                .body(onboardingPaValid)
-                .contentType(ContentType.JSON)
                 .post("/pa/completion")
                 .then()
-                .statusCode(200);
+                .statusCode(200); // Verifica del codice di stato
 
-        Mockito.verify(onboardingService, times(1))
-                .onboardingCompletion(any(), any());
+        // Verifica che il servizio sia stato chiamato correttamente
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
     }
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingCompletePsp() {
+    void onboardingPspCompletionMultipart() {
 
-        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
+        // Mock della risposta del servizio
+        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
+        // Creazione di un file fittizio per il test
+        File testFile = new File("src/test/resources/application.properties");
+
+        // Esecuzione della richiesta simulata
         given()
+                .multiPart("contract", testFile) // Aggiunta del file
+                .multiPart("onboardingRequest", onboardingRequestJson) // Aggiunta del JSON come stringa
+                .contentType("multipart/form-data")
                 .when()
-                .body(onboardingPspValid)
-                .contentType(ContentType.JSON)
                 .post("/psp/completion")
                 .then()
-                .statusCode(200);
+                .statusCode(200); // Verifica del codice di stato
 
-        Mockito.verify(onboardingService, times(1))
-                .onboardingCompletion(any(), any());
+        // Verifica che il servizio sia stato chiamato correttamente
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
     }
 
     @Test
@@ -644,7 +663,7 @@ class OnboardingControllerTest {
         onboardingPgRequest.setDigitalAddress("digital@address.it");
         onboardingPgRequest.setOrigin(Origin.INFOCAMERE);
 
-        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
+        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
         given()
@@ -656,8 +675,7 @@ class OnboardingControllerTest {
                 .statusCode(200);
 
         ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
-        Mockito.verify(onboardingService, times(1))
-                .onboardingCompletion(captor.capture(), any());
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any(), any());
         assertEquals(InstitutionType.PG, captor.getValue().getInstitution().getInstitutionType());
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- In the various completion APIs, a file has been added to the request as an input parameter
- the service logic has been revised as these APIs previously exploited a common method which was also used for the onboarding flow from FE
- the method that uses the complete API has been revised as it is useful for the completion logic. Except that unlike the complete, when the compilation is invoked the Token is also created on the DB

#### Motivation and Context

This change was necessary because when SM carried out manual onboarding it manually stored the contract on Azure storage. This behavior, in addition to being dangerous and cumbersome, did not even allow the automatic creation of the Token in the collection of the same name on the DB

#### How Has This Been Tested?

the API was invoked and it was verified that the Token was created on the DB and that the contract was loaded under the correct path

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.