### PR TITLE
[SELC-6798] fix: allowed duplicate institution onboarding with different institut…

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -149,10 +149,7 @@ public class CompletionServiceDefault implements CompletionService {
 
         if (Objects.nonNull(institutionsResponse.getInstitutions())
                 && institutionsResponse.getInstitutions().size() > 1) {
-            return institutionsResponse.getInstitutions().stream()
-                    .filter(institutionResponse -> institutionResponse.getInstitutionType().equals(onboarding.getInstitution().getInstitutionType().name()))
-                    .findFirst()
-                    .orElse(createInstitution(institution));
+            throw new GenericOnboardingException("List of institutions is ambiguous, it is empty or has more than one element!!");
         }
 
         return

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefaultTest.java
@@ -210,27 +210,21 @@ public class CompletionServiceDefaultTest {
     }
 
     @Test
-    void createOrRetrieveInstitutions() {
+    void createOrRetrieveInstitutionFailure() {
         Onboarding onboarding = createOnboarding();
         Institution institution = new Institution();
         institution.setId("actual-id");
         institution.setTaxCode("123");
-        institution.setInstitutionType(InstitutionType.PSP);
         onboarding.setInstitution(institution);
 
         InstitutionsResponse response = new InstitutionsResponse();
         InstitutionResponse institutionResponse = new InstitutionResponse();
-        institutionResponse.setInstitutionType(InstitutionType.PSP.name());
-        institutionResponse.setId("actual-id");
         response.setInstitutions(List.of(institutionResponse, institutionResponse));
 
         when(institutionApi.getInstitutionsUsingGET(institution.getTaxCode(), null, null, null))
                 .thenReturn(response);
 
-        InstitutionResponse serviceResponse = completionServiceDefault.createOrRetrieveInstitution(onboarding);
-
-        assertNotNull(serviceResponse);
-        assertEquals("actual-id", serviceResponse.getId());
+        assertThrows(GenericOnboardingException.class, () -> completionServiceDefault.createOrRetrieveInstitution(onboarding));
     }
 
     void mockOnboardingUpdateAndExecuteCreateInstitution(Onboarding onboarding) {

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -502,6 +502,9 @@ public class OnboardingServiceDefault implements OnboardingService {
                         .getRoleMappings(onboarding.getInstitution().getInstitutionType().name())
                         : product.getRoleMappings(onboarding.getInstitution().getInstitutionType().name());
 
+        if (Objects.nonNull(product.getParentId())) {
+            setInstitutionId(onboarding, product.getParentId());
+        }
         /* I have to retrieve onboarding id for saving reference to pdv */
         return Panache.withTransaction(
                 () ->
@@ -536,6 +539,30 @@ public class OnboardingServiceDefault implements OnboardingService {
                                                         .onItem()
                                                         .invoke(onboardingPersisted::setUsers)
                                                         .replaceWith(onboardingPersisted)));
+    }
+
+    private void setInstitutionId(Onboarding onboarding, String parentId) {
+        final String taxCode = onboarding.getInstitution().getTaxCode();
+        final String origin = onboarding.getInstitution().getOrigin().name();
+        final String originId = onboarding.getInstitution().getOriginId();
+        final String subunitCode = onboarding.getInstitution().getSubunitCode();
+        final String institutionType = onboarding.getInstitution().getInstitutionType().name();
+
+        List<Onboarding> onboardings = getOnboardingByFilters(taxCode, subunitCode, origin, originId, parentId)
+                .filter(item -> institutionType.equalsIgnoreCase(item.getInstitution().getInstitutionType().name()))
+                .collect().asList()
+                .await().indefinitely();
+
+        if (!onboardings.isEmpty()) {
+            onboarding.getInstitution().setId(onboardings.get(0).getInstitution().getId());
+        } else {
+            throw new ResourceNotFoundException(
+                    String.format(
+                            "Onboarding for taxCode %s, origin %s, originId %s, parentId %s, subunitCode %s not found and institutionType %s",
+                            taxCode, origin, originId, parentId, subunitCode, institutionType
+                    )
+            );
+        }
     }
 
     private Uni<Onboarding> addReferencedOnboardingId(Onboarding onboarding) {
@@ -913,7 +940,7 @@ public class OnboardingServiceDefault implements OnboardingService {
                 .filter(
                         aggregateInstitution ->
                                 Optional.ofNullable(aggregateInstitution.getSubunitCode()).equals(Optional.ofNullable(aggregate.getSubunitCode())) &&
-                                aggregateInstitution.getTaxCode().equals(aggregate.getTaxCode()))
+                                        aggregateInstitution.getTaxCode().equals(aggregate.getTaxCode()))
                 .findAny()
                 .ifPresent(aggregateInstitutionRequest -> aggregateInstitutionRequest.setUsers(users));
     }
@@ -1652,14 +1679,16 @@ public class OnboardingServiceDefault implements OnboardingService {
                             if (Objects.isNull(response.getInstitutions())
                                     || response.getInstitutions().size() > 1) {
                                 return Uni.createFrom()
-                                        .failure(
-                                                new ResourceNotFoundException(
+                                        .item(response.getInstitutions().stream()
+                                                .filter(institutionResponse ->
+                                                        institutionResponse.getInstitutionType().name().equals(request.getInstitutionType().name()))
+                                                .findFirst().orElseThrow(() -> new ResourceNotFoundException(
                                                         String.format(
                                                                 INSTITUTION_NOT_FOUND.getMessage(),
                                                                 request.getTaxCode(),
                                                                 request.getOrigin(),
                                                                 request.getOriginId(),
-                                                                request.getSubunitCode())));
+                                                                request.getSubunitCode()))));
                             }
                             return Uni.createFrom().item(response.getInstitutions().get(0));
                         });

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefaultTest.java
@@ -1377,12 +1377,18 @@ class OnboardingServiceDefaultTest {
         PanacheMock.mock(Onboarding.class);
         ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
 
-    Mockito.doAnswer(invocation -> Multi.createFrom().empty())
-        .doAnswer(invocation -> Multi.createFrom().items(new Onboarding()))
-        .when(query)
-        .stream();
+        Onboarding onboarding1 = new Onboarding();
+        Onboarding onboarding2 = new Onboarding();
+        onboarding2.setInstitution(institutionPspRequest);
+
+        Mockito.doAnswer(invocation -> Multi.createFrom().empty())
+                .doAnswer(invocation -> Multi.createFrom().items(onboarding1))
+                .doAnswer(invocation -> Multi.createFrom().items(onboarding2))
+                .when(query)
+                .stream();
 
         when(Onboarding.find(any())).thenReturn(query);
+        when(Onboarding.find(any(Document.class), any(Document.class))).thenReturn(query);
 
         asserter.assertThat(
                 () -> onboardingService.onboarding(onboardingRequest, users, null),
@@ -1393,6 +1399,7 @@ class OnboardingServiceDefaultTest {
                     PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
                     PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
                     PanacheMock.verify(Onboarding.class, times(2)).find(any(Document.class));
+                    PanacheMock.verify(Onboarding.class, times(1)).find(any(Document.class), any(Document.class));
                     PanacheMock.verifyNoMoreInteractions(Onboarding.class);
                 });
     }
@@ -2537,10 +2544,12 @@ class OnboardingServiceDefaultTest {
         request.setSubunitCode("subunitCode");
         request.setProductId(PROD_INTEROP.getValue());
         request.setUsers(users);
+        request.setInstitutionType(PA);
 
         org.openapi.quarkus.core_json.model.InstitutionResponse institutionResponse = new org.openapi.quarkus.core_json.model.InstitutionResponse();
         institutionResponse.setOrigin(Origin.IPA.name());
         institutionResponse.setOriginId("originId");
+        institutionResponse.setInstitutionType(org.openapi.quarkus.core_json.model.InstitutionResponse.InstitutionTypeEnum.PSP);
         InstitutionsResponse response = new InstitutionsResponse();
         response.setInstitutions(List.of(institutionResponse, institutionResponse));
         when(institutionApi.getInstitutionsUsingGET("taxCode", "subunitCode", null, null))
@@ -2551,6 +2560,48 @@ class OnboardingServiceDefaultTest {
                 .subscribe()
                 .withSubscriber(UniAssertSubscriber.create())
                 .assertFailedWith(ResourceNotFoundException.class);
+
+    }
+
+    @Test
+    @RunOnVertxContext
+    void onboardingUsersWithInstitutions(UniAsserter asserter) {
+
+        OnboardingUserRequest request = new OnboardingUserRequest();
+        List<UserRequest> users = List.of(manager);
+        request.setProductId(PROD_INTEROP.getValue());
+        request.setUsers(users);
+        request.setInstitutionType(InstitutionType.PSP);
+        mockPersistOnboarding(asserter);
+        mockPersistToken(asserter);
+
+        mockSimpleSearchPOSTAndPersist(asserter);
+        mockSimpleProductValidAssert(request.getProductId(), false, asserter);
+
+        Onboarding onboarding = createDummyOnboarding();
+        PanacheMock.mock(Onboarding.class);
+        ReactivePanacheQuery query = Mockito.mock(ReactivePanacheQuery.class);
+        when(query.stream()).thenReturn(Multi.createFrom().item(onboarding));
+        when(Onboarding.find((Document) any(), any())).thenReturn(query);
+
+        asserter.execute(() -> when(userRegistryApi.updateUsingPATCH(any(), any()))
+                .thenReturn(Uni.createFrom().item(Response.noContent().build())));
+
+        org.openapi.quarkus.core_json.model.InstitutionResponse institutionResponse = new org.openapi.quarkus.core_json.model.InstitutionResponse();
+        institutionResponse.setOrigin(Origin.IPA.name());
+        institutionResponse.setOriginId("originId");
+        institutionResponse.setInstitutionType(org.openapi.quarkus.core_json.model.InstitutionResponse.InstitutionTypeEnum.PSP);
+        InstitutionsResponse response = new InstitutionsResponse();
+        response.setInstitutions(List.of(institutionResponse, institutionResponse));
+        asserter.execute(() -> when(institutionApi.getInstitutionsUsingGET(any(), any(), any(), any()))
+                .thenReturn(Uni.createFrom().item(response)));
+
+        asserter.assertThat(() -> onboardingService.onboardingUsers(request, "userId", WorkflowType.USERS), Assertions::assertNotNull);
+
+        asserter.execute(() -> {
+            PanacheMock.verify(Onboarding.class).persist(any(Onboarding.class), any());
+            PanacheMock.verify(Onboarding.class).persistOrUpdate(any(List.class));
+        });
 
     }
 


### PR DESCRIPTION
…ionType

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- allowed duplicate institution onboarding with different institutionType
- allowed user onboarding for duplicate institution with different institutionType

#### Motivation and Context

To ensure that the pagopa BO works correctly in the DB, institutions (duplicates) with the same taxCode have been inserted, the only difference is the institutionType. For this reason, when the PSP entity tried to join a product, an error was returned because it was not known for which of the two institutions to do the onboarding. An additional discriminant (institutionType) has been inserted for which to recover the correct institution

#### How Has This Been Tested?

è stato avviato il MS in locale e sono stati effettuati degli onboarding con i casi classici e quello di institution duplicato

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.