### PR TITLE
[SELC-7142] feat: refactor onboarding aggregator/aggregate logic

### DIFF
--- a/apps/onboarding-cdc/src/main/openapi/onboarding_functions.json
+++ b/apps/onboarding-cdc/src/main/openapi/onboarding_functions.json
@@ -525,7 +525,8 @@
           "CONFIRMATION_AGGREGATE",
           "INCREMENT_REGISTRATION_AGGREGATOR",
           "USERS_PG",
-          "USERS_EA"
+          "USERS_EA",
+          "CONFIRMATION_AGGREGATOR"
         ],
         "type": "string"
       },

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -32,6 +32,7 @@ public class ActivityName {
   public static final String RESEND_NOTIFICATIONS_ACTIVITY = "ResendNotificationsActivity";
   public static final String CREATE_AGGREGATES_CSV_ACTIVITY = "CreateAggregatesCsv";
   public static final String EXISTS_DELEGATION_ACTIVITY = "ExistsDelegationActivity";
+  public static final String VERIFY_ONBOARDING_AGGREGATE_ACTIVITY = "ExistsOnboardingActivity";
   public static final String RETRIEVE_AGGREGATES_ACTIVITY = "RetrieveAggregates";
   public static final String BUILD_ATTACHMENTS_SAVE_TOKENS_ACTIVITY = "BuildAttachmentAndSaveTokens";
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -56,9 +56,11 @@ public interface OnboardingMapper {
         if (Objects.nonNull(institution)) {
             aggregate.setOrigin(institution.getOrigin());
             aggregate.setInstitutionType(institution.getInstitutionType());
+            aggregate.setCountry(institution.getCountry());
         }
         return aggregate;
     }
+
 
     @Named("mapAggregateUsers")
     default List<User> mapAggregateUsers(Onboarding onboarding, AggregateInstitution aggregateInstitution) {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionService.java
@@ -34,6 +34,8 @@ public interface CompletionService {
 
     String existsDelegation(OnboardingAggregateOrchestratorInput onboardingAggregateOrchestratorInput);
 
+    String verifyOnboardingAggregate(OnboardingAggregateOrchestratorInput onboardingAggregateOrchestratorInput);
+
     List<DelegationResponse> retrieveAggregates(Onboarding onboarding);
 
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -311,7 +311,7 @@ public class CompletionServiceDefault implements CompletionService {
                                     input.getProductId())
                             .stream()
                             .findFirst()
-                            .map(o -> o.getInstitution().getId())
+                            .map(onboardingAggregator -> onboardingAggregator.getInstitution().getId())
                             .orElseThrow(() -> new GenericOnboardingException("Onboarding not found"))
             );
         }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/CompletionServiceDefault.java
@@ -302,12 +302,18 @@ public class CompletionServiceDefault implements CompletionService {
     @Override
     public String verifyOnboardingAggregate(OnboardingAggregateOrchestratorInput input) {
         if (Objects.isNull(input.getInstitution().getId())) {
-            Onboarding onboardingAggregator = onboardingRepository.findByFilters(input.getInstitution().getTaxCode(),
-                            null, input.getInstitution().getOrigin().getValue(),
-                            input.getInstitution().getOriginId(), input.getProductId()).stream()
-                    .findFirst()
-                    .orElseThrow(() -> new GenericOnboardingException("Onboarding not found"));
-            input.getInstitution().setId(onboardingAggregator.getInstitution().getId());
+            input.getInstitution().setId(
+                    onboardingRepository.findByFilters(
+                                    input.getInstitution().getTaxCode(),
+                                    null,
+                                    input.getInstitution().getOrigin().getValue(),
+                                    input.getInstitution().getOriginId(),
+                                    input.getProductId())
+                            .stream()
+                            .findFirst()
+                            .map(o -> o.getInstitution().getId())
+                            .orElseThrow(() -> new GenericOnboardingException("Onboarding not found"))
+            );
         }
 
         if (Objects.isNull(input.getAggregate().getId())) {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
@@ -157,7 +157,11 @@ public interface WorkflowExecutor {
                                                 EXISTS_DELEGATION_ACTIVITY, onboardingAggregateWithInstitutionId, String.class)
                                         .await());
                 if (!existsDelegation) {
-                    ctx.callActivity(CREATE_DELEGATION_ACTIVITY, onboardingAggregateWithInstitutionIdString, String.class).await();
+                    String delegationId = ctx.callActivity(CREATE_DELEGATION_ACTIVITY, onboardingAggregateWithInstitutionIdString, String.class).await();
+                    onboardingAggregateWithInstitutionId.setDelegationId(delegationId);
+
+                    final String onboardingWithDelegationIdString = getOnboardingString(objectMapper(), onboardingAggregateWithInstitutionId);
+                    ctx.callActivity(CREATE_USERS_ACTIVITY, onboardingWithDelegationIdString, String.class).await();
                 }
             } else {
                 parallelTasks.add(ctx.callSubOrchestrator(ONBOARDINGS_AGGREGATE_ORCHESTRATOR, onboardingAggregateString, String.class));

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmationAggregator.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorConfirmationAggregator.java
@@ -1,0 +1,30 @@
+package it.pagopa.selfcare.onboarding.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.durabletask.TaskOptions;
+import com.microsoft.durabletask.TaskOrchestrationContext;
+import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
+import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
+import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
+
+import java.util.Optional;
+
+import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
+import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingWorkflowString;
+
+public class WorkflowExecutorConfirmationAggregator extends WorkflowExecutorContractRegistrationAggregator {
+
+    public WorkflowExecutorConfirmationAggregator(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) {
+        super(objectMapper, optionsRetry, onboardingMapper);
+    }
+
+    @Override
+    public Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
+        String onboardingWorkflowString = getOnboardingWorkflowString(super.objectMapper(), onboardingWorkflow);
+        ctx.callActivity(CREATE_AGGREGATES_CSV_ACTIVITY, onboardingWorkflowString, super.optionsRetry(), String.class).await();
+        ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, super.optionsRetry(), String.class).await();
+        ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, super.optionsRetry(), String.class).await();
+        return Optional.of(OnboardingStatus.PENDING);
+    }
+
+}

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
@@ -50,7 +50,7 @@ public class WorkflowExecutorContractRegistrationAggregator implements WorkflowE
 
         createInstitutionAndOnboardingAggregate(ctx, onboarding, onboardingMapper);
 
