### PR TITLE
[SELC-7710] feat: added logic to retrieve taxCode for PRV_PF

### DIFF
--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Institution.java
@@ -4,9 +4,7 @@ import it.pagopa.selfcare.onboarding.common.InstitutionPaSubunitType;
 import it.pagopa.selfcare.onboarding.common.InstitutionType;
 import it.pagopa.selfcare.onboarding.common.Origin;
 import java.util.List;
-import java.util.Optional;
 
-import it.pagopa.selfcare.onboarding.crypto.utils.DataEncryptionUtils;
 import lombok.Data;
 import org.bson.codecs.pojo.annotations.BsonProperty;
 @Data
@@ -47,18 +45,6 @@ public class Institution {
     private String parentDescription;
     private List<String> atecoCodes;
     private String legalForm;
-
-    public String decryptTaxCode() {
-        return Optional.ofNullable(taxCode)
-                .map(DataEncryptionUtils::decrypt)
-                .orElse("");
-    }
-
-    public String decryptOriginId() {
-        return Optional.ofNullable(originId)
-                .map(DataEncryptionUtils::decrypt)
-                .orElse("");
-    }
 
     @Override
     public String toString() {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/entity/Onboarding.java
@@ -40,7 +40,6 @@ public class Onboarding {
     private String delegationId;
     private Boolean sendMailForImport;
     private Payment payment;
-    private Boolean soleTrader;
 
     //This field is used in case of workflowType USER
     private String previousManagerId;
@@ -69,7 +68,6 @@ public class Onboarding {
                 ", aggregates=" + aggregates +
                 ", isAggregator='" + isAggregator + '\'' +
                 ", sendMailForImport='" + sendMailForImport + '\'' +
-                ", soleTrader='" + soleTrader + '\'' +
                 '}';
     }
 

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.util.function.Function;
 
 import static it.pagopa.selfcare.onboarding.common.ProductId.*;
+import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_FIELD_LIST;
 import static it.pagopa.selfcare.onboarding.service.OnboardingService.USERS_WORKS_FIELD_LIST;
 import static it.pagopa.selfcare.onboarding.utils.GenericError.*;
 import static it.pagopa.selfcare.onboarding.utils.PdfMapper.*;
@@ -322,14 +323,23 @@ public class ContractServiceDefault implements ContractService {
     // Setting baseUrl used to construct aggregates csv url
     String baseUrl = templatePlaceholdersConfig.rejectOnboardingUrlValue();
     // Prepare common data for the contract document.
-    Map<String, Object> data = setUpCommonData(manager, users, onboarding, baseUrl);
+    Map<String, Object> data;
     // Customize data based on the product and institution type.
+    if (InstitutionType.PRV_PF.equals(onboarding.getInstitution().getInstitutionType())) {
+        UserResource userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, onboarding.getInstitution().getTaxCode());
+        onboarding.getInstitution().setTaxCode(userResource.getFiscalCode());
+        onboarding.getInstitution().setOriginId(userResource.getFiscalCode());
+        data = setUpCommonData(manager, users, onboarding, baseUrl);
+    } else {
+        data = setUpCommonData(manager, users, onboarding, baseUrl);
+    }
     if ((PROD_PAGOPA.getValue().equalsIgnoreCase(productId) || PROD_DASHBOARD_PSP.getValue().equalsIgnoreCase(productId))
       && InstitutionType.PSP == institution.getInstitutionType()) {
       setupPSPData(data, manager, onboarding);
     } else if ((PROD_PAGOPA.getValue().equalsIgnoreCase(productId) || PROD_IDPAY_MERCHANT.getValue().equalsIgnoreCase(productId))
-      && (InstitutionType.PRV == institution.getInstitutionType() || InstitutionType.GPU == institution.getInstitutionType())) {
-      setupPRVData(data, onboarding, users);
+            && (InstitutionType.PRV == institution.getInstitutionType() || InstitutionType.GPU == institution.getInstitutionType()
+            || InstitutionType.PRV_PF == institution.getInstitutionType())) {
+        setupPRVData(data, onboarding, users);
 
       Payment payment = onboarding.getPayment();
       if (Objects.nonNull(payment)) {

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/service/ContractServiceDefault.java
@@ -329,10 +329,8 @@ public class ContractServiceDefault implements ContractService {
         UserResource userResource = userRegistryApi.findByIdUsingGET(USERS_FIELD_LIST, onboarding.getInstitution().getTaxCode());
         onboarding.getInstitution().setTaxCode(userResource.getFiscalCode());
         onboarding.getInstitution().setOriginId(userResource.getFiscalCode());
-        data = setUpCommonData(manager, users, onboarding, baseUrl);
-    } else {
-        data = setUpCommonData(manager, users, onboarding, baseUrl);
     }
+    data = setUpCommonData(manager, users, onboarding, baseUrl);
     if ((PROD_PAGOPA.getValue().equalsIgnoreCase(productId) || PROD_DASHBOARD_PSP.getValue().equalsIgnoreCase(productId))
       && InstitutionType.PSP == institution.getInstitutionType()) {
       setupPSPData(data, manager, onboarding);

--- a/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
+++ b/apps/onboarding-functions/src/main/java/it/pagopa/selfcare/onboarding/utils/PdfMapper.java
@@ -62,10 +62,6 @@ public class PdfMapper {
       throw new GenericOnboardingException(
           MANAGER_EMAIL_NOT_FOUND.getMessage(), MANAGER_EMAIL_NOT_FOUND.getCode());
     }
-    if(Boolean.TRUE.equals(onboarding.getSoleTrader())) {
-        institution.setTaxCode(institution.decryptTaxCode());
-        institution.setOriginId(institution.decryptOriginId());
-    }
     Map<String, Object> map = new HashMap<>();
     map.put(INSTITUTION_NAME, institution.getDescription());
     map.put("address", institution.getAddress());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added logic to retrieve taxCode for PRV_PF
- removed soleTrader boolean 

#### Motivation and Context

Due to the new "Appliance Bonus Initiative," sole trader (PRV_PF) can now participate. In these cases, the institution's fiscal code is the same as the individual's personal fiscal code. To comply with corporate GDPR policies, this data must be tokenized using the PDV system. For this reason, all of these related processes have been adapted.

#### How Has This Been Tested?

All the APIs involved in the changes were called to verify the correct  detokenization of the data, ensuring the pre-existing logic was not impacted.

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.