### PR TITLE
[SELC-6435] feat: set CONTRACT_REGISTRATION workflowType for products with parent

### DIFF
--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
@@ -7,6 +7,8 @@ import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.exception.InvalidRequestException;
 import it.pagopa.selfcare.product.entity.Product;
 
+import java.util.Objects;
+
 public class RegistryManagerSELC extends BaseRegistryManager<Object> {
 
     public RegistryManagerSELC(Onboarding onboarding) {
@@ -25,7 +27,7 @@ public class RegistryManagerSELC extends BaseRegistryManager<Object> {
 
     @Override
     public Uni<Onboarding> customValidation(Product product) {
-        if (isWorkflowTypeAllowed(onboarding.getWorkflowType())) {
+        if (isWorkflowTypeAllowed(onboarding.getWorkflowType()) || Objects.nonNull(product.getParentId())) {
             return Uni.createFrom().item(onboarding);
         }
 

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -656,6 +656,8 @@ public class OnboardingServiceDefault implements OnboardingService {
      */
     private WorkflowType getWorkflowType(Onboarding onboarding) {
         InstitutionType institutionType = onboarding.getInstitution().getInstitutionType();
+        Product product = productService.getProductIsValid(onboarding.getProductId());
+
         if (InstitutionType.PT.equals(institutionType)) {
             return WorkflowType.FOR_APPROVE_PT;
         }
@@ -669,6 +671,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                 || isGspAndProdInterop(institutionType, onboarding.getProductId())
                 || InstitutionType.SA.equals(institutionType)
                 || InstitutionType.AS.equals(institutionType)
+                || Objects.nonNull(product.getParentId())
                 || (InstitutionType.PRV.equals(institutionType)
                 && !PROD_PAGOPA.getValue().equals(onboarding.getProductId()))) {
             return WorkflowType.CONTRACT_REGISTRATION;

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -276,8 +276,11 @@ class OnboardingServiceDefaultTest {
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
+        Product productResource = new Product();
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
-                .thenThrow(IllegalArgumentException.class));
+                .thenReturn(productResource) // Prima chiamata: ritorna un valore valido
+                .thenThrow(new IllegalArgumentException()) // Seconda chiamata: lancia un'eccezione
+        );
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users, null), OnboardingNotAllowedException.class);
     }
@@ -291,8 +294,11 @@ class OnboardingServiceDefaultTest {
         onboardingRequest.setProductId("productId");
         onboardingRequest.setInstitution(new Institution());
 
+        Product productResource = new Product();
         asserter.execute(() -> when(productService.getProductIsValid(onboardingRequest.getProductId()))
-                .thenThrow(ProductNotFoundException.class));
+                .thenReturn(productResource) // Prima chiamata: ritorna un valore valido
+                .thenThrow(new ProductNotFoundException()) // Seconda chiamata: lancia un'eccezione
+        );
 
         asserter.assertFailedWith(() -> onboardingService.onboarding(onboardingRequest, users, null), OnboardingNotAllowedException.class);
     }
@@ -466,7 +472,7 @@ class OnboardingServiceDefaultTest {
     void onboarding_throwExceptionIfProductRoleIsNotValid(UniAsserter asserter) {
         Onboarding onboardingRequest = new Onboarding();
         List<UserRequest> users = List.of(manager);
-        onboardingRequest.setProductId("productId");
+        onboardingRequest.setProductId("prod-pn");
         Institution institutionBaseRequest = new Institution();
         institutionBaseRequest.setInstitutionType(InstitutionType.PG);
         onboardingRequest.setInstitution(institutionBaseRequest);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- set CONTRACT_REGISTRATION workflowType for products with parent

#### Motivation and Context

All products that have a parent must follow a CONTRACT_REGISTRATION workflowType, i.e. they do not have to go through the validation of the institution data by the SelfCare admin, this is because the validation has already been performed for the parent product and the data used for joining the child product are similar to those used previously

#### How Has This Been Tested?

the MS was started locally and various scenarios were tested to verify that the workflowType was set correctly both for products that have a parent and for those that do not

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.