### PR TITLE
[SELC-6062] feat: added check on workflow type for SELC Manager and default origin and originId

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerPT.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerPT.java
@@ -20,6 +20,7 @@ public class RegistryManagerPT extends RegistryManagerSELC {
                     onboarding.getInstitution().getTaxCode(),
                     onboarding.getProductId()), DEFAULT_ERROR.getCode());
         }
-        return Uni.createFrom().item(onboarding);
+
+        return super.customValidation(product);
     }
 }

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
@@ -1,7 +1,10 @@
 package it.pagopa.selfcare.onboarding.entity.registry;
 
 import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.onboarding.common.Origin;
+import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.exception.InvalidRequestException;
 import it.pagopa.selfcare.product.entity.Product;
 
 public class RegistryManagerSELC extends BaseRegistryManager<Object> {
@@ -11,12 +14,28 @@ public class RegistryManagerSELC extends BaseRegistryManager<Object> {
     }
 
     public Object retrieveInstitution() {
-      return Uni.createFrom().item(new Object());
+        setDefaultOriginAndOriginId();
+        return Uni.createFrom().item(new Object());
+    }
+
+    private void setDefaultOriginAndOriginId() {
+        onboarding.getInstitution().setOriginId(onboarding.getInstitution().getTaxCode());
+        onboarding.getInstitution().setOrigin(Origin.SELC);
     }
 
     @Override
     public Uni<Onboarding> customValidation(Product product) {
-        return Uni.createFrom().item(onboarding);
+        if (isWorkflowTypeAllowed(onboarding.getWorkflowType())) {
+            return Uni.createFrom().item(onboarding);
+        }
+
+        return Uni.createFrom().failure(new InvalidRequestException("Invalid workflow type for origin SELC"));
+    }
+
+    protected boolean isWorkflowTypeAllowed(WorkflowType workflowType) {
+        return workflowType == WorkflowType.FOR_APPROVE ||
+                workflowType == WorkflowType.IMPORT ||
+                workflowType == WorkflowType.FOR_APPROVE_PT;
     }
 
     @Override

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELCTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELCTest.java
@@ -1,0 +1,66 @@
+package it.pagopa.selfcare.onboarding.entity.registry;
+
+import io.smallrye.mutiny.Uni;
+import it.pagopa.selfcare.onboarding.common.Origin;
+import it.pagopa.selfcare.onboarding.common.WorkflowType;
+import it.pagopa.selfcare.onboarding.entity.Institution;
+import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.exception.InvalidRequestException;
+import it.pagopa.selfcare.product.entity.Product;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RegistryManagerSELCTest {
+
+    private Onboarding onboarding;
+    private RegistryManagerSELC registryManagerSELC;
+
+    @BeforeEach
+    void setUp() {
+        onboarding = mock(Onboarding.class);
+        registryManagerSELC = new RegistryManagerSELC(onboarding);
+    }
+
+    @Test
+    void retrieveInstitution_shouldSetDefaultOriginAndOriginId() {
+        var institution = mock(Institution.class);
+        when(onboarding.getInstitution()).thenReturn(institution);
+        when(institution.getTaxCode()).thenReturn("123456");
+
+        registryManagerSELC.retrieveInstitution();
+
+        verify(institution).setOriginId("123456");
+        verify(institution).setOrigin(Origin.SELC);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WorkflowType.class, names = {"FOR_APPROVE", "IMPORT", "FOR_APPROVE_PT"})
+    void customValidation_shouldReturnOnboarding_whenWorkflowTypeAllowed(WorkflowType workflowType) {
+        when(onboarding.getWorkflowType()).thenReturn(workflowType);
+
+        Uni<Onboarding> result = registryManagerSELC.customValidation(mock(Product.class));
+
+        assertEquals(onboarding, result.await().indefinitely());
+    }
+
+    @Test
+    void customValidation_shouldThrowInvalidRequestException_whenWorkflowTypeNotAllowed() {
+        when(onboarding.getWorkflowType()).thenReturn(WorkflowType.CONFIRMATION);
+
+        Uni<Onboarding> result = registryManagerSELC.customValidation(mock(Product.class));
+
+        assertThrows(InvalidRequestException.class, () -> result.await().indefinitely());
+    }
+
+    @Test
+    void isValid_shouldReturnTrue() {
+        Uni<Boolean> result = registryManagerSELC.isValid();
+
+        assertTrue(result.await().indefinitely());
+    }
+}

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -277,6 +277,9 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setInstitutionType(InstitutionType.PA);
         institutionBaseRequest.setTaxCode("taxCode");
         institutionBaseRequest.setOriginId("originId");
+        institutionBaseRequest.setOrigin(Origin.IPA);
+        institutionBaseRequest.setDescription(DESCRIPTION_FIELD);
+        institutionBaseRequest.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
         onboardingRequest.setInstitution(institutionBaseRequest);
         Billing billing = new Billing();
         billing.setRecipientCode("recCode");
@@ -293,6 +296,12 @@ class OnboardingServiceDefaultTest {
         mockSimpleProductValidAssert(onboardingRequest.getProductId(), false, asserter);
         mockVerifyAllowedMap(onboardingRequest.getInstitution().getTaxCode(), onboardingRequest.getProductId(), asserter);
         mockVerifyOnboardingNotEmpty(asserter);
+
+        InstitutionResource institutionResource = new InstitutionResource();
+        institutionResource.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
+        institutionResource.setDescription(DESCRIPTION_FIELD);
+        when(institutionRegistryProxyApi.findInstitutionUsingGET(any(), any(), any())).thenReturn(Uni.createFrom().item(institutionResource));
+
 
         UOResource uoResource = new UOResource();
         uoResource.setCodiceFiscaleSfe("codSfe");
@@ -317,6 +326,9 @@ class OnboardingServiceDefaultTest {
         institution.setInstitutionType("PA");
         institution.setOriginId("originId");
         institution.setTaxCode("taxCode");
+        institution.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
+        institution.setDescription(DESCRIPTION_FIELD);
+        institution.setOrigin(Origin.IPA);
         onboardingResponse.setInstitution(institution);
 
         UserOnboardingResponse userOnboardingResponse = new UserOnboardingResponse();
@@ -485,6 +497,7 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setTaxCode("taxCode");
         institutionBaseRequest.setSubunitType(InstitutionPaSubunitType.AOO);
         institutionBaseRequest.setSubunitCode("SubunitCode");
+        institutionBaseRequest.setOrigin(Origin.IPA);
         request.setInstitution(institutionBaseRequest);
 
         mockPersistOnboarding(asserter);
@@ -594,6 +607,7 @@ class OnboardingServiceDefaultTest {
         institutionBaseRequest.setTaxCode("taxCode");
         institutionBaseRequest.setSubunitType(InstitutionPaSubunitType.UO);
         institutionBaseRequest.setSubunitCode("SubunitCode");
+        institutionBaseRequest.setOrigin(Origin.IPA);
         request.setInstitution(institutionBaseRequest);
 
         mockPersistOnboarding(asserter);
@@ -779,6 +793,33 @@ class OnboardingServiceDefaultTest {
             PanacheMock.verify(Onboarding.class).find(any(Document.class));
             PanacheMock.verifyNoMoreInteractions(Onboarding.class);
         });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void onboarding_SELC_Forbidden_WorkflowType(UniAsserter asserter) {
+        Onboarding request = new Onboarding();
+        List<UserRequest> users = List.of(manager);
+        request.setProductId(PROD_PAGOPA.getValue());
+        Institution institutionBaseRequest = new Institution();
+        institutionBaseRequest.setDescription("name");
+        institutionBaseRequest.setDigitalAddress("pec");
+        institutionBaseRequest.setInstitutionType(InstitutionType.GSP);
+        institutionBaseRequest.setTaxCode("taxCode");
+        request.setInstitution(institutionBaseRequest);
+        mockPersistOnboarding(asserter);
+
+        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))
+                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+
+
+        mockSimpleSearchPOSTAndPersist(asserter);
+        mockSimpleProductValidAssert(request.getProductId(), false, asserter);
+        mockVerifyOnboardingNotFound();
+        mockVerifyAllowedMap(request.getInstitution().getTaxCode(), request.getProductId(), asserter);
+
+        // onboardingCompletion will set the workflowType to COMPLETION, which is not allowed for GSP
+        asserter.assertFailedWith(() -> onboardingService.onboardingCompletion(request, users, null), InvalidRequestException.class);
     }
 
     @Test
@@ -1143,7 +1184,7 @@ class OnboardingServiceDefaultTest {
 
     Institution dummyInstitution() {
         Institution institution = new Institution();
-        institution.setInstitutionType(InstitutionType.SA);
+        institution.setInstitutionType(InstitutionType.GSP);
         return institution;
     }
 
@@ -1250,7 +1291,7 @@ class OnboardingServiceDefaultTest {
 
         Onboarding request = new Onboarding();
         List<UserRequest> users = List.of(wrongManager);
-        request.setProductId(PROD_INTEROP.getValue());
+        request.setProductId(PROD_PAGOPA.getValue());
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.GSP);
         request.setInstitution(institutionPspRequest);
@@ -1291,7 +1332,7 @@ class OnboardingServiceDefaultTest {
 
         Onboarding request = new Onboarding();
         List<UserRequest> users = List.of(newManager);
-        request.setProductId(PROD_INTEROP.getValue());
+        request.setProductId(PROD_IO.getValue());
         Institution institutionPspRequest = new Institution();
         institutionPspRequest.setInstitutionType(InstitutionType.GSP);
         request.setInstitution(institutionPspRequest);
@@ -1349,6 +1390,12 @@ class OnboardingServiceDefaultTest {
         mockVerifyOnboardingNotFound();
         mockVerifyAllowedMap(request.getInstitution().getTaxCode(), request.getProductId(), asserter);
 
+        InstitutionResource institutionResource = new InstitutionResource();
+        institutionResource.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
+        institutionResource.setDescription(DESCRIPTION_FIELD);
+        when(institutionRegistryProxyApi.findInstitutionUsingGET(any(), any(), any())).thenReturn(Uni.createFrom().item(institutionResource));
+
+
         asserter.execute(() -> when(Onboarding.persistOrUpdate(any(List.class)))
                 .thenAnswer(arg -> {
                     List<Onboarding> onboardings = (List<Onboarding>) arg.getArguments()[0];
@@ -1371,8 +1418,10 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboarding_shouldThrowExceptionIfUserRegistryFails(UniAsserter asserter) {
         Onboarding onboardingDefaultRequest = new Onboarding();
-        onboardingDefaultRequest.setInstitution(dummyInstitution());
-        onboardingDefaultRequest.setProductId(PROD_INTEROP.getValue());
+        Institution institution = new Institution();
+        institution.setInstitutionType(InstitutionType.GSP);
+        onboardingDefaultRequest.setInstitution(institution);
+        onboardingDefaultRequest.setProductId(PROD_PAGOPA.getValue());
         List<UserRequest> users = List.of(manager);
 
         mockPersistOnboarding(asserter);
@@ -2010,11 +2059,17 @@ class OnboardingServiceDefaultTest {
     void onboarding_aggregationCompletion(UniAsserter asserter) {
         Onboarding request = new Onboarding();
         List<UserRequest> users = List.of(manager);
-        request.setProductId(PROD_IO.getValue());
+        request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setTaxCode("taxCode");
         institutionBaseRequest.setInstitutionType(InstitutionType.SA);
+        institutionBaseRequest.setOrigin(Origin.IPA);
+        institutionBaseRequest.setDescription(DESCRIPTION_FIELD);
+        institutionBaseRequest.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
         request.setInstitution(institutionBaseRequest);
+        Billing billing = new Billing();
+        billing.setRecipientCode("recipientCode");
+        request.setBilling(billing);
 
         mockPersistOnboarding(asserter);
         mockPersistToken(asserter);
@@ -2029,6 +2084,8 @@ class OnboardingServiceDefaultTest {
 
         InstitutionResource institutionResource = new InstitutionResource();
         institutionResource.setCategory("L37");
+        institutionResource.setDescription(DESCRIPTION_FIELD);
+        institutionResource.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
         asserter.execute(() -> when(institutionRegistryProxyApi.findInstitutionUsingGET(institutionBaseRequest.getTaxCode(), null, null))
                 .thenReturn(Uni.createFrom().item(institutionResource)));
 
@@ -2046,12 +2103,15 @@ class OnboardingServiceDefaultTest {
     @RunOnVertxContext
     void onboardingCompletion(UniAsserter asserter) {
         Onboarding request = new Onboarding();
-        Product product = createDummyProduct(PROD_IO.getValue(), false);
+        Product product = createDummyProduct(PROD_INTEROP.getValue(), false);
         List<UserRequest> users = List.of(manager);
-        request.setProductId(PROD_IO.getValue());
+        request.setProductId(PROD_INTEROP.getValue());
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setTaxCode("taxCode");
         institutionBaseRequest.setInstitutionType(InstitutionType.SA);
+        institutionBaseRequest.setOrigin(Origin.IPA);
+        institutionBaseRequest.setDescription(DESCRIPTION_FIELD);
+        institutionBaseRequest.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
         request.setInstitution(institutionBaseRequest);
 
         mockPersistOnboarding(asserter);
@@ -2069,6 +2129,8 @@ class OnboardingServiceDefaultTest {
 
         InstitutionResource institutionResource = new InstitutionResource();
         institutionResource.setCategory("L37");
+        institutionResource.setDigitalAddress(DIGITAL_ADDRESS_FIELD);
+        institutionResource.setDescription(DESCRIPTION_FIELD);
         asserter.execute(() -> when(institutionRegistryProxyApi.findInstitutionUsingGET(institutionBaseRequest.getTaxCode(), null, null))
                 .thenReturn(Uni.createFrom().item(institutionResource)));
 

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -819,7 +819,7 @@ class OnboardingServiceDefaultTest {
         mockVerifyAllowedMap(request.getInstitution().getTaxCode(), request.getProductId(), asserter);
 
         // onboardingCompletion will set the workflowType to COMPLETION, which is not allowed for GSP
-        asserter.assertFailedWith(() -> onboardingService.onboardingCompletion(request, users, null), InvalidRequestException.class);
+        asserter.assertFailedWith(() -> onboardingService.onboardingCompletion(request, users), InvalidRequestException.class);
     }
 
     @Test


### PR DESCRIPTION
#### List of Changes

added check on workflow type for SELC Manager and default origin and originId

#### Motivation and Context

Added a check on the workflow type field to ensure that a SELC onboarding can proceed only in the case of IMPORT or human VALIDATION

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.