-        //ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, getOnboardingWorkflowString(objectMapper(), onboardingWorkflow), optionsRetry, String.class).await();
+        ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, getOnboardingWorkflowString(objectMapper(), onboardingWorkflow), optionsRetry, String.class).await();
         return Optional.of(OnboardingStatus.COMPLETED);
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
@@ -16,7 +16,17 @@ import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
 import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingWorkflowString;
 import static it.pagopa.selfcare.onboarding.utils.Utils.readOnboardingValue;
 
-public record WorkflowExecutorContractRegistrationAggregator(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) implements WorkflowExecutor {
+public class WorkflowExecutorContractRegistrationAggregator implements WorkflowExecutor {
+
+    private final ObjectMapper objectMapper;
+    private final TaskOptions optionsRetry;
+    protected final OnboardingMapper onboardingMapper;
+
+    public WorkflowExecutorContractRegistrationAggregator(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) {
+        this.objectMapper = objectMapper;
+        this.optionsRetry = optionsRetry;
+        this.onboardingMapper = onboardingMapper;
+    }
 
     @Override
     public Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
@@ -40,13 +50,23 @@ public record WorkflowExecutorContractRegistrationAggregator(ObjectMapper object
 
         createInstitutionAndOnboardingAggregate(ctx, onboarding, onboardingMapper);
 
-        ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, getOnboardingWorkflowString(objectMapper(), onboardingWorkflow), optionsRetry, String.class).await();
+        //ctx.callActivity(SEND_MAIL_COMPLETION_ACTIVITY, getOnboardingWorkflowString(objectMapper(), onboardingWorkflow), optionsRetry, String.class).await();
         return Optional.of(OnboardingStatus.COMPLETED);
     }
 
     @Override
     public OnboardingWorkflow createOnboardingWorkflow(Onboarding onboarding) {
         return new OnboardingWorkflowAggregator(onboarding, AGGREGATOR.name());
+    }
+
+    @Override
+    public ObjectMapper objectMapper() {
+        return objectMapper;
+    }
+
+    @Override
+    public TaskOptions optionsRetry() {
+        return optionsRetry;
     }
 
 

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -1,27 +1,7 @@
 package it.pagopa.selfcare.onboarding.functions;
 
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.BUILD_ATTACHMENTS_SAVE_TOKENS_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.BUILD_CONTRACT_ACTIVITY_NAME;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_AGGREGATES_CSV_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_AGGREGATE_ONBOARDING_REQUEST_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_DELEGATION_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_INSTITUTION_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_ONBOARDING_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.CREATE_USERS_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.EXISTS_DELEGATION_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.ONBOARDINGS_AGGREGATE_ORCHESTRATOR;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.RETRIEVE_AGGREGATES_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_COMPLETION_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_REGISTRATION_FOR_CONTRACT;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_REGISTRATION_FOR_CONTRACT_WHEN_APPROVE_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.SEND_MAIL_REJECTION_ACTIVITY;
-import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.STORE_ONBOARDING_ACTIVATEDAT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyList;
@@ -104,6 +84,12 @@ class OnboardingFunctionsTest {
   final String onboardingAttachmentString =
       "{\"onboardingString\":{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null},\"attachmentTemplate\":{"
           + "\"templatePath\": null, \"templateVersion\": null, \"name\": null, \"mandatory\": null, \"generated\": null, \"workflowType\": null, \"workflowState\": null, \"order\": null}}";
+
+  final String onboardingWithoutInstitutionIdString =
+          "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":{\"id\":null},\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
+
+  final String onboardingWithInstitutionIdString =
+          "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":{\"id\":\"inst123\"},\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
 
   static ExecutionContext executionContext;
 
@@ -231,6 +217,9 @@ class OnboardingFunctionsTest {
     onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+    Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
@@ -252,6 +241,57 @@ class OnboardingFunctionsTest {
   }
 
   @Test
+  void onboardingOrchestratorContractRegistrationAggregatorWithExistsAggregateOnboarding_Pending() {
+    Onboarding onboarding = new Onboarding();
+    onboarding.setId("onboardingId");
+    onboarding.setStatus(OnboardingStatus.PENDING);
+    AggregateInstitution aggregate1 = new AggregateInstitution();
+    aggregate1.setTaxCode("code1");
+    AggregateInstitution aggregate2 = new AggregateInstitution();
+    aggregate1.setTaxCode("code2");
+    AggregateInstitution aggregate3 = new AggregateInstitution();
+    aggregate1.setTaxCode("code3");
+    onboarding.setAggregates(List.of(aggregate1, aggregate2, aggregate3));
+    Institution institution = new Institution();
+    institution.setId("id");
+    onboarding.setInstitution(institution);
+    onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR);
+
+    TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+    Task<String> verifyTask2 = mockTaskWithValue("false");
+    Task<String> verifyWithInstitution = mockTaskWithValue(onboardingWithInstitutionIdString);
+    Task<String> verifyWithoutInstitution = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyWithInstitution)  // 1
+            .thenReturn(verifyWithInstitution)  // 2
+            .thenReturn(verifyWithoutInstitution);
+    when(orchestrationContext.callActivity(eq(EXISTS_DELEGATION_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask2);
+    Task<String> createDelegationTask = mockTaskWithValue("delegation-created");
+    when(orchestrationContext.callActivity(eq(CREATE_DELEGATION_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(createDelegationTask);
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
+
+    ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(orchestrationContext, times(5))
+            .callActivity(captorActivity.capture(), any(), any(), any());
+    assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
+    assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
+    assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
+    assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(3));
+    assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
+
+    Mockito.verify(orchestrationContext, times(1))
+            .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
+
+    Mockito.verify(service, times(1))
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
+  }
+
+  @Test
   void onboardingOrchestratorIncrementRegistrationAggregator_Pending_delgationAlreadyExists() {
     Onboarding onboarding = new Onboarding();
     onboarding.setId("onboardingId");
@@ -268,6 +308,9 @@ class OnboardingFunctionsTest {
 
     TaskOrchestrationContext orchestrationContext =
         mockTaskOrchestrationContextForIncrementAggregator(onboarding, "true");
+    Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     Mockito.verify(service, times(1))
@@ -279,7 +322,9 @@ class OnboardingFunctionsTest {
     Onboarding onboarding = getOnboarding();
     TaskOrchestrationContext orchestrationContext =
         mockTaskOrchestrationContextForIncrementAggregator(onboarding, "false");
-
+    Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     Mockito.verify(orchestrationContext, times(2))
@@ -287,6 +332,69 @@ class OnboardingFunctionsTest {
 
     Mockito.verify(service, times(1))
         .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+  }
+
+  @Test
+  void onboardingOrchestratorConfirmationAggregator() {
+    Onboarding onboarding = new Onboarding();
+    onboarding.setId("onboardingId");
+    onboarding.setStatus(OnboardingStatus.REQUEST);
+    onboarding.setWorkflowType(WorkflowType.CONFIRMATION_AGGREGATOR);
+
+    TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
+
+    ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+    verify(orchestrationContext, times(3))
+            .callActivity(captorActivity.capture(), any(), any(), any());
+    assertEquals(CREATE_AGGREGATES_CSV_ACTIVITY, captorActivity.getAllValues().get(0));
+    assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
+    assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(2));
+
+    verify(service, times(1)).updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
+
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
+  }
+
+  @Test
+  void onboardingOrchestratorConfirmationAggregator_Pending() {
+    Onboarding onboarding = new Onboarding();
+    onboarding.setId("onboardingId");
+    onboarding.setStatus(OnboardingStatus.PENDING);
+    AggregateInstitution aggregate1 = new AggregateInstitution();
+    aggregate1.setTaxCode("code1");
+    AggregateInstitution aggregate2 = new AggregateInstitution();
+    aggregate1.setTaxCode("code2");
+    AggregateInstitution aggregate3 = new AggregateInstitution();
+    aggregate1.setTaxCode("code3");
+    onboarding.setAggregates(List.of(aggregate1, aggregate2, aggregate3));
+    Institution institution = new Institution();
+    institution.setId("id");
+    onboarding.setInstitution(institution);
+    onboarding.setWorkflowType(WorkflowType.CONFIRMATION_AGGREGATOR);
+
+    TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
+    Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask);
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
+
+    ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
+    Mockito.verify(orchestrationContext, times(5))
+            .callActivity(captorActivity.capture(), any(), any(), any());
+    assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
+    assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
+    assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
+    assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(3));
+    assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
+
+    Mockito.verify(orchestrationContext, times(3))
+            .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
+
+    Mockito.verify(service, times(1))
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+
+    function.onboardingsOrchestrator(orchestrationContext, executionContext);
   }
 
   private static Onboarding getOnboarding() {
@@ -1094,6 +1202,18 @@ class OnboardingFunctionsTest {
   }
 
   @Test
+  void verifyOnboardingAggregate() {
+
+    when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
+    when(completionService.verifyOnboardingAggregate(any())).thenReturn(onboardingWithoutInstitutionIdString);
+
+    String onboardingAggregate = function.verifyOnboardingAggregate(onboardingStringBase, executionContext);
+
+    Assertions.assertEquals(onboardingAggregate, onboardingWithoutInstitutionIdString);
+    verify(completionService, times(1)).verifyOnboardingAggregate(any());
+  }
+
+  @Test
   void sendTestEmail() {
     @SuppressWarnings("unchecked")
     final HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
@@ -1258,7 +1378,9 @@ class OnboardingFunctionsTest {
     onboarding.setAggregates(aggregateInstitutions);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
-
+    Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
+    when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(verifyTask);
     // when
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
@@ -1286,6 +1408,17 @@ class OnboardingFunctionsTest {
     product.setUserContractMappings(createDummyContractTemplateInstitution());
 
     return product;
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> Task<T> mockTaskWithValue(T value) {
+    Task<T> task = mock(Task.class);
+    try {
+      when(task.await()).thenReturn(value);
+    } catch (Exception e) {
+      fail("Failed mocking task.await(): " + e.getMessage());
+    }
+    return task;
   }
 
   private static Map<String, ContractTemplate> createDummyContractTemplateInstitution() {

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -271,6 +271,9 @@ class OnboardingFunctionsTest {
     Task<String> createDelegationTask = mockTaskWithValue("delegation-created");
     when(orchestrationContext.callActivity(eq(CREATE_DELEGATION_ACTIVITY), any(), eq(String.class)))
             .thenReturn(createDelegationTask);
+    Task<String> createUserTask = mockTaskWithValue("user-created");
+    when(orchestrationContext.callActivity(eq(CREATE_USERS_ACTIVITY), any(), eq(String.class)))
+            .thenReturn(createUserTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);

--- a/apps/onboarding-ms/src/main/docs/openapi.json
+++ b/apps/onboarding-ms/src/main/docs/openapi.json
@@ -478,8 +478,8 @@
     "/v1/onboarding/aggregation/completion" : {
       "post" : {
         "tags" : [ "Onboarding Controller" ],
-        "summary" : "Asynchronously complete aggregated onboarding to COMPLETED status.",
-        "description" : "Perform onboarding aggregation as /onboarding but completing the onboarding request to COMPLETED phase. The operation will be performed async due to the possible amount of time the process could take.",
+        "summary" : "Asynchronously complete aggregated onboarding to PENDING status.",
+        "description" : "Perform onboarding aggregation as /onboarding to PENDING phase. The operation will be performed async due to the possible amount of time the process could take.",
         "operationId" : "onboardingAggregationCompletion",
         "requestBody" : {
           "content" : {
@@ -562,6 +562,44 @@
             "application/json" : {
               "schema" : {
                 "$ref" : "#/components/schemas/OnboardingPaRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/OnboardingResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/v1/onboarding/aggregation/psp/completion" : {
+      "post" : {
+        "tags" : [ "Onboarding Controller" ],
+        "summary" : "Asynchronously complete aggregated PSP onboarding to PENDING status.",
+        "description" : "Perform onboarding aggregation as /onboarding to PENDING phase. The operation will be performed async due to the possible amount of time the process could take.",
+        "operationId" : "onboardingAggregationPspCompletion",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/OnboardingPspRequest"
               }
             }
           }

--- a/apps/onboarding-ms/src/main/docs/openapi.yaml
+++ b/apps/onboarding-ms/src/main/docs/openapi.yaml
@@ -346,10 +346,10 @@ paths:
     post:
       tags:
       - Onboarding Controller
-      summary: Asynchronously complete aggregated onboarding to COMPLETED status.
-      description: Perform onboarding aggregation as /onboarding but completing the
-        onboarding request to COMPLETED phase. The operation will be performed async
-        due to the possible amount of time the process could take.
+      summary: Asynchronously complete aggregated onboarding to PENDING status.
+      description: Perform onboarding aggregation as /onboarding to PENDING phase.
+        The operation will be performed async due to the possible amount of time the
+        process could take.
       operationId: onboardingAggregationCompletion
       requestBody:
         content:
@@ -410,6 +410,33 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/OnboardingPaRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OnboardingResponse"
+        "401":
+          description: Not Authorized
+        "403":
+          description: Not Allowed
+      security:
+      - SecurityScheme: []
+  /v1/onboarding/aggregation/psp/completion:
+    post:
+      tags:
+      - Onboarding Controller
+      summary: Asynchronously complete aggregated PSP onboarding to PENDING status.
+      description: Perform onboarding aggregation as /onboarding to PENDING phase.
+        The operation will be performed async due to the possible amount of time the
+        process could take.
+      operationId: onboardingAggregationPspCompletion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OnboardingPspRequest"
       responses:
         "200":
           description: OK

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/controller/OnboardingController.java
@@ -519,14 +519,28 @@ public class OnboardingController {
     }
 
     @Operation(
-            summary = "Asynchronously complete aggregated onboarding to COMPLETED status.",
-            description = "Perform onboarding aggregation as /onboarding but completing the onboarding request to COMPLETED phase. The operation will be performed async due to the possible amount of time the process could take."
+            summary = "Asynchronously complete aggregated onboarding to PENDING status.",
+            description = "Perform onboarding aggregation as /onboarding to PENDING phase. The operation will be performed async due to the possible amount of time the process could take."
     )
     @Path("/aggregation/completion")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Uni<OnboardingResponse> onboardingAggregationCompletion(@Valid OnboardingDefaultRequest onboardingRequest, @Context SecurityContext ctx) {
+        return readUserIdFromToken(ctx)
+                .onItem().transformToUni(userId -> onboardingService
+                        .onboardingAggregationCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers(), onboardingRequest.getAggregates()));
+    }
+
+    @Operation(
+            summary = "Asynchronously complete aggregated PSP onboarding to PENDING status.",
+            description = "Perform onboarding aggregation as /onboarding to PENDING phase. The operation will be performed async due to the possible amount of time the process could take."
+    )
+    @Path("/aggregation/psp/completion")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Uni<OnboardingResponse> onboardingAggregationPspCompletion(@Valid OnboardingPspRequest onboardingRequest, @Context SecurityContext ctx) {
         return readUserIdFromToken(ctx)
                 .onItem().transformToUni(userId -> onboardingService
                         .onboardingAggregationCompletion(fillUserId(onboardingMapper.toEntity(onboardingRequest), userId), onboardingRequest.getUsers(), onboardingRequest.getAggregates()));

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/entity/registry/RegistryManagerSELC.java
@@ -40,7 +40,7 @@ public class RegistryManagerSELC extends BaseRegistryManager<Object> {
                 workflowType == WorkflowType.FOR_APPROVE_PT ||
                 workflowType == WorkflowType.FOR_APPROVE_GPU ||
                 workflowType == WorkflowType.CONFIRMATION ||
-                workflowType == WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR;
+                workflowType == WorkflowType.CONFIRMATION_AGGREGATOR;
     }
 
     @Override

--- a/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
+++ b/apps/onboarding-ms/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingServiceDefault.java
@@ -257,8 +257,8 @@ public class OnboardingServiceDefault implements OnboardingService {
             Onboarding onboarding,
             List<UserRequest> userRequests,
             List<AggregateInstitutionRequest> aggregates) {
-        onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR);
-        onboarding.setStatus(PENDING);
+        onboarding.setWorkflowType(WorkflowType.CONFIRMATION_AGGREGATOR);
+        onboarding.setStatus(OnboardingStatus.REQUEST);
 
         return fillUsersAndOnboarding(onboarding, userRequests, aggregates, null, false);
     }

--- a/apps/onboarding-ms/src/main/openapi/onboarding_functions.json
+++ b/apps/onboarding-ms/src/main/openapi/onboarding_functions.json
@@ -521,7 +521,9 @@
           "FOR_APPROVE_GPU",
           "CONFIRMATION",
           "IMPORT",
-          "IMPORT_AGGREGATION"
+          "IMPORT_AGGREGATION",
+          "CONFIRMATION_AGGREGATOR",
+          "CONTRACT_REGISTRATION_AGGREGATOR"
         ],
         "type": "string"
       },

--- a/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
+++ b/apps/onboarding-ms/src/test/java/it/pagopa/selfcare/onboarding/controller/OnboardingControllerTest.java
@@ -1177,7 +1177,7 @@ class OnboardingControllerTest {
 
     @Test
     @TestSecurity(user = "userJwt")
-    void onboardingAggregationComplete() {
+    void onboardingAggregationCompletion() {
 
         Mockito.when(onboardingService.onboardingAggregationCompletion(any(), any(), any()))
                 .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
@@ -1187,6 +1187,25 @@ class OnboardingControllerTest {
                 .body(onboardingBaseValid)
                 .contentType(ContentType.JSON)
                 .post("/aggregation/completion")
+                .then()
+                .statusCode(200);
+
+        Mockito.verify(onboardingService, times(1))
+                .onboardingAggregationCompletion(any(), any(), any());
+    }
+
+    @Test
+    @TestSecurity(user = "userJwt")
+    void onboardingAggregationPspCompletion() {
+
+        Mockito.when(onboardingService.onboardingAggregationCompletion(any(), any(), any()))
+                .thenReturn(Uni.createFrom().item(new OnboardingResponse()));
+
+        given()
+                .when()
+                .body(onboardingPspValid)
+                .contentType(ContentType.JSON)
+                .post("/aggregation/psp/completion")
                 .then()
                 .statusCode(200);
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added CONFIRMATION_AGGREGATOR WorkflowType
- added new api for SM to complete onboarding aggregator
- added new logic to verify existing onboarding for aggregate


#### Motivation and Context

A good part of the logic of the onboarding of aggregator entities has been revised, in particular now when an entity that is present in the list of aggregates was already onboarded on AR, it is not created and provisioned and an onboarding is completed again creating problems for datalake, but simply the delegation is created between the aggregate and the aggregator. In addition, the api for SM has been corrected by adding a new WorkflowType dedicated to adding aggregators/aggregates.

#### How Has This Been Tested?

the MS was started locally and the whole process was tested to verify that an entity already present on AR but present as an aggregate was not re-boarded but only the delegation was created

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.