### PR TITLE
[SELC-6174] feat: rework onboarding completion logic

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmation.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmation.java
@@ -11,12 +11,18 @@ import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowInstitution;
 import java.util.Optional;
 
 import static it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowType.INSTITUTION;
+import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
+import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingWorkflowString;
 
-public record WorkflowExecutorConfirmation(ObjectMapper objectMapper, TaskOptions optionsRetry) implements WorkflowExecutor {
+public record WorkflowExecutorConfirmation(ObjectMapper objectMapper,
+                                           TaskOptions optionsRetry) implements WorkflowExecutor {
 
     @Override
     public Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
-        return Optional.empty();
+        String onboardingWorkflowString = getOnboardingWorkflowString(objectMapper, onboardingWorkflow);
+        ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
+        ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
+        return Optional.of(OnboardingStatus.PENDING);
     }
 
     @Override

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -502,24 +502,9 @@
         "operationId" : "onboardingCompletion",
         "requestBody" : {
           "content" : {
-            "multipart/form-data" : {
+            "application/json" : {
               "schema" : {
-                "required" : [ "contract" ],
-                "type" : "object",
-                "properties" : {
-                  "onboardingRequest" : {
-                    "$ref" : "#/components/schemas/OnboardingDefaultRequest"
-                  },
-                  "contract" : {
-                    "format" : "binary",
-                    "type" : "string"
-                  }
-                }
-              },
-              "encoding" : {
-                "onboardingRequest" : {
-                  "contentType" : "application/json"
-                }
+                "$ref" : "#/components/schemas/OnboardingDefaultRequest"
               }
             }
           }
@@ -695,24 +680,9 @@
         "operationId" : "onboardingPaCompletion",
         "requestBody" : {
           "content" : {
-            "multipart/form-data" : {
+            "application/json" : {
               "schema" : {
-                "required" : [ "contract" ],
-                "type" : "object",
-                "properties" : {
-                  "onboardingRequest" : {
-                    "$ref" : "#/components/schemas/OnboardingPaRequest"
-                  },
-                  "contract" : {
-                    "format" : "binary",
-                    "type" : "string"
-                  }
-                }
-              },
-              "encoding" : {
-                "onboardingRequest" : {
-                  "contentType" : "application/json"
-                }
+                "$ref" : "#/components/schemas/OnboardingPaRequest"
               }
             }
           }
@@ -862,24 +832,9 @@
         "operationId" : "onboardingPspCompletion",
         "requestBody" : {
           "content" : {
-            "multipart/form-data" : {
+            "application/json" : {
               "schema" : {
-                "required" : [ "contract" ],
-                "type" : "object",
-                "properties" : {
-                  "onboardingRequest" : {
-                    "$ref" : "#/components/schemas/OnboardingPspRequest"
-                  },
-                  "contract" : {
-                    "format" : "binary",
-                    "type" : "string"
-                  }
-                }
-              },
-              "encoding" : {
-                "onboardingRequest" : {
-                  "contentType" : "application/json"
-                }
+                "$ref" : "#/components/schemas/OnboardingPspRequest"
               }
             }
           }

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -367,20 +367,9 @@ paths:
       operationId: onboardingCompletion
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              required:
-              - contract
-              type: object
-              properties:
-                onboardingRequest:
-                  $ref: "#/components/schemas/OnboardingDefaultRequest"
-                contract:
-                  format: binary
-                  type: string
-            encoding:
-              onboardingRequest:
-                contentType: application/json
+              $ref: "#/components/schemas/OnboardingDefaultRequest"
       responses:
         "200":
           description: OK
@@ -511,20 +500,9 @@ paths:
       operationId: onboardingPaCompletion
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              required:
-              - contract
-              type: object
-              properties:
-                onboardingRequest:
-                  $ref: "#/components/schemas/OnboardingPaRequest"
-                contract:
-                  format: binary
-                  type: string
-            encoding:
-              onboardingRequest:
-                contentType: application/json
+              $ref: "#/components/schemas/OnboardingPaRequest"
       responses:
         "200":
           description: OK
@@ -631,20 +609,9 @@ paths:
       operationId: onboardingPspCompletion
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              required:
-              - contract
-              type: object
-              properties:
-                onboardingRequest:
-                  $ref: "#/components/schemas/OnboardingPspRequest"
-                contract:
-                  format: binary
-                  type: string
-            encoding:
-              onboardingRequest:
-                contentType: application/json
+              $ref: "#/components/schemas/OnboardingPspRequest"
       responses:
         "200":
           description: OK

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -33,7 +33,6 @@ import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
-import org.jboss.resteasy.reactive.PartType;
 import org.jboss.resteasy.reactive.RestForm;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 
@@ -172,21 +171,12 @@ public class OnboardingController {
     @POST
     @Tag(name = "Onboarding Controller")
     @Tag(name = "internal-v1")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingCompletion(
-            @NotNull @RestForm("contract") File file,
-            @NotNull @FormParam("onboardingRequest") @PartType(MediaType.APPLICATION_JSON) OnboardingDefaultRequest onboardingRequest,
-            @Context ResteasyReactiveRequestContext ctx,
-            @Context SecurityContext securityContext) {
-
-        return readUserIdFromToken(securityContext)
-                .onItem()
-                .transformToUni(
-                        userId -> onboardingService.onboardingCompletion(
-                                fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
-                                onboardingRequest.getUsers(),
-                                retrieveContractFromFormData(ctx.getFormData(), file)));
+    public Uni<OnboardingResponse> onboardingCompletion(@Valid OnboardingDefaultRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(userId -> onboardingService
+                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
     }
 
     @Operation(
@@ -197,21 +187,12 @@ public class OnboardingController {
     @Path("/pa/completion")
     @Tag(name = "Onboarding Controller")
     @Tag(name = "internal-v1")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingPaCompletion(
-            @NotNull @RestForm("contract") File file,
-            @NotNull @FormParam("onboardingRequest") @PartType(MediaType.APPLICATION_JSON) OnboardingPaRequest onboardingRequest,
-            @Context ResteasyReactiveRequestContext ctx,
-            @Context SecurityContext securityContext) {
-
-        return readUserIdFromToken(securityContext)
-                .onItem()
-                .transformToUni(
-                        userId -> onboardingService.onboardingCompletion(
-                                fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
-                                onboardingRequest.getUsers(),
-                                retrieveContractFromFormData(ctx.getFormData(), file)));
+    public Uni<OnboardingResponse> onboardingPaCompletion(@Valid OnboardingPaRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(userId -> onboardingService
+                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
     }
 
     @Operation(
@@ -250,21 +231,12 @@ public class OnboardingController {
     @Path("/psp/completion")
     @Tag(name = "Onboarding Controller")
     @Tag(name = "internal-v1")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Uni<OnboardingResponse> onboardingPspCompletion(
-            @NotNull @RestForm("contract") File file,
-            @NotNull @FormParam("onboardingRequest") @PartType(MediaType.APPLICATION_JSON) OnboardingPspRequest onboardingRequest,
-            @Context ResteasyReactiveRequestContext ctx,
-            @Context SecurityContext securityContext) {
-
-        return readUserIdFromToken(securityContext)
-                .onItem()
-                .transformToUni(
-                        userId -> onboardingService.onboardingCompletion(
-                                fillUserId(onboardingMapper.toEntity(onboardingRequest), userId),
-                                onboardingRequest.getUsers(),
-                                retrieveContractFromFormData(ctx.getFormData(), file)));
+    public Uni<OnboardingResponse> onboardingPspCompletion(@Valid OnboardingPspRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(userId -> onboardingService
+                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
     }
 
     @Operation(
@@ -280,7 +252,7 @@ public class OnboardingController {
     public Uni<OnboardingResponse> onboardingPgCompletion(@Valid OnboardingPgRequest onboardingRequest, @Context SecurityContext ctx) {
         return readUserIdFromToken(ctx)
                 .onItem().transformToUni(userId -> onboardingService
-                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers(), null));
+                        .onboardingCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers()));
     }
 
     @Operation(

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -35,7 +35,7 @@ public interface OnboardingService {
             boolean forceImport);
 
     Uni<OnboardingResponse> onboardingCompletion(
-            Onboarding onboarding, List<UserRequest> userRequests, FormItem formItem);
+            Onboarding onboarding, List<UserRequest> userRequests);
 
     Uni<OnboardingResponse> onboardingAggregationCompletion(
             Onboarding onboarding,

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -576,77 +576,96 @@ class OnboardingControllerTest {
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingCompletionMultipart() {
+    void onboardingCompletion() {
 
-        // Mock della risposta del servizio
-        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
+        OnboardingDefaultRequest onboardingDefaultRequest = dummyOnboardingDefaultRequest();
+
+        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
-        // Creazione di un file fittizio per il test
-        File testFile = new File("src/test/resources/application.properties");
-
-        // Esecuzione della richiesta simulata
         given()
-                .multiPart("contract", testFile) // Aggiunta del file
-                .multiPart("onboardingRequest", new OnboardingDefaultRequest()) // Aggiunta del JSON come stringa
-                .contentType("multipart/form-data")
                 .when()
+                .body(onboardingDefaultRequest)
+                .contentType(ContentType.JSON)
                 .post("/completion")
                 .then()
-                .statusCode(200); // Verifica del codice di stato
+                .statusCode(200);
 
-        // Verifica che il servizio sia stato chiamato correttamente
-        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any());
+        assertEquals(InstitutionType.PRV, captor.getValue().getInstitution().getInstitutionType());
+    }
+
+    private static OnboardingDefaultRequest dummyOnboardingDefaultRequest() {
+        OnboardingDefaultRequest onboardingDefaultRequest = new OnboardingDefaultRequest();
+        InstitutionBaseRequest institution = new InstitutionBaseRequest();
+        onboardingDefaultRequest.setProductId("productId");
+        onboardingDefaultRequest.setUsers(List.of(userDTO));
+        institution.setTaxCode("taxCode");
+        institution.setDigitalAddress("digital@address.it");
+        institution.setOrigin(Origin.SELC);
+        institution.setInstitutionType(InstitutionType.PRV);
+        onboardingDefaultRequest.setInstitution(institution);
+        return onboardingDefaultRequest;
     }
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingPaCompletionMultipart() {
+    void onboardingPaCompletion() {
 
-        // Mock della risposta del servizio
-        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
+        OnboardingPaRequest onboardingPaRequest = dummyOnboardingPa();
+
+        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
-        // Creazione di un file fittizio per il test
-        File testFile = new File("src/test/resources/application.properties");
-
-        // Esecuzione della richiesta simulata
         given()
-                .multiPart("contract", testFile) // Aggiunta del file
-                .multiPart("onboardingRequest", new OnboardingPaRequest()) // Aggiunta del JSON come stringa
-                .contentType("multipart/form-data")
                 .when()
+                .body(onboardingPaRequest)
+                .contentType(ContentType.JSON)
                 .post("/pa/completion")
                 .then()
-                .statusCode(200); // Verifica del codice di stato
+                .statusCode(200);
 
-        // Verifica che il servizio sia stato chiamato correttamente
-        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any());
+        assertEquals(InstitutionType.PA, captor.getValue().getInstitution().getInstitutionType());
     }
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingPspCompletionMultipart() {
+    void onboardingPspCompletion() {
 
-        // Mock della risposta del servizio
-        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
+        OnboardingPspRequest onboardingPspRequest = getOnboardingPspRequest();
+
+        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
-        // Creazione di un file fittizio per il test
-        File testFile = new File("src/test/resources/application.properties");
-
-        // Esecuzione della richiesta simulata
         given()
-                .multiPart("contract", testFile) // Aggiunta del file
-                .multiPart("onboardingRequest", new OnboardingPspRequest()) // Aggiunta del JSON come stringa
-                .contentType("multipart/form-data")
                 .when()
+                .body(onboardingPspRequest)
+                .contentType(ContentType.JSON)
                 .post("/psp/completion")
                 .then()
-                .statusCode(200); // Verifica del codice di stato
+                .statusCode(200);
 
-        // Verifica che il servizio sia stato chiamato correttamente
-        Mockito.verify(onboardingService, times(1)).onboardingCompletion(any(), any(), any());
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any());
+        assertEquals(InstitutionType.PSP, captor.getValue().getInstitution().getInstitutionType());
+    }
+
+    private static OnboardingPspRequest getOnboardingPspRequest() {
+        OnboardingPspRequest onboardingPspRequest = new OnboardingPspRequest();
+        InstitutionPspRequest institution = new InstitutionPspRequest();
+        onboardingPspRequest.setProductId("productId");
+        onboardingPspRequest.setUsers(List.of(userDTO));
+        institution.setTaxCode("taxCode");
+        institution.setDigitalAddress("digital@address.it");
+        institution.setOrigin(Origin.SELC);
+        institution.setInstitutionType(InstitutionType.PSP);
+        institution.setPaymentServiceProvider(new PaymentServiceProviderRequest());
+        institution.setDataProtectionOfficer(new DataProtectionOfficerRequest());
+        onboardingPspRequest.setInstitution(institution);
+        return onboardingPspRequest;
     }
 
     @Test
@@ -660,7 +679,7 @@ class OnboardingControllerTest {
         onboardingPgRequest.setDigitalAddress("digital@address.it");
         onboardingPgRequest.setOrigin(Origin.INFOCAMERE);
 
-        Mockito.when(onboardingService.onboardingCompletion(any(), any(), any()))
+        Mockito.when(onboardingService.onboardingCompletion(any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
 
         given()
@@ -672,7 +691,7 @@ class OnboardingControllerTest {
                 .statusCode(200);
 
         ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
-        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any(), any());
+        Mockito.verify(onboardingService, times(1)).onboardingCompletion(captor.capture(), any());
         assertEquals(InstitutionType.PG, captor.getValue().getInstitution().getInstitutionType());
     }
 
@@ -1013,6 +1032,8 @@ class OnboardingControllerTest {
         BillingPaRequest billingPaRequest = new BillingPaRequest();
         billingPaRequest.setRecipientCode("code");
         billingPaRequest.setVatNumber("vat");
+
+        institution.setInstitutionType(InstitutionType.PA);
 
         onboardingPaValid.setUsers(List.of(userDTO));
         onboardingPaValid.setInstitution(institution);

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -2072,11 +2072,7 @@ class OnboardingServiceDefaultTest {
         asserter.execute(() -> when(institutionRegistryProxyApi.findInstitutionUsingGET(institutionBaseRequest.getTaxCode(), null, null))
                 .thenReturn(Uni.createFrom().item(institutionResource)));
 
-        final String filepath = "upload-file-path";
-        when(azureBlobClient.uploadFile(any(), any(), any())).thenReturn(filepath);
-        mockUpdateToken(asserter, filepath);
-
-        asserter.assertThat(() -> onboardingService.onboardingCompletion(request, users, TEST_FORM_ITEM), Assertions::assertNotNull);
+        asserter.assertThat(() -> onboardingService.onboardingCompletion(request, users), Assertions::assertNotNull);
 
         asserter.execute(() -> {
             PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

-set status to REQUEST in Onboarding completion APIs

#### Motivation and Context

This change is necessary as SM will first have to create an onboarding request and then invoke another API to load the signed agreement and complete the same request. Here the logic has been revised so that in the case of invoking the API the request is put in Request and the Request phase is executed which includes creation of the contract and saving of the Token on the DB also in the workflowType CONFIRMATION

#### How Has This Been Tested?

the local ms was started and the api was invoked and onboarding was subsequently completed

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.