### PR TITLE
[SELC-6979] feat: added logic to send mail for user during onboarding request phase

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctions.java
@@ -205,17 +205,17 @@ public class OnboardingFunctions {
 
       switch (onboarding.getWorkflowType()) {
         case CONTRACT_REGISTRATION ->
-            workflowExecutor = new WorkflowExecutorContractRegistration(objectMapper, optionsRetry);
+            workflowExecutor = new WorkflowExecutorContractRegistration(objectMapper, optionsRetry, onboardingMapper);
         case CONTRACT_REGISTRATION_AGGREGATOR ->
             workflowExecutor =
                 new WorkflowExecutorContractRegistrationAggregator(
                     objectMapper, optionsRetry, onboardingMapper);
         case FOR_APPROVE ->
-            workflowExecutor = new WorkflowExecutorForApprove(objectMapper, optionsRetry);
+            workflowExecutor = new WorkflowExecutorForApprove(objectMapper, optionsRetry, onboardingMapper);
         case FOR_APPROVE_PT ->
             workflowExecutor = new WorkflowExecutorForApprovePt(objectMapper, optionsRetry);
         case FOR_APPROVE_GPU ->
-            workflowExecutor = new WorkflowExecutorForApproveGpu(objectMapper, optionsRetry);
+            workflowExecutor = new WorkflowExecutorForApproveGpu(objectMapper, optionsRetry, onboardingMapper);
         case CONFIRMATION ->
             workflowExecutor = new WorkflowExecutorConfirmation(objectMapper, optionsRetry);
         case CONFIRMATION_AGGREGATE ->
@@ -451,6 +451,23 @@ public class OnboardingFunctions {
                     SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY,
                     onboardingString));
     service.sendMailRegistration(readOnboardingValue(objectMapper, onboardingString));
+  }
+
+  /** This is the activity function that gets invoked by the orchestrator function. */
+  @FunctionName(SEND_MAIL_REGISTRATION_FOR_USER)
+  public void sendMailRegistrationForUser(
+          @DurableActivityTrigger(name = "onboardingString") String onboardingString,
+          final ExecutionContext context) {
+    context
+            .getLogger()
+            .info(
+                    () ->
+                            String.format(
+                                    FORMAT_LOGGER_ONBOARDING_STRING,
+                                    SEND_MAIL_REGISTRATION_FOR_USER,
+                                    onboardingString));
+    service.sendMailRegistrationForUser(
+            readOnboardingValue(objectMapper, onboardingString));
   }
 
   @FunctionName(SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY)

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/functions/utils/ActivityName.java
@@ -14,6 +14,7 @@ public class ActivityName {
       "SendMailRegistrationForContractWhenApprove";
   public static final String SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY =
       "SendMailRegistrationRequest";
+  public static final String SEND_MAIL_REGISTRATION_FOR_USER = "SendMailRegistrationForUser";
   public static final String SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY =
       "SendMailRegistrationApprove";
   public static final String SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY = "SendMailOnboardingApprove";

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/OnboardingMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.openapi.quarkus.core_json.model.DelegationResponse;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,6 +47,10 @@ public interface OnboardingMapper {
     @Mapping(target = "parentDescription", source = "institutionRootName")
     Institution mapInstitutionFromDelegation(DelegationResponse delegationResponse);
 
+    @Mapping(target = "id", source = "onboarding.id")
+    @Mapping(target = "users", expression = "java(mapSingleUser(user))")
+    Onboarding mapToOnboardingWithSingleUser(Onboarding onboarding, User user);
+
     /**
      * We need to create an explicit method to map the aggregate into the institution field of the new onboarding entity
      * because the data related to institutionType and origin must be retrieved from the aggregator,
@@ -79,6 +84,11 @@ public interface OnboardingMapper {
             onboarding.getUsers().forEach(user -> user.setRole(ADMIN_EA));
         }
         return onboarding.getUsers();
+    }
+
+    @Named("mapSingleUser")
+    default List<User> mapSingleUser(User user) {
+        return Collections.singletonList(user);
     }
 
     Institution mapFromAggregateInstitution(AggregateInstitution aggregateInstitution);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/UserMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/mapper/UserMapper.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.openapi.quarkus.user_json.model.AddUserRoleDto;
+import org.openapi.quarkus.user_json.model.PartyRole;
 
 @Mapper(componentModel = "cdi")
 public interface UserMapper {
@@ -14,7 +15,7 @@ public interface UserMapper {
     @Mapping(target = "product", source = ".")
     AddUserRoleDto toUserRole(Onboarding onboarding);
 
-
+    PartyRole toUserPartyRole(it.pagopa.selfcare.onboarding.common.PartyRole partyRole);
 
 
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/OnboardingService.java
@@ -20,6 +20,7 @@ import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
 import it.pagopa.selfcare.onboarding.entity.Token;
 import it.pagopa.selfcare.onboarding.entity.User;
 import it.pagopa.selfcare.onboarding.exception.GenericOnboardingException;
+import it.pagopa.selfcare.onboarding.mapper.UserMapper;
 import it.pagopa.selfcare.onboarding.repository.OnboardingRepository;
 import it.pagopa.selfcare.onboarding.repository.TokenRepository;
 import it.pagopa.selfcare.onboarding.utils.GenericError;
@@ -39,6 +40,7 @@ import org.bson.Document;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.openapi.quarkus.core_json.model.OnboardedProductResponse;
 import org.openapi.quarkus.user_json.api.InstitutionApi;
+import org.openapi.quarkus.user_json.model.SendMailDto;
 import org.openapi.quarkus.user_json.model.UserInstitutionResponse;
 import org.openapi.quarkus.user_registry_json.api.UserApi;
 import org.openapi.quarkus.user_registry_json.model.CertifiableFieldResourceOfstring;
@@ -60,6 +62,8 @@ public class OnboardingService {
 
   @RestClient @Inject UserApi userRegistryApi;
   @RestClient @Inject InstitutionApi userInstitutionApi;
+  @RestClient @Inject
+  org.openapi.quarkus.user_json.api.UserApi userApi;
   @Inject NotificationService notificationService;
   private final ContractService contractService;
   private final ProductService productService;
@@ -67,6 +71,7 @@ public class OnboardingService {
   private final TokenRepository tokenRepository;
   private final MailTemplatePathConfig mailTemplatePathConfig;
   private final MailTemplatePlaceholdersConfig mailTemplatePlaceholdersConfig;
+  private final UserMapper userMapper;
 
   public OnboardingService(
           ProductService productService,
@@ -75,7 +80,7 @@ public class OnboardingService {
           MailTemplatePathConfig mailTemplatePathConfig,
           MailTemplatePlaceholdersConfig mailTemplatePlaceholdersConfig,
           TokenRepository tokenRepository,
-          NotificationService notificationService) {
+          NotificationService notificationService, UserMapper userMapper) {
     this.contractService = contractService;
     this.repository = repository;
     this.tokenRepository = tokenRepository;
@@ -83,6 +88,7 @@ public class OnboardingService {
     this.notificationService = notificationService;
     this.mailTemplatePathConfig = mailTemplatePathConfig;
     this.mailTemplatePlaceholdersConfig = mailTemplatePlaceholdersConfig;
+      this.userMapper = userMapper;
   }
 
   public Optional<Onboarding> getOnboarding(String onboardingId) {
@@ -231,6 +237,22 @@ public class OnboardingService {
             sendMailInput.userRequestName,
             sendMailInput.userRequestSurname,
             sendMailInput.product.getTitle());
+  }
+
+  public void sendMailRegistrationForUser(Onboarding onboarding) {
+
+   User user = onboarding.getUsers().get(0);
+   SendMailDto sendMailDto = new SendMailDto();
+   sendMailDto.setInstitutionName(onboarding.getInstitution().getDescription());
+   sendMailDto.setProductId(onboarding.getProductId());
+   sendMailDto.setRole(userMapper.toUserPartyRole(user.getRole()));
+   sendMailDto.setUserMailUuid(user.getUserMailUuid());
+
+   try {
+     userApi.sendMailRequest(user.getId(), sendMailDto);
+   } catch (Exception e) {
+     log.error("Impossible to send mail to user");
+   }
   }
 
   public void sendMailRegistrationForContract(OnboardingWorkflow onboardingWorkflow) {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutor.java
@@ -202,4 +202,13 @@ public interface WorkflowExecutor {
         }
     }
 
+    default void sendMailForUserActivity(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow, OnboardingMapper onboardingMapper) {
+        Onboarding onboarding = onboardingWorkflow.getOnboarding();
+        onboarding.getUsers().forEach(user -> {
+            Onboarding onboardingWithSingleUser = onboardingMapper.mapToOnboardingWithSingleUser(onboardingWorkflow.getOnboarding(), user);
+            onboardingWorkflow.setOnboarding(onboardingWithSingleUser);
+            ctx.callActivity(SEND_MAIL_REGISTRATION_FOR_USER, getOnboardingString(objectMapper(), onboardingWorkflow.getOnboarding()), optionsRetry(), String.class).await();
+        });
+    }
+
 }

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistration.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistration.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowInstitution;
+import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
 
 import java.util.Optional;
 
@@ -14,7 +15,7 @@ import static it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowType.INSTIT
 import static it.pagopa.selfcare.onboarding.functions.utils.ActivityName.*;
 import static it.pagopa.selfcare.onboarding.utils.Utils.getOnboardingWorkflowString;
 
-public record WorkflowExecutorContractRegistration(ObjectMapper objectMapper, TaskOptions optionsRetry) implements WorkflowExecutor {
+public record WorkflowExecutorContractRegistration(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) implements WorkflowExecutor {
 
     @Override
     public Optional<OnboardingStatus> executeRequestState(TaskOrchestrationContext ctx, OnboardingWorkflow onboardingWorkflow) {
@@ -22,6 +23,7 @@ public record WorkflowExecutorContractRegistration(ObjectMapper objectMapper, Ta
         ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SEND_MAIL_REGISTRATION_FOR_CONTRACT, onboardingWorkflowString, optionsRetry, String.class).await();
+        sendMailForUserActivity(ctx, onboardingWorkflow, onboardingMapper);
         return Optional.of(OnboardingStatus.PENDING);
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorContractRegistrationAggregator.java
@@ -35,6 +35,7 @@ public class WorkflowExecutorContractRegistrationAggregator implements WorkflowE
         ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SEND_MAIL_REGISTRATION_FOR_CONTRACT, onboardingWorkflowString, optionsRetry, String.class).await();
+        sendMailForUserActivity(ctx, onboardingWorkflow, onboardingMapper);
         return Optional.of(OnboardingStatus.PENDING);
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprove.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApprove.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflowInstitution;
+import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
 
 import java.util.Optional;
 
@@ -19,10 +20,12 @@ public class WorkflowExecutorForApprove implements WorkflowExecutor {
 
     private final ObjectMapper objectMapper;
     private final TaskOptions optionsRetry;
+    private final OnboardingMapper onboardingMapper;
 
-    public WorkflowExecutorForApprove(ObjectMapper objectMapper, TaskOptions optionsRetry) {
+    public WorkflowExecutorForApprove(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) {
         this.objectMapper = objectMapper;
         this.optionsRetry = optionsRetry;
+        this.onboardingMapper = onboardingMapper;
     }
 
     @Override
@@ -38,6 +41,7 @@ public class WorkflowExecutorForApprove implements WorkflowExecutor {
         ctx.callActivity(BUILD_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, onboardingWorkflowString, optionsRetry, String.class).await();
         ctx.callActivity(SEND_MAIL_REGISTRATION_FOR_CONTRACT_WHEN_APPROVE_ACTIVITY, onboardingWorkflowString, optionsRetry, String.class).await();
+        sendMailForUserActivity(ctx, onboardingWorkflow, onboardingMapper);
         return Optional.of(OnboardingStatus.PENDING);
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApproveGpu.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/workflow/WorkflowExecutorForApproveGpu.java
@@ -8,12 +8,14 @@ import com.microsoft.durabletask.TaskOptions;
 import com.microsoft.durabletask.TaskOrchestrationContext;
 import it.pagopa.selfcare.onboarding.common.OnboardingStatus;
 import it.pagopa.selfcare.onboarding.entity.OnboardingWorkflow;
+import it.pagopa.selfcare.onboarding.mapper.OnboardingMapper;
+
 import java.util.Optional;
 
 public class WorkflowExecutorForApproveGpu extends WorkflowExecutorForApprove {
 
-    public WorkflowExecutorForApproveGpu(ObjectMapper objectMapper, TaskOptions optionsRetry) {
-        super(objectMapper, optionsRetry);
+    public WorkflowExecutorForApproveGpu(ObjectMapper objectMapper, TaskOptions optionsRetry, OnboardingMapper onboardingMapper) {
+        super(objectMapper, optionsRetry, onboardingMapper);
     }
 
     @Override

--- a/apps/onboarding-functions/src/main/openapi/user.json
+++ b/apps/onboarding-functions/src/main/openapi/user.json
@@ -122,6 +122,192 @@
         } ]
       }
     },
+    "/institutions/{institutionId}" : {
+      "put" : {
+        "tags" : [ "Institution" ],
+        "summary" : "Update institution's description across all userInstitution records",
+        "description" : "Modifies the description field in all occurrences of `userInstitution` entities associated with a given institutionId. This ensures that the institution's descriptive information is consistently updated across all related user records.",
+        "operationId" : "updateInstitutionDescription",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateDescriptionDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/institutions/{institutionId}/product/{productId}/check-user" : {
+      "post" : {
+        "tags" : [ "Institution" ],
+        "summary" : "Verify if a user is already onboarded on an institution and product given its fiscal code",
+        "description" : "Verify if a user is already onboarded on an institution and product given its fiscal code",
+        "operationId" : "checkUserUsingPOST",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SearchUserDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "boolean"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/institutions/{institutionId}/products/{productId}/created-at" : {
+      "put" : {
+        "tags" : [ "Institution" ],
+        "summary" : "Update user's onboarded product creation date",
+        "description" : "Updates the `createdAt` timestamp for a user's onboarded product based on the provided institutionId, productId, and list of userIds. This is useful for tracking when a user was onboarded to a specific product within an institution.",
+        "operationId" : "updateUserProductCreatedAt",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "createdAt",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/OffsetDateTime"
+          }
+        }, {
+          "name" : "userIds",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
     "/institutions/{institutionId}/products/{productId}/users" : {
       "delete" : {
         "tags" : [ "Institution" ],
@@ -200,54 +386,12 @@
         } ]
       }
     },
-    "/institutions/{institutionId}" : {
-      "put" : {
+    "/institutions/{institutionId}/products/{productId}/users/count" : {
+      "get" : {
         "tags" : [ "Institution" ],
-        "summary" : "Update institution's description across all userInstitution records",
-        "description" : "Modifies the description field in all occurrences of `userInstitution` entities associated with a given institutionId. This ensures that the institution's descriptive information is consistently updated across all related user records.",
-        "operationId" : "updateInstitutionDescription",
-        "parameters" : [ {
-          "name" : "institutionId",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/UpdateDescriptionDto"
-              }
-            }
-          }
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : { }
-            }
-          },
-          "401" : {
-            "description" : "Not Authorized"
-          },
-          "403" : {
-            "description" : "Not Allowed"
-          }
-        },
-        "security" : [ {
-          "SecurityScheme" : [ ]
-        } ]
-      }
-    },
-    "/institutions/{institutionId}/products/{productId}/created-at" : {
-      "put" : {
-        "tags" : [ "Institution" ],
-        "summary" : "Update user's onboarded product creation date",
-        "description" : "Updates the `createdAt` timestamp for a user's onboarded product based on the provided institutionId, productId, and list of userIds. This is useful for tracking when a user was onboarded to a specific product within an institution.",
-        "operationId" : "updateUserProductCreatedAt",
+        "summary" : "Get the number of users for a certain product of an institution with a certain role and status",
+        "description" : "Count the number of users associated with a specific product of an institution, with an optional filter by roles and status. If no filter is specified count users with any role in status ACTIVE",
+        "operationId" : "getUsersCount",
         "parameters" : [ {
           "name" : "institutionId",
           "in" : "path",
@@ -263,16 +407,17 @@
             "type" : "string"
           }
         }, {
-          "name" : "createdAt",
+          "name" : "roles",
           "in" : "query",
-          "required" : true,
           "schema" : {
-            "$ref" : "#/components/schemas/OffsetDateTime"
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
           }
         }, {
-          "name" : "userIds",
+          "name" : "status",
           "in" : "query",
-          "required" : true,
           "schema" : {
             "type" : "array",
             "items" : {
@@ -284,7 +429,11 @@
           "200" : {
             "description" : "OK",
             "content" : {
-              "application/json" : { }
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UsersCountResponse"
+                }
+              }
             }
           },
           "401" : {
@@ -1410,13 +1559,101 @@
         },
         "responses" : {
           "200" : {
-            "description" : "The user is already a manager for the specified product.",
+            "description" : "The user is already onboarded for the specified product.",
             "content" : {
               "application/json" : { }
             }
           },
           "201" : {
             "description" : "The user has been created or updated with a new role."
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/users/{userId}/send-mail-otp" : {
+      "post" : {
+        "tags" : [ "User" ],
+        "summary" : "Send an email with OTP",
+        "description" : "The sendEmailOtp function is used to send email containing a One Time Password for account verification",
+        "operationId" : "sendEmailOtp",
+        "parameters" : [ {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SendEmailOtpDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "202" : {
+            "description" : "Email send accepted!"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Not Authorized"
+          },
+          "403" : {
+            "description" : "Not Allowed"
+          }
+        },
+        "security" : [ {
+          "SecurityScheme" : [ ]
+        } ]
+      }
+    },
+    "/users/{userId}/send-mail-request" : {
+      "post" : {
+        "tags" : [ "User" ],
+        "summary" : "Sends an email notification to a user when the institution receives an onboarding request.",
+        "description" : "Sends an email notification to a user when the institution receives an onboarding request.",
+        "operationId" : "sendMailRequest",
+        "parameters" : [ {
+          "name" : "userId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SendMailDto"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created"
           },
           "401" : {
             "description" : "Not Authorized"
@@ -1495,6 +1732,21 @@
           },
           "hasToSendEmail" : {
             "type" : "boolean"
+          }
+        }
+      },
+      "DeletedUserCountResponse" : {
+        "type" : "object",
+        "properties" : {
+          "institutionId" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "deletedUserCount" : {
+            "format" : "int64",
+            "type" : "integer"
           }
         }
       },
@@ -1591,6 +1843,10 @@
           }
         }
       },
+      "PartyRole" : {
+        "enum" : [ "MANAGER", "DELEGATE", "SUB_DELEGATE", "OPERATOR", "ADMIN_EA" ],
+        "type" : "string"
+      },
       "PermissionTypeEnum" : {
         "enum" : [ "ADMIN", "ANY" ],
         "type" : "string"
@@ -1684,6 +1940,41 @@
           }
         }
       },
+      "SendEmailOtpDto" : {
+        "required" : [ "otp", "institutionalEmail" ],
+        "type" : "object",
+        "properties" : {
+          "otp" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "institutionalEmail" : {
+            "minLength" : 1,
+            "type" : "string"
+          }
+        }
+      },
+      "SendMailDto" : {
+        "required" : [ "userMailUuid", "institutionName", "productId", "role" ],
+        "type" : "object",
+        "properties" : {
+          "userMailUuid" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "institutionName" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "productId" : {
+            "minLength" : 1,
+            "type" : "string"
+          },
+          "role" : {
+            "$ref" : "#/components/schemas/PartyRole"
+          }
+        }
+      },
       "UpdateDescriptionDto" : {
         "required" : [ "institutionDescription" ],
         "type" : "object",
@@ -1698,7 +1989,6 @@
         }
       },
       "UpdateUserRequest" : {
-        "required" : [ "email" ],
         "type" : "object",
         "properties" : {
           "name" : {
@@ -1708,6 +1998,10 @@
             "type" : "string"
           },
           "email" : {
+            "type" : "string"
+          },
+          "mobilePhone" : {
+            "pattern" : "^\\+?[0-9]{7,15}$",
             "type" : "string"
           }
         }
@@ -1789,6 +2083,9 @@
             "$ref" : "#/components/schemas/CertifiableFieldResponseString"
           },
           "email" : {
+            "$ref" : "#/components/schemas/CertifiableFieldResponseString"
+          },
+          "mobilePhone" : {
             "$ref" : "#/components/schemas/CertifiableFieldResponseString"
           },
           "workContacts" : {
@@ -1966,6 +2263,9 @@
           "email" : {
             "type" : "string"
           },
+          "mobilePhone" : {
+            "type" : "string"
+          },
           "workContacts" : {
             "type" : "object",
             "additionalProperties" : {
@@ -1989,6 +2289,9 @@
           "email" : {
             "type" : "string"
           },
+          "mobilePhone" : {
+            "type" : "string"
+          },
           "role" : {
             "description" : "Available values: MANAGER, DELEGATE, SUB_DELEGATE, OPERATOR, ADMIN_EA",
             "type" : "string"
@@ -2004,6 +2307,33 @@
           },
           "relationshipStatus" : {
             "$ref" : "#/components/schemas/OnboardedProductState"
+          }
+        }
+      },
+      "UsersCountResponse" : {
+        "type" : "object",
+        "properties" : {
+          "institutionId" : {
+            "type" : "string"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "roles" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PartyRole"
+            }
+          },
+          "status" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OnboardedProductState"
+            }
+          },
+          "count" : {
+            "format" : "int64",
+            "type" : "integer"
           }
         }
       },
@@ -2023,21 +2353,6 @@
         "properties" : {
           "email" : {
             "$ref" : "#/components/schemas/CertifiableFieldResponseString"
-          }
-        }
-      },
-      "DeletedUserCountResponse" : {
-        "type" : "object",
-        "properties" : {
-          "institutionId" : {
-            "type" : "string"
-          },
-          "productId" : {
-            "type" : "string"
-          },
-          "deletedUserCount" : {
-            "format" : "int64",
-            "type" : "integer"
           }
         }
       }

--- a/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
+++ b/apps/onboarding-functions/src/test/java/it/pagopa/selfcare/onboarding/functions/OnboardingFunctionsTest.java
@@ -34,6 +34,7 @@ import it.pagopa.selfcare.onboarding.common.WorkflowType;
 import it.pagopa.selfcare.onboarding.entity.AggregateInstitution;
 import it.pagopa.selfcare.onboarding.entity.Institution;
 import it.pagopa.selfcare.onboarding.entity.Onboarding;
+import it.pagopa.selfcare.onboarding.entity.User;
 import it.pagopa.selfcare.onboarding.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.onboarding.service.CompletionService;
 import it.pagopa.selfcare.onboarding.service.OnboardingService;
@@ -73,17 +74,17 @@ class OnboardingFunctionsTest {
   final String onboardingStringBase = "{\"onboardingId\":\"onboardingId\"}";
 
   final String onboardingWorkflowString =
-      "{\"type\":\"INSTITUTION\",\"onboardingString\":{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}}";
+          "{\"type\":\"INSTITUTION\",\"onboardingString\":{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}}";
 
   final String onboardingString =
-      "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
+          "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
 
   final String onboardingString2 =
-      "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"CONTRACT_REGISTRATION\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
+          "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"CONTRACT_REGISTRATION\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
 
   final String onboardingAttachmentString =
-      "{\"onboardingString\":{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null},\"attachmentTemplate\":{"
-          + "\"templatePath\": null, \"templateVersion\": null, \"name\": null, \"mandatory\": null, \"generated\": null, \"workflowType\": null, \"workflowState\": null, \"order\": null}}";
+          "{\"onboardingString\":{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":null,\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null},\"attachmentTemplate\":{"
+                  + "\"templatePath\": null, \"templateVersion\": null, \"name\": null, \"mandatory\": null, \"generated\": null, \"workflowType\": null, \"workflowState\": null, \"order\": null}}";
 
   final String onboardingWithoutInstitutionIdString =
           "{\"id\":\"id\",\"productId\":\"prod-test\",\"testEnvProductIds\":null,\"workflowType\":\"FOR_APPROVE\",\"institution\":{\"id\":null},\"users\":null,\"aggregates\":null,\"pricingPlan\":null,\"billing\":null,\"signContract\":null,\"expiringDate\":null,\"status\":\"REQUEST\",\"userRequestUid\":null,\"workflowInstanceId\":null,\"createdAt\":null,\"updatedAt\":null,\"activatedAt\":null,\"deletedAt\":null,\"reasonForReject\":null,\"isAggregator\":null}";
@@ -114,13 +115,13 @@ class OnboardingFunctionsTest {
 
     doAnswer(
             (Answer<HttpResponseMessage.Builder>)
-                invocation -> {
-                  HttpStatus status = (HttpStatus) invocation.getArguments()[0];
-                  return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
-                      .status(status);
-                })
-        .when(req)
-        .createResponseBuilder(any(HttpStatus.class));
+                    invocation -> {
+                      HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                      return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
+                              .status(status);
+                    })
+            .when(req)
+            .createResponseBuilder(any(HttpStatus.class));
 
     final ExecutionContext context = mock(ExecutionContext.class);
     doReturn(Logger.getGlobal()).when(context).getLogger();
@@ -130,8 +131,8 @@ class OnboardingFunctionsTest {
     final String scheduleNewOrchestrationInstance = "scheduleNewOrchestrationInstance";
     doReturn(client).when(durableContext).getClient();
     doReturn(scheduleNewOrchestrationInstance)
-        .when(client)
-        .scheduleNewOrchestrationInstance("Onboardings", onboardingId);
+            .when(client)
+            .scheduleNewOrchestrationInstance("Onboardings", onboardingId);
 
     HttpResponseMessage responseMessage = function.startOrchestration(req, durableContext, context);
 
@@ -147,31 +148,37 @@ class OnboardingFunctionsTest {
     when(orchestrationContext.getInput(String.class)).thenReturn(onboardingId);
     when(service.getOnboarding(onboardingId)).thenReturn(Optional.empty());
     assertThrows(
-        ResourceNotFoundException.class,
-        () -> function.onboardingsOrchestrator(orchestrationContext, executionContext));
+            ResourceNotFoundException.class,
+            () -> function.onboardingsOrchestrator(orchestrationContext, executionContext));
 
     verify(service, times(1))
-        .updateOnboardingStatusAndInstanceId(
-            onboardingId, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
+            .updateOnboardingStatusAndInstanceId(
+                    onboardingId, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
   }
 
   @Test
   void onboardingsOrchestratorContractRegistration() {
     Onboarding onboarding = new Onboarding();
+    List<User> users = new ArrayList<>();
+    User user = new User();
+    users.add(user);
     onboarding.setId("onboardingId");
     onboarding.setStatus(OnboardingStatus.REQUEST);
     onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION);
+    onboarding.setUsers(users);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-    verify(orchestrationContext, times(3))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+    verify(orchestrationContext, times(4))
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(0));
     assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
     assertEquals(SEND_MAIL_REGISTRATION_FOR_CONTRACT, captorActivity.getAllValues().get(2));
+    assertEquals(SEND_MAIL_REGISTRATION_FOR_USER, captorActivity.getAllValues().get(3));
+
 
     verify(service, times(1)).updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
   }
@@ -179,20 +186,26 @@ class OnboardingFunctionsTest {
   @Test
   void onboardingOrchestratorContractRegistrationAggregator() {
     Onboarding onboarding = new Onboarding();
+    List<User> users = new ArrayList<>();
+    User user = new User();
+    users.add(user);
     onboarding.setId("onboardingId");
     onboarding.setStatus(OnboardingStatus.REQUEST);
     onboarding.setWorkflowType(WorkflowType.CONTRACT_REGISTRATION_AGGREGATOR);
+    onboarding.setUsers(users);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-    verify(orchestrationContext, times(4))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+    verify(orchestrationContext, times(5))
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_AGGREGATES_CSV_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
     assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(2));
     assertEquals(SEND_MAIL_REGISTRATION_FOR_CONTRACT, captorActivity.getAllValues().get(3));
+    assertEquals(SEND_MAIL_REGISTRATION_FOR_USER, captorActivity.getAllValues().get(4));
+
 
     verify(service, times(1)).updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
 
@@ -224,7 +237,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     Mockito.verify(orchestrationContext, times(5))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -232,10 +245,10 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
 
     Mockito.verify(orchestrationContext, times(3))
-        .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
+            .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
 
     Mockito.verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
   }
@@ -310,31 +323,31 @@ class OnboardingFunctionsTest {
     onboarding.setWorkflowType(WorkflowType.INCREMENT_REGISTRATION_AGGREGATOR);
 
     TaskOrchestrationContext orchestrationContext =
-        mockTaskOrchestrationContextForIncrementAggregator(onboarding, "true");
+            mockTaskOrchestrationContextForIncrementAggregator(onboarding, "true");
     Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
     when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
             .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     Mockito.verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
   void onboardingOrchestratorIncrementRegistrationAggregator_Pending_delgationNotExists() {
     Onboarding onboarding = getOnboarding();
     TaskOrchestrationContext orchestrationContext =
-        mockTaskOrchestrationContextForIncrementAggregator(onboarding, "false");
+            mockTaskOrchestrationContextForIncrementAggregator(onboarding, "false");
     Task<String> verifyTask = mockTaskWithValue(onboardingWithoutInstitutionIdString);
     when(orchestrationContext.callActivity(eq(VERIFY_ONBOARDING_AGGREGATE_ACTIVITY), any(), eq(String.class)))
             .thenReturn(verifyTask);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     Mockito.verify(orchestrationContext, times(2))
-        .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
+            .callSubOrchestrator(eq(ONBOARDINGS_AGGREGATE_ORCHESTRATOR), any(), any());
 
     Mockito.verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -429,7 +442,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(3))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(0));
     assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
     assertEquals(SEND_MAIL_REGISTRATION_FOR_CONTRACT, captorActivity.getAllValues().get(2));
@@ -450,32 +463,37 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(1))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(SEND_MAIL_ONBOARDING_APPROVE_ACTIVITY, captorActivity.getAllValues().get(0));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
   }
 
   @Test
   void onboardingsOrchestratorForApproveWhenToBeValidated() {
     Onboarding onboarding = new Onboarding();
+    List<User> users = new ArrayList<>();
+    User user = new User();
+    users.add(user);
     onboarding.setId("onboardingId");
     onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
     onboarding.setWorkflowType(WorkflowType.FOR_APPROVE);
+    onboarding.setUsers(users);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-    verify(orchestrationContext, times(3))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+    verify(orchestrationContext, times(4))
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(0));
     assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
     assertEquals(
-        SEND_MAIL_REGISTRATION_FOR_CONTRACT_WHEN_APPROVE_ACTIVITY,
-        captorActivity.getAllValues().get(2));
+            SEND_MAIL_REGISTRATION_FOR_CONTRACT_WHEN_APPROVE_ACTIVITY,
+            captorActivity.getAllValues().get(2));
+    assertEquals(SEND_MAIL_REGISTRATION_FOR_USER, captorActivity.getAllValues().get(3));
 
     verify(service, times(1)).updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
   }
@@ -494,7 +512,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(5))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -502,7 +520,7 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -520,7 +538,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(7))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -530,7 +548,7 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(6));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -548,7 +566,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     Mockito.verify(orchestrationContext, times(5))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_DELEGATION_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -556,7 +574,7 @@ class OnboardingFunctionsTest {
     assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(4));
 
     Mockito.verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
     Mockito.verify(completionService, times(0)).sendCompletedEmailAggregate(any());
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
@@ -579,11 +597,11 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(2))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     verify(orchestrationContext, times(1)).callSubOrchestrator(eq("Onboardings"), any(), any());
     assertEquals(EXISTS_DELEGATION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(
-        CREATE_AGGREGATE_ONBOARDING_REQUEST_ACTIVITY, captorActivity.getAllValues().get(1));
+            CREATE_AGGREGATE_ONBOARDING_REQUEST_ACTIVITY, captorActivity.getAllValues().get(1));
   }
 
   @Test
@@ -598,20 +616,20 @@ class OnboardingFunctionsTest {
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
 
     when(orchestrationContext.callActivity(any(), any(), any(), any()))
-        .thenThrow(ResourceNotFoundException.class);
+            .thenThrow(ResourceNotFoundException.class);
 
     assertThrows(
-        ResourceNotFoundException.class,
-        () -> function.onboardingsAggregateOrchestrator(orchestrationContext, executionContext));
+            ResourceNotFoundException.class,
+            () -> function.onboardingsAggregateOrchestrator(orchestrationContext, executionContext));
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(1))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
 
     assertEquals(EXISTS_DELEGATION_ACTIVITY, captorActivity.getAllValues().get(0));
     verify(service, times(1))
-        .updateOnboardingStatusAndInstanceId(
-            null, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
+            .updateOnboardingStatusAndInstanceId(
+                    null, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
   }
 
   @Test
@@ -626,20 +644,20 @@ class OnboardingFunctionsTest {
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
 
     when(orchestrationContext.callActivity(any(), any(), any(), any()))
-        .thenThrow(TaskFailedException.class);
+            .thenThrow(TaskFailedException.class);
 
     assertThrows(
-        TaskFailedException.class,
-        () -> function.onboardingsAggregateOrchestrator(orchestrationContext, executionContext));
+            TaskFailedException.class,
+            () -> function.onboardingsAggregateOrchestrator(orchestrationContext, executionContext));
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(1))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
 
     assertEquals(EXISTS_DELEGATION_ACTIVITY, captorActivity.getAllValues().get(0));
     verify(service, times(1))
-        .updateOnboardingStatusAndInstanceId(
-            null, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
+            .updateOnboardingStatusAndInstanceId(
+                    null, OnboardingStatus.FAILED, orchestrationContext.getInstanceId());
   }
 
   @Test
@@ -656,13 +674,13 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(3))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -704,13 +722,13 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(3))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(1));
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(2));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -726,12 +744,12 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(2))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(SEND_MAIL_REGISTRATION_REQUEST_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(SEND_MAIL_REGISTRATION_APPROVE_ACTIVITY, captorActivity.getAllValues().get(1));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.TOBEVALIDATED);
   }
 
   @Test
@@ -748,7 +766,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(5))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -756,7 +774,7 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   TaskOrchestrationContext mockTaskOrchestrationContext(Onboarding onboarding) {
@@ -775,7 +793,7 @@ class OnboardingFunctionsTest {
   }
 
   TaskOrchestrationContext mockTaskOrchestrationContextForIncrementAggregator(
-      Onboarding onboarding, String returnValue) {
+          Onboarding onboarding, String returnValue) {
     TaskOrchestrationContext orchestrationContext = mock(TaskOrchestrationContext.class);
     when(orchestrationContext.getInput(String.class)).thenReturn(onboarding.getId());
     when(service.getOnboarding(onboarding.getId())).thenReturn(Optional.of(onboarding));
@@ -790,13 +808,13 @@ class OnboardingFunctionsTest {
   }
 
   TaskOrchestrationContext mockTaskOrchestrationContextForUsersEa(
-      Onboarding onboarding, List<DelegationResponse> delegationResponseList) {
+          Onboarding onboarding, List<DelegationResponse> delegationResponseList) {
     TaskOrchestrationContext orchestrationContext = mock(TaskOrchestrationContext.class);
     when(orchestrationContext.getInput(String.class)).thenReturn(onboarding.getId());
     when(service.getOnboarding(anyString())).thenReturn(Optional.of(onboarding));
     when(completionService.retrieveAggregates(any())).thenReturn(delegationResponseList);
     String delegationResponseListString =
-        Utils.getDelegationResponseListString(objectMapper, delegationResponseList);
+            Utils.getDelegationResponseListString(objectMapper, delegationResponseList);
 
     Task task = mock(Task.class);
     when(orchestrationContext.callActivity(any(), any(), any(), any())).thenReturn(task);
@@ -823,13 +841,13 @@ class OnboardingFunctionsTest {
 
     doAnswer(
             (Answer<HttpResponseMessage.Builder>)
-                invocation -> {
-                  HttpStatus status = (HttpStatus) invocation.getArguments()[0];
-                  return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
-                      .status(status);
-                })
-        .when(req)
-        .createResponseBuilder(any(HttpStatus.class));
+                    invocation -> {
+                      HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                      return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
+                              .status(status);
+                    })
+            .when(req)
+            .createResponseBuilder(any(HttpStatus.class));
 
     final ExecutionContext context = mock(ExecutionContext.class);
     doReturn(Logger.getGlobal()).when(context).getLogger();
@@ -840,17 +858,17 @@ class OnboardingFunctionsTest {
 
     doReturn(client).when(durableContext).getClient();
     doReturn(instanceId)
-        .when(client)
-        .scheduleNewOrchestrationInstance("BuildAttachmentAndSaveToken", onboardingString);
+            .when(client)
+            .scheduleNewOrchestrationInstance("BuildAttachmentAndSaveToken", onboardingString);
     when(durableContext.createCheckStatusResponse(req, instanceId))
-        .thenReturn(
-            new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
-                .status(HttpStatus.ACCEPTED)
-                .build());
+            .thenReturn(
+                    new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
+                            .status(HttpStatus.ACCEPTED)
+                            .build());
 
     // Invoke
     HttpResponseMessage responseMessage =
-        function.buildAttachmentsAndSaveTokens(req, durableContext, context);
+            function.buildAttachmentsAndSaveTokens(req, durableContext, context);
 
     // Verify
     assertEquals(HttpStatus.ACCEPTED.value(), responseMessage.getStatusCode());
@@ -864,13 +882,13 @@ class OnboardingFunctionsTest {
 
     doAnswer(
             (Answer<HttpResponseMessage.Builder>)
-                invocation -> {
-                  HttpStatus status = (HttpStatus) invocation.getArguments()[0];
-                  return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
-                      .status(status);
-                })
-        .when(req)
-        .createResponseBuilder(any(HttpStatus.class));
+                    invocation -> {
+                      HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                      return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
+                              .status(status);
+                    })
+            .when(req)
+            .createResponseBuilder(any(HttpStatus.class));
 
     final ExecutionContext context = mock(ExecutionContext.class);
     doReturn(Logger.getGlobal()).when(context).getLogger();
@@ -879,7 +897,7 @@ class OnboardingFunctionsTest {
 
     // Invoke
     HttpResponseMessage responseMessage =
-        function.buildAttachmentsAndSaveTokens(req, durableContext, context);
+            function.buildAttachmentsAndSaveTokens(req, durableContext, context);
 
     // Verify
     assertEquals(HttpStatus.BAD_REQUEST.value(), responseMessage.getStatusCode());
@@ -984,6 +1002,17 @@ class OnboardingFunctionsTest {
   }
 
   @Test
+  void sendMailRegistrationForUser() {
+
+    when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
+    doNothing().when(service).sendMailRegistrationForUser(any());
+
+    function.sendMailRegistrationForUser(onboardingStringBase, executionContext);
+
+    verify(service, times(1)).sendMailRegistrationForUser(any());
+  }
+
+  @Test
   void sendMailRegistrationApprove() {
 
     when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
@@ -1030,7 +1059,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(5))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(2));
@@ -1038,7 +1067,7 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(4));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
   }
 
   @Test
@@ -1055,7 +1084,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(1))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(SEND_MAIL_REJECTION_ACTIVITY, captorActivity.getAllValues().get(0));
   }
 
@@ -1073,7 +1102,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(2))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(STORE_ONBOARDING_ACTIVATEDAT, captorActivity.getAllValues().get(1));
   }
@@ -1092,7 +1121,7 @@ class OnboardingFunctionsTest {
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(0))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
   }
 
   @Test
@@ -1101,10 +1130,10 @@ class OnboardingFunctionsTest {
     final String institutionId = "institutionId";
     when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
     when(completionService.createInstitutionAndPersistInstitutionId(any()))
-        .thenReturn(institutionId);
+            .thenReturn(institutionId);
 
     String actualInstitutionId =
-        function.createInstitutionAndPersistInstitutionId(onboardingStringBase, executionContext);
+            function.createInstitutionAndPersistInstitutionId(onboardingStringBase, executionContext);
 
     assertEquals(institutionId, actualInstitutionId);
     verify(completionService, times(1)).createInstitutionAndPersistInstitutionId(any());
@@ -1174,8 +1203,8 @@ class OnboardingFunctionsTest {
     when(completionService.createAggregateOnboardingRequest(any())).thenReturn(onboardingId);
 
     String response =
-        function.createAggregateOnboardingRequest(
-            onboardingAggregateOrchestratorInputString, executionContext);
+            function.createAggregateOnboardingRequest(
+                    onboardingAggregateOrchestratorInputString, executionContext);
 
     Assertions.assertEquals(onboardingId, response);
     Mockito.verify(completionService, times(1)).createAggregateOnboardingRequest(any());
@@ -1187,7 +1216,7 @@ class OnboardingFunctionsTest {
     when(completionService.createDelegation(any())).thenReturn("delegationId");
 
     String delegationId =
-        function.createDelegationForAggregation(onboardingStringBase, executionContext);
+            function.createDelegationForAggregation(onboardingStringBase, executionContext);
 
     Assertions.assertEquals("delegationId", delegationId);
     verify(completionService, times(1)).createDelegation(any());
@@ -1223,13 +1252,13 @@ class OnboardingFunctionsTest {
 
     doAnswer(
             (Answer<HttpResponseMessage.Builder>)
-                invocation -> {
-                  HttpStatus status = (HttpStatus) invocation.getArguments()[0];
-                  return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
-                      .status(status);
-                })
-        .when(req)
-        .createResponseBuilder(any(HttpStatus.class));
+                    invocation -> {
+                      HttpStatus status = (HttpStatus) invocation.getArguments()[0];
+                      return new HttpResponseMessageMock.HttpResponseMessageBuilderMock()
+                              .status(status);
+                    })
+            .when(req)
+            .createResponseBuilder(any(HttpStatus.class));
 
     when(executionContext.getLogger()).thenReturn(Logger.getGlobal());
     doNothing().when(completionService).sendTestEmail(executionContext);
@@ -1253,8 +1282,8 @@ class OnboardingFunctionsTest {
     String delegationsList = function.retrieveAggregates(onboardingStringBase, executionContext);
 
     Assertions.assertEquals(
-        Utils.getDelegationResponseListString(objectMapper, delegationResponseList),
-        delegationsList);
+            Utils.getDelegationResponseListString(objectMapper, delegationResponseList),
+            delegationsList);
     verify(completionService, times(1)).retrieveAggregates(any());
   }
 
@@ -1272,12 +1301,12 @@ class OnboardingFunctionsTest {
     delegationResponseList.add(delegationResponse);
 
     TaskOrchestrationContext orchestrationContext =
-        mockTaskOrchestrationContextForUsersEa(onboarding, delegationResponseList);
+            mockTaskOrchestrationContextForUsersEa(onboarding, delegationResponseList);
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(6))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
 
     assertEquals(CREATE_USERS_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(RETRIEVE_AGGREGATES_ACTIVITY, captorActivity.getAllValues().get(1));
@@ -1287,7 +1316,7 @@ class OnboardingFunctionsTest {
     assertEquals(SEND_MAIL_COMPLETION_ACTIVITY, captorActivity.getAllValues().get(5));
 
     verify(service, times(1))
-        .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
+            .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.COMPLETED);
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
   }
@@ -1344,20 +1373,25 @@ class OnboardingFunctionsTest {
   @Test
   void onboardingsOrchestratorForApproveGpuWhenToBeValidated() {
     Onboarding onboarding = new Onboarding();
+    List<User> users = new ArrayList<>();
+    User user = new User();
+    users.add(user);
     onboarding.setId("onboardingId");
     onboarding.setStatus(OnboardingStatus.TOBEVALIDATED);
     onboarding.setWorkflowType(WorkflowType.FOR_APPROVE_GPU);
+    onboarding.setUsers(users);
 
     TaskOrchestrationContext orchestrationContext = mockTaskOrchestrationContext(onboarding);
 
     function.onboardingsOrchestrator(orchestrationContext, executionContext);
 
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
-    verify(orchestrationContext, times(3))
+    verify(orchestrationContext, times(4))
             .callActivity(captorActivity.capture(), any(), any(), any());
     assertEquals(BUILD_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(0));
     assertEquals(SAVE_TOKEN_WITH_CONTRACT_ACTIVITY_NAME, captorActivity.getAllValues().get(1));
     assertEquals(SEND_MAIL_REGISTRATION_FOR_CONTRACT_WHEN_APPROVE_ACTIVITY, captorActivity.getAllValues().get(2));
+    assertEquals(SEND_MAIL_REGISTRATION_FOR_USER, captorActivity.getAllValues().get(3));
 
     verify(service, times(1))
             .updateOnboardingStatus(onboarding.getId(), OnboardingStatus.PENDING);
@@ -1391,9 +1425,9 @@ class OnboardingFunctionsTest {
     ArgumentCaptor<String> captorActivity = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> captorActivitySubOrchestrator = ArgumentCaptor.forClass(String.class);
     verify(orchestrationContext, times(4))
-        .callActivity(captorActivity.capture(), any(), any(), any());
+            .callActivity(captorActivity.capture(), any(), any(), any());
     verify(orchestrationContext, times(1))
-        .callSubOrchestrator(captorActivitySubOrchestrator.capture(), any(), any());
+            .callSubOrchestrator(captorActivitySubOrchestrator.capture(), any(), any());
 
     assertEquals(CREATE_INSTITUTION_ACTIVITY, captorActivity.getAllValues().get(0));
     assertEquals(CREATE_ONBOARDING_ACTIVITY, captorActivity.getAllValues().get(1));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added logic to send mail for user during onboarding request phase

#### Motivation and Context

Many times users do not have access to the institution's PEC or do not look at it at all, for this reason to notify the arrival of an onboarding request you want to send a notification to the user's email.

#### How Has This Been Tested?

a request to join was sent and it was verified that the email was sent to the user

#### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/30e72c58-185e-4d28-8a11-5308a8398f72)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.